### PR TITLE
Improve dates parsing resilience

### DIFF
--- a/openfisca_core/columns.py
+++ b/openfisca_core/columns.py
@@ -38,7 +38,7 @@ from .enumerations import Enum
 def N_(message):
     return message
 
-year_or_month_or_day_re = re.compile(ur'(18|19|20)\d{2}(-(0[1-9]|1[0-2])(-([0-2]\d|3[0-1]))?)?$')
+year_or_month_or_day_re = re.compile(ur'(18|19|20)\d{2}(-(0?[1-9]|1[0-2])(-([0-2]?\d|3[0-1]))?)?$')
 
 
 # Base Column


### PR DESCRIPTION
Stop requesting `0` padding in front of months and days numbers.

This makes it in particular easier to interact with the Web API from vanilla JS, as there is no native method to pad numbers.