### PR TITLE
Bug fix: build_reform now takes only one argument

### DIFF
--- a/openfisca_core/reforms.py
+++ b/openfisca_core/reforms.py
@@ -107,7 +107,7 @@ def compose_reforms(build_functions_and_keys, tax_benefit_system):
     """
     def compose_reforms_reducer(memo, item):
         build_reform, key = item
-        reform = build_reform(key = key, tax_benefit_system = memo)
+        reform = build_reform(tax_benefit_system = memo)
         assert isinstance(reform, AbstractReform), 'Reform {} returned an invalid value {!r}'.format(key, reform)
         return reform
     assert isinstance(build_functions_and_keys, list)


### PR DESCRIPTION
@cbenz,

I had a bug when trying to call two reforms at the same times. I think `build_reform` takes only one argument, while in `compose_reforms_reducer` two were provided. 

I did a quick and dirty fix for my own needs, but there is probably other stuff to do to keep it clean. 

Thanks ! 