### PR TITLE
Introduce reference periods

### DIFF
--- a/openfisca_core/periods.py
+++ b/openfisca_core/periods.py
@@ -673,6 +673,29 @@ class Period(tuple):
         return self[0]
 
 
+    # Reference periods
+
+    @property
+    def last_3_months(self):
+        return self.this_month.start.period('month', 3).offset(-3)
+
+    @property
+    def last_month(self):
+        return self.this_month.offset(-1)
+
+    @property
+    def n_2(self):
+        return self.start.offset('first-of', 'year').period('year').offset(-2)
+
+    @property
+    def this_year(self):
+        return self.start.offset('first-of', 'year').period('year')
+
+    @property
+    def this_month(self):
+        return self.start.offset('first-of', 'month').period('month')
+
+
 def instant(instant):
     """Return a new instant, aka a triple of integers (year, month, day).
 


### PR DESCRIPTION
Introduce some reference periods in openfisca_core/periods.py in order to simplify period uses in formula.

Eg : 

Before : 
```python
        period = period.start.offset('first-of', 'month').period('month')
        two_years_ago = period.start.offset('first-of', 'year').period('year').offset(-2)
        last_month = period.start.period('month').offset(-1)
```
After :
```python
        period = period.this_month
        two_years_ago = period.n_2
        last_month = period.last_month
```