### PR TITLE
Uniformize variable declaration : allow inputs to be declared as a formula without a function

### DIFF
--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -1240,16 +1240,11 @@ def new_filled_column(base_function = UnboundLocalError, calculate_output = Unbo
     else:
         assert issubclass(formula_class, SimpleFormula), formula_class
 
-        function = specific_attributes.pop('function', UnboundLocalError)
+        function = specific_attributes.pop('function', None)
         if is_permanent:
-            assert function is UnboundLocalError
-        if function is UnboundLocalError:
-            assert reference_column is not None and issubclass(reference_column.formula_class, SimpleFormula), \
-                """Missing attribute "function" in definition of filled column {}""".format(name)
+            assert function is None
+        if reference_column is not None:
             function = reference_column.formula_class.function
-        else:
-            assert function is not None, """Missing attribute "function" in definition of filled column {}""".format(
-                name)
         formula_class_attributes['function'] = function
 
     # Ensure that all attributes defined in ConversionColumn class are used.


### PR DESCRIPTION
As discussed with @eraviart last Friday, declaring formulas and input in different ways has a few drawbacks :
- More complexity for the developer, who has to know 2 ways of declaring a variable that look like each other with a slightly different syntax. 
- Possible mistakes (comas are needed in one syntax, not the other)
- When looking for a variable declaration with a global text research, inputs are hard to find.

It would be nice if we could have only one syntax. A possible implementation (started here) is to just allow `SimpleFormulaColumn` to not have a function. 

Before : 
```python
reference_input_variable(
    name = "ass_precondition_remplie",
    column = BoolCol,
    entity_class = Individus,
    label = u"Eligible à l'ASS",
    )

@reference_formula
class ass(SimpleFormulaColumn):
    column = FloatCol
    label = u"Montant de l'ASS pour une famille"
    entity_class = Familles

    def function(self, simulation, period):
         return period, x
```

After :

```python
@reference_formula
class ass_precondition_remplie(SimpleFormulaColumn):
    column = BoolCol
    entity_class = Individus
    label = u"Eligible à l'ASS"

@reference_formula
class ass(SimpleFormulaColumn):
    column = FloatCol
    label = u"Montant de l'ASS pour une famille"
    entity_class = Familles

    def function(self, simulation, period):
         return period, x
```