### PR TITLE
Allow SimpleFormula function to return a scalar number

### DIFF
--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -529,8 +529,14 @@ class SimpleFormula(AbstractFormula):
             u"Function {}@{}<{}>() --> <{}>{} returns an output period that doesn't include start instant of" \
             u"requested period".format(column.name, entity.key_plural, str(period), str(output_period),
                 stringify_array(array)).encode('utf-8')
-        assert isinstance(array, np.ndarray), u"Function {}@{}<{}>() --> <{}>{} doesn't return a numpy array".format(
-            column.name, entity.key_plural, str(period), str(output_period), array).encode('utf-8')
+
+        if not isinstance(array, np.ndarray):
+            try:
+                array = np.ones(entity.count) * array
+            except TypeError:
+                raise ValueError(u"Function {}@{}<{}>() --> <{}>{} doesn't return a numpy array or a number".format(
+            column.name, entity.key_plural, str(period), str(output_period), array).encode('utf-8'))
+
         assert array.size == entity.count, \
             u"Function {}@{}<{}>() --> <{}>{} returns an array of size {}, but size {} is expected for {}".format(
                 column.name, entity.key_plural, str(period), str(output_period), stringify_array(array),


### PR DESCRIPTION
To be able to replace [cryptic lines](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/model/prestations/education.py#L52) such as :
```python
nb_enfants_college = zeros(len(rfr))
```
by 
```python
nb_enfants_college = 0
```
If a function returns a scalar, it will be automatically be turned into a numpy array of the right size.