### PR TITLE
Manage circular formula calls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,2 +1,2 @@
-Cf [Contribute page](http://www.openfisca.fr/documentation/contribute/)
-in the [documentation of OpenFisca](http://www.openfisca.fr/documentation/).
+Cf [Contribute page](http://doc.openfisca.fr/contribute/)
+in the [documentation of OpenFisca](http://doc.openfisca.fr/).

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@
 [OpenFisca](http://www.openfisca.fr/) is a versatile microsimulation free software.
 This is the source code of the Core module.
 
-Please consult http://www.openfisca.fr/documentation
+Please consult http://doc.openfisca.fr/

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -23,14 +23,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from . import holders
 from .tools import empty_clone
 
 
 class AbstractEntity(object):
     column_by_name = None  # Class attribute. Must be overridden by subclasses with an OrderedDict.
     count = 0
-    holder_by_name = None
     key_plural = None
     key_singular = None
     index_for_person_variable_name = None  # Class attribute. Not used for persons
@@ -47,7 +45,6 @@ class AbstractEntity(object):
     symbol = None  # Class attribute. Must be overridden by subclasses.
 
     def __init__(self, simulation = None):
-        self.holder_by_name = {}
         if self.is_persons_entity:
             assert self.index_for_person_variable_name is None
             assert self.role_for_person_variable_name is None
@@ -63,29 +60,12 @@ class AbstractEntity(object):
         new_dict = new.__dict__
 
         for key, value in self.__dict__.iteritems():
-            if key not in ('holder_by_name', 'simulation'):
+            if key != 'simulation':
                 new_dict[key] = value
 
         new_dict['simulation'] = simulation
-        # Caution: holders must be cloned after the simulation has been set into new.
-        new_dict['holder_by_name'] = {
-            name: holder.clone(new)
-            for name, holder in self.holder_by_name.iteritems()
-            }
 
         return new
-
-    def get_or_new_holder(self, column_name):
-        holder = self.holder_by_name.get(column_name)
-        if holder is None:
-            column = self.column_by_name[column_name]
-            self.holder_by_name[column_name] = holder = holders.Holder(column = column, entity = self)
-            if column.formula_class is not None:
-                holder.formula = column.formula_class(holder = holder)
-        return holder
-
-    def graph(self, column_name, edges, get_input_variables_and_parameters, nodes, visited):
-        self.get_or_new_holder(column_name).graph(edges, get_input_variables_and_parameters, nodes, visited)
 
     def iter_member_persons_role_and_id(self, member):
         assert not self.is_persons_entity

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -75,21 +75,17 @@ class AbstractEntity(object):
 
         return new
 
-    def compute(self, column_name, period = None, accept_other_period = False, requested_formulas_by_period = None):
-        return self.get_or_new_holder(column_name).compute(period = period, accept_other_period = accept_other_period,
-            requested_formulas_by_period = requested_formulas_by_period)
+    def compute(self, column_name, period = None, accept_other_period = False):
+        return self.get_or_new_holder(column_name).compute(period = period, accept_other_period = accept_other_period)
 
-    def compute_add(self, column_name, period = None, requested_formulas_by_period = None):
-        return self.get_or_new_holder(column_name).compute_add(period = period,
-            requested_formulas_by_period = requested_formulas_by_period)
+    def compute_add(self, column_name, period = None):
+        return self.get_or_new_holder(column_name).compute_add(period = period)
 
-    def compute_add_divide(self, column_name, period = None, requested_formulas_by_period = None):
-        return self.get_or_new_holder(column_name).compute_add_divide(period = period,
-            requested_formulas_by_period = requested_formulas_by_period)
+    def compute_add_divide(self, column_name, period = None):
+        return self.get_or_new_holder(column_name).compute_add_divide(period = period)
 
-    def compute_divide(self, column_name, period = None, requested_formulas_by_period = None):
-        return self.get_or_new_holder(column_name).compute_divide(period = period,
-            requested_formulas_by_period = requested_formulas_by_period)
+    def compute_divide(self, column_name, period = None):
+        return self.get_or_new_holder(column_name).compute_divide(period = period)
 
     def get_array(self, column_name, period = None):
         return self.get_or_new_holder(column_name).get_array(period)

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -75,21 +75,6 @@ class AbstractEntity(object):
 
         return new
 
-    def compute(self, column_name, period = None, accept_other_period = False):
-        return self.get_or_new_holder(column_name).compute(period = period, accept_other_period = accept_other_period)
-
-    def compute_add(self, column_name, period = None):
-        return self.get_or_new_holder(column_name).compute_add(period = period)
-
-    def compute_add_divide(self, column_name, period = None):
-        return self.get_or_new_holder(column_name).compute_add_divide(period = period)
-
-    def compute_divide(self, column_name, period = None):
-        return self.get_or_new_holder(column_name).compute_divide(period = period)
-
-    def get_array(self, column_name, period = None):
-        return self.get_or_new_holder(column_name).get_array(period)
-
     def get_or_new_holder(self, column_name):
         holder = self.holder_by_name.get(column_name)
         if holder is None:

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -108,7 +108,7 @@ class AbstractEntityToEntity(AbstractFormula):
         keys_to_skip.add('_variable_holder')
         return super(AbstractEntityToEntity, self).clone(holder, keys_to_skip = keys_to_skip)
 
-    def compute(self, period = None):
+    def compute(self, period = None, **parameters):
         """Call the formula function (if needed) and return a dated holder containing its result."""
         assert period is not None
         holder = self.holder
@@ -264,7 +264,7 @@ class DatedFormula(AbstractGroupedFormula):
 
         return new
 
-    def compute(self, period = None):
+    def compute(self, period = None, **parameters):
         dated_holder = None
         stop_instant = period.stop
         for dated_formula in self.dated_formulas:
@@ -273,7 +273,7 @@ class DatedFormula(AbstractGroupedFormula):
             output_period = period.intersection(dated_formula['start_instant'], dated_formula['stop_instant'])
             if output_period is None:
                 continue
-            dated_holder = dated_formula['formula'].compute(period = output_period)
+            dated_holder = dated_formula['formula'].compute(period = output_period, **parameters)
             if dated_holder.array is None:
                 break
             self.used_formula = dated_formula['formula']
@@ -474,7 +474,7 @@ class SimpleFormula(AbstractFormula):
                 raise
         return target_array
 
-    def compute(self, period = None):
+    def compute(self, period = None, **parameters):
         """Call the formula function (if needed) and return a dated holder containing its result."""
         assert period is not None
         holder = self.holder

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -498,7 +498,7 @@ class SimpleFormula(AbstractFormula):
         if self in requested_values.keys():
 
             # Make sure the formula doesn't call itself for the same period it is being called for. It would be a pure circular definition.
-            assert period not in requested_values[self], \
+            assert period not in requested_values[self] and not column.is_permanent, \
                 'Circular definition detected while trying to compute {}<{}>. The formulas and period involved are: {}'.format(
                     column.name,
                     period,

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -515,7 +515,7 @@ class SimpleFormula(AbstractFormula):
 
             if len(requested_values[self]) > max_number_recursive_calls:
                 dated_holder = holder.at_period(period)
-                dated_holder.array = self.zeros() + self.holder.column.default
+                dated_holder.array = self.zeros() + column.default
                 return dated_holder
             requested_values[self].append(period)
 

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -500,7 +500,7 @@ class SimpleFormula(AbstractFormula):
         # If self is already in there, it means this formula calls itself recursively
         # The data structure of requested_values is: {formula: [period1, period2]}
         if self in requested_values:
-            circular_definition_message = 'Circular definition detected on formula {}<{}>. Formulas and periods involved: {}'.format(
+            circular_definition_message = 'Circular definition detected on formula {}<{}>. Formulas and periods involved: {}.'.format(
                 column.name,
                 period,
                 u', '.join(sorted(set(
@@ -519,7 +519,7 @@ class SimpleFormula(AbstractFormula):
             # recursive call, but no error will be raised and default value will be returned.
             max_nb_recursive_calls = parameters.get('max_nb_recursive_calls')
             assert max_nb_recursive_calls is not None, circular_definition_message + \
-                'Hint: use "max_nb_recursive_calls = 0" to get default value, or "= N" to allow N recursion calls.'
+                ' Hint: use "max_nb_recursive_calls = 0" to get default value, or "= N" to allow N recursion calls.'
 
             if len(requested_values[self]) > max_nb_recursive_calls:
                 dated_holder = holder.at_period(period)

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -516,6 +516,9 @@ class SimpleFormula(AbstractFormula):
             if len(requested_values[self]) > max_number_recursive_calls:
                 dated_holder = holder.at_period(period)
                 dated_holder.array = self.zeros() + column.default
+                if debug and not max_number_recursive_calls:
+                    log.info("Recursive call detected on formula {}. Recursion is by default deactivated, default value {} will be returned for period {}. Use max_number_recursive_calls parameter in compute or calcultate to allow recursion."
+                    .format(column.name, column.default, period))
                 return dated_holder
             requested_values[self].append(period)
 

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -498,7 +498,7 @@ class SimpleFormula(AbstractFormula):
             requested_formulas_by_period[period_or_none] = period_requested_formulas = set()
         else:
             assert self not in period_requested_formulas, \
-                'Infinite loop in formula {}<{}>. Missing values for columns: {}'.format(
+                'Circular definition detected while trying to compute {}<{}>. The formulas and period involved are: {}'.format(
                     column.name,
                     period,
                     u', '.join(sorted(set(

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -928,10 +928,15 @@ class FormulaColumnMetaclass(type):
 
         self = super(FormulaColumnMetaclass, cls).__new__(cls, name, bases, attributes)
         comments = inspect.getcomments(self)
-        source_file_path = inspect.getsourcefile(self)
-        source_lines, line_number = inspect.getsourcelines(self)
-        source_code = textwrap.dedent(''.join(source_lines))
-
+        try:
+            source_file_path = inspect.getsourcefile(self)
+        except TypeError:
+            source_file_path = None
+        try:
+            source_lines, line_number = inspect.getsourcelines(self)
+            source_code = textwrap.dedent(''.join(source_lines))
+        except TypeError:
+            source_code, line_number = None, None
         return new_filled_column(
             base_function = attributes.pop('base_function', UnboundLocalError),
             calculate_output = attributes.pop('calculate_output', UnboundLocalError),
@@ -1020,7 +1025,7 @@ def last_duration_last_value(formula, simulation, period):
     return period, array
 
 
-def make_reference_formula_decorator(entity_class_by_symbol = None, update = False):
+def make_formula_decorator(entity_class_by_symbol = None, update = False):
     assert isinstance(entity_class_by_symbol, dict)
 
     def reference_formula_decorator(column):

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -81,6 +81,10 @@ class AbstractFormula(object):
 
         return new
 
+    def default_values(self):
+        '''Return a new NumPy array which length is the entity count, filled with default values.'''
+        return self.zeros() + self.holder.column.default
+
     @property
     def real_formula(self):
         return self

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -503,9 +503,9 @@ class SimpleFormula(AbstractFormula):
                     column.name,
                     period,
                     u', '.join(sorted(set(
-                        u'{}<{}>'.format(requested_formula.holder.column.name, period1)
-                        for period1, period_requested_formulas1 in requested_values.iteritems()
-                        for requested_formula in period_requested_formulas1
+                        u'{}<{}>'.format(column.name, period2)
+                        for formula, periods in requested_values.iteritems()
+                        for period2 in periods
                         ))).encode('utf-8'),
                     )
             # A formula can call itself with a time offset (different periods), but we want to make sure this doesn't result in an infinite race

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -327,11 +327,11 @@ class EntityToPerson(AbstractEntityToEntity):
         array = dated_holder.array
         target_array = np.empty(persons.count, dtype = array.dtype)
         target_array.fill(dated_holder.column.default)
-        entity_index_array = persons.holder_by_name[entity.index_for_person_variable_name].array
+        entity_index_array = persons.simulation.holder_by_name[entity.index_for_person_variable_name].array
         if roles is None:
             roles = range(entity.roles_count)
         for role in roles:
-            boolean_filter = persons.holder_by_name[entity.role_for_person_variable_name].array == role
+            boolean_filter = persons.simulation.holder_by_name[entity.role_for_person_variable_name].array == role
             try:
                 target_array[boolean_filter] = array[entity_index_array[boolean_filter]]
             except:
@@ -359,13 +359,13 @@ class PersonToEntity(AbstractEntityToEntity):
 
         target_array = np.empty(entity.count, dtype = array.dtype)
         target_array.fill(dated_holder.column.default)
-        entity_index_array = persons.holder_by_name[entity.index_for_person_variable_name].array
+        entity_index_array = persons.simulation.holder_by_name[entity.index_for_person_variable_name].array
         if roles is not None and len(roles) == 1:
             assert self.operation is None, 'Unexpected operation {} in formula {}'.format(self.operation,
                 holder.column.name)
             role = roles[0]
             # TODO: Cache filter.
-            boolean_filter = persons.holder_by_name[entity.role_for_person_variable_name].array == role
+            boolean_filter = persons.simulation.holder_by_name[entity.role_for_person_variable_name].array == role
             try:
                 target_array[entity_index_array[boolean_filter]] = array[boolean_filter]
             except:
@@ -382,7 +382,7 @@ class PersonToEntity(AbstractEntityToEntity):
                 array.dtype if array.dtype != np.bool else np.int16)
             for role in roles:
                 # TODO: Cache filters.
-                boolean_filter = persons.holder_by_name[entity.role_for_person_variable_name].array == role
+                boolean_filter = persons.simulation.holder_by_name[entity.role_for_person_variable_name].array == role
                 target_array[entity_index_array[boolean_filter]] += array[boolean_filter]
 
         return target_array
@@ -412,13 +412,13 @@ class SimpleFormula(AbstractFormula):
                 'utf-8')
             assert array.size == persons.count, u"Expected an array of size {}. Got: {}".format(persons.count,
                 array.size)
-        entity_index_array = persons.holder_by_name[entity.index_for_person_variable_name].array
+        entity_index_array = persons.simulation.holder_by_name[entity.index_for_person_variable_name].array
         if roles is None:
             roles = range(entity.roles_count)
         target_array = self.zeros(dtype = np.bool)
         for role in roles:
             # TODO Mettre les filtres en cache dans la simulation
-            boolean_filter = persons.holder_by_name[entity.role_for_person_variable_name].array == role
+            boolean_filter = persons.simulation.holder_by_name[entity.role_for_person_variable_name].array == role
             target_array[entity_index_array[boolean_filter]] += array[boolean_filter]
         return target_array
 
@@ -461,11 +461,11 @@ class SimpleFormula(AbstractFormula):
         assert not entity.is_persons_entity
         target_array = np.empty(persons.count, dtype = array.dtype)
         target_array.fill(default)
-        entity_index_array = persons.holder_by_name[entity.index_for_person_variable_name].array
+        entity_index_array = persons.simulation.holder_by_name[entity.index_for_person_variable_name].array
         if roles is None:
             roles = range(entity.roles_count)
         for role in roles:
-            boolean_filter = persons.holder_by_name[entity.role_for_person_variable_name].array == role
+            boolean_filter = persons.simulation.holder_by_name[entity.role_for_person_variable_name].array == role
             try:
                 target_array[boolean_filter] = array[entity_index_array[boolean_filter]]
             except:
@@ -604,11 +604,11 @@ class SimpleFormula(AbstractFormula):
                 array.size)
             if default is None:
                 default = 0
-        entity_index_array = persons.holder_by_name[entity.index_for_person_variable_name].array
+        entity_index_array = persons.simulation.holder_by_name[entity.index_for_person_variable_name].array
         assert isinstance(role, int)
         target_array = np.empty(entity.count, dtype = array.dtype)
         target_array.fill(default)
-        boolean_filter = persons.holder_by_name[entity.role_for_person_variable_name].array == role
+        boolean_filter = persons.simulation.holder_by_name[entity.role_for_person_variable_name].array == role
         try:
             target_array[entity_index_array[boolean_filter]] = array[boolean_filter]
         except:
@@ -657,7 +657,7 @@ class SimpleFormula(AbstractFormula):
                 array.size)
             if default is None:
                 default = 0
-        entity_index_array = persons.holder_by_name[entity.index_for_person_variable_name].array
+        entity_index_array = persons.simulation.holder_by_name[entity.index_for_person_variable_name].array
         if roles is None:
             # To ensure that existing formulas don't fail, ensure there is always at least 11 roles.
             # roles = range(entity.roles_count)
@@ -666,7 +666,7 @@ class SimpleFormula(AbstractFormula):
         for role in roles:
             target_array_by_role[role] = target_array = np.empty(entity.count, dtype = array.dtype)
             target_array.fill(default)
-            boolean_filter = persons.holder_by_name[entity.role_for_person_variable_name].array == role
+            boolean_filter = persons.simulation.holder_by_name[entity.role_for_person_variable_name].array == role
             try:
                 target_array[entity_index_array[boolean_filter]] = array[boolean_filter]
             except:
@@ -695,13 +695,13 @@ class SimpleFormula(AbstractFormula):
                 'utf-8')
             assert array.size == persons.count, u"Expected an array of size {}. Got: {}".format(persons.count,
                 array.size)
-        entity_index_array = persons.holder_by_name[entity.index_for_person_variable_name].array
+        entity_index_array = persons.simulation.holder_by_name[entity.index_for_person_variable_name].array
         if roles is None:
             roles = range(entity.roles_count)
         target_array = self.zeros(dtype = array.dtype if array.dtype != np.bool else np.int16)
         for role in roles:
             # TODO: Mettre les filtres en cache dans la simulation
-            boolean_filter = persons.holder_by_name[entity.role_for_person_variable_name].array == role
+            boolean_filter = persons.simulation.holder_by_name[entity.role_for_person_variable_name].array == role
             target_array[entity_index_array[boolean_filter]] += array[boolean_filter]
         return target_array
 

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -113,7 +113,7 @@ class Holder(object):
     def calculate_output(self, period):
         return self.formula.calculate_output(period)
 
-    def clone(self, entity):
+    def clone(self):
         """Copy the holder just enough to be able to run a new simulation without modifying the original simulation."""
         new = empty_clone(self)
         new_dict = new.__dict__
@@ -126,7 +126,7 @@ class Holder(object):
             elif key not in ('entity', 'formula'):
                 new_dict[key] = value
 
-        new_dict['entity'] = entity
+        new_dict['entity'] = self.entity
         # Caution: formula must be cloned after the entity has been set into new.
         formula = self.formula
         if formula is not None:

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -106,9 +106,8 @@ class Holder(object):
     def at_period(self, period):
         return self if self.column.is_permanent else DatedHolder(self, period)
 
-    def calculate(self, period = None, accept_other_period = False, requested_formulas_by_period = None):
-        dated_holder = self.compute(period = period, accept_other_period = accept_other_period,
-            requested_formulas_by_period = requested_formulas_by_period)
+    def calculate(self, period = None, accept_other_period = False):
+        dated_holder = self.compute(period = period, accept_other_period = accept_other_period)
         return dated_holder.array
 
     def calculate_output(self, period):
@@ -135,7 +134,7 @@ class Holder(object):
 
         return new
 
-    def compute(self, period = None, accept_other_period = False, requested_formulas_by_period = None):
+    def compute(self, period = None, accept_other_period = False):
         """Compute array if needed and/or convert it to requested period and return a dated holder containig it.
 
         The returned dated holder is always of the requested period and this method never returns None.
@@ -156,8 +155,7 @@ class Holder(object):
         column_stop_instant = periods.instant(column.end)
         if (column_start_instant is None or column_start_instant <= period.start) \
                 and (column_stop_instant is None or period.start <= column_stop_instant):
-            formula_dated_holder = self.formula.compute(period = period,
-                requested_formulas_by_period = requested_formulas_by_period)
+            formula_dated_holder = self.formula.compute(period = period)
             assert formula_dated_holder is not None
             if not column.is_permanent:
                 assert accept_other_period or formula_dated_holder.period == period, \
@@ -169,7 +167,7 @@ class Holder(object):
         dated_holder.array = array
         return dated_holder
 
-    def compute_add(self, period = None, requested_formulas_by_period = None):
+    def compute_add(self, period = None):
         dated_holder = self.at_period(period)
         if dated_holder.array is not None:
             return dated_holder
@@ -183,8 +181,7 @@ class Holder(object):
             remaining_period_months = period.size * 12
         requested_period = period.start.period(unit)
         while True:
-            dated_holder = self.compute(accept_other_period = True, period = requested_period,
-                requested_formulas_by_period = requested_formulas_by_period)
+            dated_holder = self.compute(accept_other_period = True, period = requested_period)
             requested_start = requested_period.start
             returned_period = dated_holder.period
             returned_start = returned_period.start
@@ -222,7 +219,7 @@ class Holder(object):
             else:
                 requested_period = requested_start.offset(returned_period_months, u'month').period(u'month')
 
-    def compute_add_divide(self, period = None, requested_formulas_by_period = None):
+    def compute_add_divide(self, period = None):
         dated_holder = self.at_period(period)
         if dated_holder.array is not None:
             return dated_holder
@@ -236,8 +233,7 @@ class Holder(object):
             remaining_period_months = period.size * 12
         requested_period = period.start.period(unit)
         while True:
-            dated_holder = self.compute(accept_other_period = True, period = requested_period,
-                requested_formulas_by_period = requested_formulas_by_period)
+            dated_holder = self.compute(accept_other_period = True, period = requested_period)
             requested_start = requested_period.start
             returned_period = dated_holder.period
             returned_start = returned_period.start
@@ -274,7 +270,7 @@ class Holder(object):
             else:
                 requested_period = requested_start.offset(intersection_months, u'month').period(u'month')
 
-    def compute_divide(self, period = None, requested_formulas_by_period = None):
+    def compute_divide(self, period = None):
         dated_holder = self.at_period(period)
         if dated_holder.array is not None:
             return dated_holder
@@ -283,8 +279,7 @@ class Holder(object):
         unit = period[0]
         year, month, day = period.start
         if unit == u'month':
-            dated_holder = self.compute(accept_other_period = True, period = period,
-                requested_formulas_by_period = requested_formulas_by_period)
+            dated_holder = self.compute(accept_other_period = True, period = period)
             assert dated_holder.period.start <= period.start and period.stop <= dated_holder.period.stop, \
                 "Period {} returned by variable {} doesn't include requested period {}.".format(
                     dated_holder.period, self.column.name, period)
@@ -300,7 +295,7 @@ class Holder(object):
             return dated_holder
         else:
             assert unit == u'year', unit
-            return self.compute(period = period, requested_formulas_by_period = requested_formulas_by_period)
+            return self.compute(period = period)
 
     def delete_arrays(self):
         if self._array is not None:

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -144,7 +144,7 @@ class Holder(object):
         if period is None:
             period = simulation.period
         column = self.column
-        accept_other_period = 'accept_other_period' in parameters and parameters['accept_other_period']
+        accept_other_period = parameters.get('accept_other_period', False)
 
         # First look for dated_holders covering the whole period (without hole).
         dated_holder = self.at_period(period)

--- a/openfisca_core/reforms.py
+++ b/openfisca_core/reforms.py
@@ -66,10 +66,9 @@ class AbstractReform(taxbenefitsystems.AbstractTaxBenefitSystem):
     def full_key(self):
         key = self.key
         assert key is not None, 'key was not set for reform {} (name: {!r})'.format(self, self.name)
-        if self.reference is not None:
-            reference_key = getattr(self.reference, 'key', None)
-            if reference_key is not None:
-                key = u'.'.join([reference_key, key])
+        if self.reference is not None and hasattr(self.reference, 'key'):
+            reference_full_key = self.reference.full_key
+            key = u'.'.join([reference_full_key, key])
         return key
 
     def modify_legislation_json(self, modifier_function):
@@ -152,17 +151,17 @@ def make_reform(key, name, reference, decomposition_dir_name = None, decompositi
 
         @classmethod
         def formula(cls, column):
-            assert not cls._constructed, \
-                'You are trying to add a formula to a Reform but its constructor has already been called.'
-            return formulas.make_reference_formula_decorator(
+            if cls._constructed:
+                print 'Caution: You are adding a formula to an instantiated Reform. Reform must be reinstatiated.'
+            return formulas.make_formula_decorator(
                 entity_class_by_symbol = reform_entity_class_by_symbol,
                 update = True,
                 )(column)
 
         @classmethod
         def input_variable(cls, entity_class = None, **kwargs):
-            assert not cls._constructed, \
-                'You are trying to add an input variable to a Reform but its constructor has already been called.'
+            if cls._constructed:
+                print 'Caution: You are adding a formula to an instantiated Reform. Reform must be reinstatiated.'
             # Ensure that entity_class belongs to reform (instead of reference tax-benefit system).
             entity_class = cls.entity_class_by_key_plural[entity_class.key_plural]
             assert 'update' not in kwargs

--- a/openfisca_core/scenarios.py
+++ b/openfisca_core/scenarios.py
@@ -97,12 +97,12 @@ class AbstractScenario(object):
                 if entity is persons:
                     continue
 
-                index_holder = persons.get_or_new_holder(entity.index_for_person_variable_name)
+                index_holder = simulation.get_or_new_holder(entity.index_for_person_variable_name)
                 index_array = index_holder.array
                 if index_array is None:
                     index_holder.array = np.arange(persons.count, dtype = index_holder.column.dtype)
 
-                role_holder = persons.get_or_new_holder(entity.role_for_person_variable_name)
+                role_holder = simulation.get_or_new_holder(entity.role_for_person_variable_name)
                 role_array = role_holder.array
                 if role_array is None:
                     role_holder.array = role_array = np.zeros(persons.count, role_holder.column.dtype)
@@ -135,10 +135,10 @@ class AbstractScenario(object):
                 if entity.is_persons_entity:
                     continue
                 entity_step_size = entity.step_size
-                persons.get_or_new_holder(entity.index_for_person_variable_name).array = person_entity_id_array = \
+                simulation.get_or_new_holder(entity.index_for_person_variable_name).array = person_entity_id_array = \
                     np.empty(steps_count * persons.step_size,
                         dtype = column_by_name[entity.index_for_person_variable_name].dtype)
-                persons.get_or_new_holder(entity.role_for_person_variable_name).array = person_entity_role_array = \
+                simulation.get_or_new_holder(entity.role_for_person_variable_name).array = person_entity_role_array = \
                     np.empty(steps_count * persons.step_size,
                         dtype = column_by_name[entity.role_for_person_variable_name].dtype)
                 for member_index, member in enumerate(test_case[entity_key_plural]):
@@ -172,7 +172,7 @@ class AbstractScenario(object):
                                     variable_periods.update(cell.iterkeys())
                             elif cell is not None:
                                 variable_periods.add(simulation_period)
-                        holder = entity.get_or_new_holder(variable_name)
+                        holder = simulation.get_or_new_holder(variable_name)
                         variable_default_value = column.default
                         # Note: For set_input to work, handle days, before months, before years => use sorted().
                         for variable_period in sorted(variable_periods):

--- a/openfisca_core/scripts/measure_performances.py
+++ b/openfisca_core/scripts/measure_performances.py
@@ -41,7 +41,7 @@ from openfisca_core import periods, simulations
 from openfisca_core.columns import BoolCol, DateCol, FixedStrCol, FloatCol, IntCol
 from openfisca_core.entities import AbstractEntity
 from openfisca_core.formulas import (dated_function, DatedFormulaColumn, EntityToPersonColumn,
-    make_reference_formula_decorator, PersonToEntityColumn, reference_input_variable, SimpleFormulaColumn)
+    make_formula_decorator, PersonToEntityColumn, reference_input_variable, SimpleFormulaColumn)
 from openfisca_core.taxbenefitsystems import AbstractTaxBenefitSystem
 from openfisca_core.tools import assert_near
 
@@ -168,7 +168,7 @@ reference_input_variable(
 # Calculated variables
 
 
-reference_formula = make_reference_formula_decorator(entity_class_by_symbol = entity_class_by_symbol)
+reference_formula = make_formula_decorator(entity_class_by_symbol = entity_class_by_symbol)
 
 
 @reference_formula

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -48,8 +48,11 @@ class Simulation(object):
     def __init__(self, debug = False, debug_all = False, period = None, tax_benefit_system = None, trace = False):
         assert isinstance(period, periods.Period)
         self.period = period
-        self.requested_formulas_by_period = {}
         self.holder_by_name = {}
+
+        # To keep track of the values (formulas and periods) being calculated to detect circular definitions.
+        self.requested_values = {}
+
         if debug:
             self.debug = True
         if debug_all:
@@ -90,7 +93,6 @@ class Simulation(object):
         if period is None:
             period = self.period
         return self.compute(column_name, period = period, **parameters).array
-
 
     def calculate_add(self, column_name, period = None, **parameters):
         if period is None:

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -165,8 +165,10 @@ class Simulation(object):
             caller_input_variables_infos = calling_frame['input_variables_infos']
             if variable_infos not in caller_input_variables_infos:
                 caller_input_variables_infos.append(variable_infos)
-        return self.entity_by_column_name[column_name].compute(column_name, period = period,
-            accept_other_period = accept_other_period)
+        entity = self.entity_by_column_name[column_name]
+        holder = entity.get_or_new_holder(column_name)
+        return holder.compute(period = period, accept_other_period = accept_other_period)
+
 
     def compute_add(self, column_name, period = None):
         if period is None:
@@ -179,7 +181,9 @@ class Simulation(object):
             caller_input_variables_infos = calling_frame['input_variables_infos']
             if variable_infos not in caller_input_variables_infos:
                 caller_input_variables_infos.append(variable_infos)
-        return self.entity_by_column_name[column_name].compute_add(column_name, period = period)
+        entity = self.entity_by_column_name[column_name]
+        holder = entity.get_or_new_holder(column_name)
+        return holder.compute_add(period = period, accept_other_period = accept_other_period)
 
     def compute_add_divide(self, column_name, period = None):
         if period is None:
@@ -192,7 +196,9 @@ class Simulation(object):
             caller_input_variables_infos = calling_frame['input_variables_infos']
             if variable_infos not in caller_input_variables_infos:
                 caller_input_variables_infos.append(variable_infos)
-        return self.entity_by_column_name[column_name].compute_add_divide(column_name, period = period)
+        entity = self.entity_by_column_name[column_name]
+        holder = entity.get_or_new_holder(column_name)
+        return holder.compute_add_divide(period = period, accept_other_period = accept_other_period)
 
     def compute_divide(self, column_name, period = None):
         if period is None:
@@ -205,7 +211,9 @@ class Simulation(object):
             caller_input_variables_infos = calling_frame['input_variables_infos']
             if variable_infos not in caller_input_variables_infos:
                 caller_input_variables_infos.append(variable_infos)
-        return self.entity_by_column_name[column_name].compute_divide(column_name, period = period)
+        entity = self.entity_by_column_name[column_name]
+        holder = entity.get_or_new_holder(column_name)
+        return holder.compute_divide(period = period, accept_other_period = accept_other_period)
 
     def get_array(self, column_name, period = None):
         if period is None:
@@ -218,7 +226,8 @@ class Simulation(object):
             caller_input_variables_infos = calling_frame['input_variables_infos']
             if variable_infos not in caller_input_variables_infos:
                 caller_input_variables_infos.append(variable_infos)
-        return self.entity_by_column_name[column_name].get_array(column_name, period)
+        entity = self.entity_by_column_name[column_name]
+        return entity.get_or_new_holder(column_name).get_array(period)
 
     def get_compact_legislation(self, instant):
         compact_legislation = self.compact_legislation_by_instant_cache.get(instant)

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -48,6 +48,7 @@ class Simulation(object):
     def __init__(self, debug = False, debug_all = False, period = None, tax_benefit_system = None, trace = False):
         assert isinstance(period, periods.Period)
         self.period = period
+        self.requested_formulas_by_period = {}
         if debug:
             self.debug = True
         if debug_all:
@@ -84,29 +85,25 @@ class Simulation(object):
                 self.persons = entity
                 break
 
-    def calculate(self, column_name, period = None, accept_other_period = False, requested_formulas_by_period = None):
+    def calculate(self, column_name, period = None, accept_other_period = False):
         if period is None:
             period = self.period
-        return self.compute(column_name, period = period, accept_other_period = accept_other_period,
-            requested_formulas_by_period = requested_formulas_by_period).array
+        return self.compute(column_name, period = period, accept_other_period = accept_other_period).array
 
-    def calculate_add(self, column_name, period = None, requested_formulas_by_period = None):
+    def calculate_add(self, column_name, period = None):
         if period is None:
             period = self.period
-        return self.compute_add(column_name, period = period,
-            requested_formulas_by_period = requested_formulas_by_period).array
+        return self.compute_add(column_name, period = period).array
 
-    def calculate_add_divide(self, column_name, period = None, requested_formulas_by_period = None):
+    def calculate_add_divide(self, column_name, period = None):
         if period is None:
             period = self.period
-        return self.compute_add_divide(column_name, period = period,
-            requested_formulas_by_period = requested_formulas_by_period).array
+        return self.compute_add_divide(column_name, period = period).array
 
-    def calculate_divide(self, column_name, period = None, requested_formulas_by_period = None):
+    def calculate_divide(self, column_name, period = None):
         if period is None:
             period = self.period
-        return self.compute_divide(column_name, period = period,
-            requested_formulas_by_period = requested_formulas_by_period).array
+        return self.compute_divide(column_name, period = period).array
 
     def calculate_output(self, column_name, period = None):
         """Calculate the value using calculate_output hooks in formula classes."""
@@ -157,7 +154,7 @@ class Simulation(object):
 
         return new
 
-    def compute(self, column_name, period = None, accept_other_period = False, requested_formulas_by_period = None):
+    def compute(self, column_name, period = None, accept_other_period = False):
         if period is None:
             period = self.period
         elif not isinstance(period, periods.Period):
@@ -169,9 +166,9 @@ class Simulation(object):
             if variable_infos not in caller_input_variables_infos:
                 caller_input_variables_infos.append(variable_infos)
         return self.entity_by_column_name[column_name].compute(column_name, period = period,
-            accept_other_period = accept_other_period, requested_formulas_by_period = requested_formulas_by_period)
+            accept_other_period = accept_other_period)
 
-    def compute_add(self, column_name, period = None, requested_formulas_by_period = None):
+    def compute_add(self, column_name, period = None):
         if period is None:
             period = self.period
         elif not isinstance(period, periods.Period):
@@ -182,10 +179,9 @@ class Simulation(object):
             caller_input_variables_infos = calling_frame['input_variables_infos']
             if variable_infos not in caller_input_variables_infos:
                 caller_input_variables_infos.append(variable_infos)
-        return self.entity_by_column_name[column_name].compute_add(column_name, period = period,
-            requested_formulas_by_period = requested_formulas_by_period)
+        return self.entity_by_column_name[column_name].compute_add(column_name, period = period)
 
-    def compute_add_divide(self, column_name, period = None, requested_formulas_by_period = None):
+    def compute_add_divide(self, column_name, period = None):
         if period is None:
             period = self.period
         elif not isinstance(period, periods.Period):
@@ -196,10 +192,9 @@ class Simulation(object):
             caller_input_variables_infos = calling_frame['input_variables_infos']
             if variable_infos not in caller_input_variables_infos:
                 caller_input_variables_infos.append(variable_infos)
-        return self.entity_by_column_name[column_name].compute_add_divide(column_name, period = period,
-            requested_formulas_by_period = requested_formulas_by_period)
+        return self.entity_by_column_name[column_name].compute_add_divide(column_name, period = period)
 
-    def compute_divide(self, column_name, period = None, requested_formulas_by_period = None):
+    def compute_divide(self, column_name, period = None):
         if period is None:
             period = self.period
         elif not isinstance(period, periods.Period):
@@ -210,8 +205,7 @@ class Simulation(object):
             caller_input_variables_infos = calling_frame['input_variables_infos']
             if variable_infos not in caller_input_variables_infos:
                 caller_input_variables_infos.append(variable_infos)
-        return self.entity_by_column_name[column_name].compute_divide(column_name, period = period,
-            requested_formulas_by_period = requested_formulas_by_period)
+        return self.entity_by_column_name[column_name].compute_divide(column_name, period = period)
 
     def get_array(self, column_name, period = None):
         if period is None:

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -86,25 +86,26 @@ class Simulation(object):
                 self.persons = entity
                 break
 
-    def calculate(self, column_name, period = None, accept_other_period = False):
+    def calculate(self, column_name, period = None, **parameters):
         if period is None:
             period = self.period
-        return self.compute(column_name, period = period, accept_other_period = accept_other_period).array
+        return self.compute(column_name, period = period, **parameters).array
 
-    def calculate_add(self, column_name, period = None):
-        if period is None:
-            period = self.period
-        return self.compute_add(column_name, period = period).array
 
-    def calculate_add_divide(self, column_name, period = None):
+    def calculate_add(self, column_name, period = None, **parameters):
         if period is None:
             period = self.period
-        return self.compute_add_divide(column_name, period = period).array
+        return self.compute_add(column_name, period = period, **parameters).array
 
-    def calculate_divide(self, column_name, period = None):
+    def calculate_add_divide(self, column_name, period = None, **parameters):
         if period is None:
             period = self.period
-        return self.compute_divide(column_name, period = period).array
+        return self.compute_add_divide(column_name, period = period, **parameters).array
+
+    def calculate_divide(self, column_name, period = None, **parameters):
+        if period is None:
+            period = self.period
+        return self.compute_divide(column_name, period = period, **parameters).array
 
     def calculate_output(self, column_name, period = None):
         """Calculate the value using calculate_output hooks in formula classes."""
@@ -158,7 +159,7 @@ class Simulation(object):
 
         return new
 
-    def compute(self, column_name, period = None, accept_other_period = False):
+    def compute(self, column_name, period = None, **parameters):
         if period is None:
             period = self.period
         elif not isinstance(period, periods.Period):
@@ -170,10 +171,10 @@ class Simulation(object):
             if variable_infos not in caller_input_variables_infos:
                 caller_input_variables_infos.append(variable_infos)
         holder = self.get_or_new_holder(column_name)
-        return holder.compute(period = period, accept_other_period = accept_other_period)
+        return holder.compute(period = period, **parameters)
 
 
-    def compute_add(self, column_name, period = None):
+    def compute_add(self, column_name, period = None, **parameters):
         if period is None:
             period = self.period
         elif not isinstance(period, periods.Period):
@@ -185,9 +186,9 @@ class Simulation(object):
             if variable_infos not in caller_input_variables_infos:
                 caller_input_variables_infos.append(variable_infos)
         holder = self.get_or_new_holder(column_name)
-        return holder.compute_add(period = period)
+        return holder.compute_add(period = period, **parameters)
 
-    def compute_add_divide(self, column_name, period = None):
+    def compute_add_divide(self, column_name, period = None, **parameters):
         if period is None:
             period = self.period
         elif not isinstance(period, periods.Period):
@@ -199,9 +200,9 @@ class Simulation(object):
             if variable_infos not in caller_input_variables_infos:
                 caller_input_variables_infos.append(variable_infos)
         holder = self.get_or_new_holder(column_name)
-        return holder.compute_add_divide(period = period)
+        return holder.compute_add_divide(period = period, **parameters)
 
-    def compute_divide(self, column_name, period = None):
+    def compute_divide(self, column_name, period = None, **parameters):
         if period is None:
             period = self.period
         elif not isinstance(period, periods.Period):
@@ -213,7 +214,7 @@ class Simulation(object):
             if variable_infos not in caller_input_variables_infos:
                 caller_input_variables_infos.append(variable_infos)
         holder = self.get_or_new_holder(column_name)
-        return holder.compute_divide(period = period)
+        return holder.compute_divide(period = period, **parameters)
 
     def get_array(self, column_name, period = None):
         if period is None:

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -50,7 +50,7 @@ class Simulation(object):
         self.period = period
         self.holder_by_name = {}
 
-        # To keep track of the values (formulas and periods) being calculated to detect circular definitions.
+        # To keep track of the values (formulas and periods) being calculated to detect circular definitions. See use in formulas.py.
         self.requested_values = {}
 
         if debug:

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -185,7 +185,7 @@ class Simulation(object):
             if variable_infos not in caller_input_variables_infos:
                 caller_input_variables_infos.append(variable_infos)
         holder = self.get_or_new_holder(column_name)
-        return holder.compute_add(period = period, accept_other_period = accept_other_period)
+        return holder.compute_add(period = period)
 
     def compute_add_divide(self, column_name, period = None):
         if period is None:
@@ -199,7 +199,7 @@ class Simulation(object):
             if variable_infos not in caller_input_variables_infos:
                 caller_input_variables_infos.append(variable_infos)
         holder = self.get_or_new_holder(column_name)
-        return holder.compute_add_divide(period = period, accept_other_period = accept_other_period)
+        return holder.compute_add_divide(period = period)
 
     def compute_divide(self, column_name, period = None):
         if period is None:
@@ -213,7 +213,7 @@ class Simulation(object):
             if variable_infos not in caller_input_variables_infos:
                 caller_input_variables_infos.append(variable_infos)
         holder = self.get_or_new_holder(column_name)
-        return holder.compute_divide(period = period, accept_other_period = accept_other_period)
+        return holder.compute_divide(period = period)
 
     def get_array(self, column_name, period = None):
         if period is None:

--- a/openfisca_core/tests/test_countries.py
+++ b/openfisca_core/tests/test_countries.py
@@ -34,7 +34,7 @@ from openfisca_core import conv, periods
 from openfisca_core.columns import BoolCol, DateCol, FixedStrCol, FloatCol, IntCol
 from openfisca_core.entities import AbstractEntity
 from openfisca_core.formulas import (dated_function, DatedFormulaColumn, EntityToPersonColumn,
-    make_reference_formula_decorator, PersonToEntityColumn, reference_input_variable, set_input_divide_by_period,
+    make_formula_decorator, PersonToEntityColumn, reference_input_variable, set_input_divide_by_period,
     SimpleFormulaColumn)
 from openfisca_core.scenarios import AbstractScenario, set_entities_json_id
 from openfisca_core.taxbenefitsystems import AbstractTaxBenefitSystem
@@ -339,7 +339,7 @@ reference_input_variable(
 # Calculated variables
 
 
-reference_formula = make_reference_formula_decorator(entity_class_by_symbol = entity_class_by_symbol)
+reference_formula = make_formula_decorator(entity_class_by_symbol = entity_class_by_symbol)
 
 
 @reference_formula

--- a/openfisca_core/tools.py
+++ b/openfisca_core/tools.py
@@ -41,8 +41,9 @@ class Dummy(object):
     pass
 
 
-def assert_near(value, target_value, absolute_error_margin = 0, message = '', relative_error_margin = None):
-    assert absolute_error_margin is not None or relative_error_margin is not None
+def assert_near(value, target_value, absolute_error_margin = None, message = '', relative_error_margin = None):
+    if absolute_error_margin is None and relative_error_margin is None:
+        absolute_error_margin = 0
     if isinstance(value, (list, tuple)):
         value = np.array(value)
     if isinstance(target_value, (list, tuple)):

--- a/openfisca_core/web_tools.py
+++ b/openfisca_core/web_tools.py
@@ -28,6 +28,20 @@ import urllib
 import webbrowser
 
 
+def get_trace_tool_link(scenario, variables, api_url = u'http://api-test.openfisca.fr',
+        trace_tool_url = u'http://www.openfisca.fr/outils/trace'):
+    scenario_json = scenario.to_json()
+    simulation_json = {
+        'scenarios': [scenario_json],
+        'variables': variables,
+        }
+    url = trace_tool_url + '?' + urllib.urlencode({
+        'simulation': json.dumps(simulation_json),
+        'api_url': api_url,
+        })
+    return url
+
+
 def open_trace_tool(scenario, variables, api_url = u'http://api.openfisca.fr',
         trace_tool_url = u'http://www.openfisca.fr/outils/trace'):
     scenario_json = scenario.to_json()


### PR DESCRIPTION
Connected to #347 
Depends on https://github.com/openfisca/openfisca-france/pull/349 and https://github.com/openfisca/openfisca-web-api/pull/45

Please make sure openfisca france tests are ok before merging.

What has been done here : 
- Repair the infinite loop detection that was partly implemented but disconnected
- Detect the circular definition with a time offset (when a formula at time T depending on the same formula at another time). Return the default value of the variable in this case, except if recursion has been explicitly allowed.
- Refactor the `Entity` class. Take it out of the computation chain, and let `Simulation` handle holders_by_name. 
- Make it possible to transmit parameters in the computation chain without having to explicitly declare them at each level, by using `**parameters`

I'm still facing non passing tests. In some reforms like `inversion_revenus`, there is a detection of an infinite loop. I don't fully understand the problem, so I'd be happy to have some help from openfisca team :) @cbenz @eraviart 