### PR TITLE
Uniformize variable declaration

### DIFF
--- a/openfisca_core/columns.py
+++ b/openfisca_core/columns.py
@@ -483,7 +483,7 @@ class PeriodSizeIndependentIntCol(IntCol):
 
 
 def build_column(name = None, column = None, entity_class_by_symbol = None):
-    # Obsolete. Use reference_input_variable instead.
+    # Obsolete. Use a Variable without a formula instead
     from . import formulas
 
     assert isinstance(name, basestring), name

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -1303,16 +1303,11 @@ def new_filled_column(base_function = UnboundLocalError, calculate_output = Unbo
     else:
         assert issubclass(formula_class, SimpleFormula), formula_class
 
-        function = specific_attributes.pop('function', UnboundLocalError)
+        function = specific_attributes.pop('function', None)
         if is_permanent:
-            assert function is UnboundLocalError
-        if function is UnboundLocalError:
-            assert reference_column is not None and issubclass(reference_column.formula_class, SimpleFormula), \
-                """Missing attribute "function" in definition of filled column {}""".format(name)
+            assert function is None
+        if reference_column is not None and function is None:
             function = reference_column.formula_class.function
-        else:
-            assert function is not None, """Missing attribute "function" in definition of filled column {}""".format(
-                name)
         formula_class_attributes['function'] = function
 
     # Ensure that all attributes defined in ConversionColumn class are used.

--- a/openfisca_core/reforms.py
+++ b/openfisca_core/reforms.py
@@ -123,17 +123,6 @@ def make_reform(key, name, reference, decomposition_dir_name = None, decompositi
             entity_column_by_name[name] = column
             return column
 
-        @classmethod
-        def input_variable(cls, entity_class = None, **kwargs):
-            if cls._constructed:
-                print 'Caution: You are adding an input variable to an instantiated Reform. ' \
-                    'Reform must be reinstatiated.'
-            # Ensure that entity_class belongs to reform (instead of reference tax-benefit system).
-            entity_class = cls.entity_class_by_key_plural[entity_class.key_plural]
-            assert 'update' not in kwargs
-            kwargs['update'] = True
-            return formulas.reference_input_variable(entity_class = entity_class, **kwargs)
-
         # Classes for inheriting from reform variables.
 
         class DatedVariable(object):

--- a/openfisca_core/scripts/measure_performances.py
+++ b/openfisca_core/scripts/measure_performances.py
@@ -18,7 +18,7 @@ from numpy.core.defchararray import startswith
 from openfisca_core import periods, simulations
 from openfisca_core.columns import BoolCol, DateCol, FixedStrCol, FloatCol, IntCol
 from openfisca_core.entities import AbstractEntity
-from openfisca_core.formulas import (dated_function, DatedVariable, EntityToPersonColumn, PersonToEntityColumn, reference_input_variable, Variable)
+from openfisca_core.formulas import (dated_function, DatedVariable, EntityToPersonColumn, PersonToEntityColumn, Variable)
 from openfisca_core.taxbenefitsystems import AbstractTaxBenefitSystem
 from openfisca_core.tools import assert_near
 
@@ -91,55 +91,43 @@ def init_country():
 # Input variables
 
 
-reference_input_variable(
-    column = IntCol,
-    entity_class = Individus,
-    label = u"Âge (en nombre de mois)",
-    name = 'age_en_mois',
-    )
+class age_en_mois(Variable):
+    column = IntCol
+    entity_class = Individus
+    label = u"Âge (en nombre de mois)"
 
 
-reference_input_variable(
-    column = DateCol,
-    entity_class = Individus,
-    label = u"Date de naissance",
-    name = 'birth',
-    )
+class birth(Variable):
+    column = DateCol
+    entity_class = Individus
+    label = u"Date de naissance"
 
 
-reference_input_variable(
-    column = FixedStrCol(max_length = 5),
-    entity_class = Familles,
-    is_permanent = True,
-    label = u"""Code INSEE "depcom" de la commune de résidence de la famille""",
-    name = 'depcom',
-    )
+class depcom(Variable):
+    column = FixedStrCol(max_length = 5)
+    entity_class = Familles
+    is_permanent = True
+    label = u"""Code INSEE "depcom" de la commune de résidence de la famille"""
 
 
-reference_input_variable(
-    column = IntCol,
-    entity_class = Individus,
-    is_permanent = True,
-    label = u"Identifiant de la famille",
-    name = 'id_famille',
-    )
+class id_famille(Variable):
+    column = IntCol
+    entity_class = Individus
+    is_permanent = True
+    label = u"Identifiant de la famille"
 
 
-reference_input_variable(
-    column = IntCol,
-    entity_class = Individus,
-    is_permanent = True,
-    label = u"Rôle dans la famille",
-    name = 'role_dans_famille',
-    )
+class role_dans_famille(Variable):
+    column = IntCol
+    entity_class = Individus
+    is_permanent = True
+    label = u"Rôle dans la famille"
 
 
-reference_input_variable(
-    column = FloatCol,
-    entity_class = Individus,
-    label = "Salaire brut",
-    name = 'salaire_brut',
-    )
+class salaire_brut(Variable):
+    column = FloatCol
+    entity_class = Individus
+    label = "Salaire brut"
 
 
 # Calculated variables

--- a/openfisca_core/tests/dummy_country.py
+++ b/openfisca_core/tests/dummy_country.py
@@ -7,7 +7,7 @@ import itertools
 from openfisca_core import conv
 from openfisca_core.columns import IntCol
 from openfisca_core.entities import AbstractEntity
-from openfisca_core.formulas import reference_input_variable
+from openfisca_core.formulas import Variable
 from openfisca_core.scenarios import AbstractScenario, set_entities_json_id
 from openfisca_core.taxbenefitsystems import AbstractTaxBenefitSystem
 
@@ -65,23 +65,17 @@ entity_class_by_symbol = dict(
 # Mandatory input variables
 
 
-reference_input_variable(
-    column = IntCol,
-    entity_class = Individus,
-    is_permanent = True,
-    label = u"Identifiant de la famille",
-    name = 'id_famille',
-    )
+class id_famille(Variable):
+    column = IntCol
+    entity_class = Individus
+    is_permanent = True
+    label = u"Identifiant de la famille"
 
-
-reference_input_variable(
-    column = IntCol,
-    entity_class = Individus,
-    is_permanent = True,
-    label = u"Rôle dans la famille",
-    name = 'role_dans_famille',
-    )
-
+class role_dans_famille(Variable):
+    column = IntCol
+    entity_class = Individus
+    is_permanent = True
+    label = u"Rôle dans la famille"
 
 # Scenarios
 

--- a/openfisca_core/tests/test_countries.py
+++ b/openfisca_core/tests/test_countries.py
@@ -8,7 +8,7 @@ from numpy.core.defchararray import startswith
 from openfisca_core import periods
 from openfisca_core.columns import BoolCol, DateCol, FixedStrCol, FloatCol, IntCol
 from openfisca_core.formulas import (dated_function, DatedVariable, EntityToPersonColumn,
-    PersonToEntityColumn, reference_input_variable, set_input_divide_by_period, Variable)
+    PersonToEntityColumn, set_input_divide_by_period, Variable)
 from openfisca_core.tests import dummy_country
 from openfisca_core.tests.dummy_country import Familles, Individus
 from openfisca_core.tools import assert_near
@@ -17,38 +17,27 @@ from openfisca_core.tools import assert_near
 # Input variables
 
 
-reference_input_variable(
-    column = IntCol,
-    entity_class = Individus,
-    label = u"Âge (en nombre de mois)",
-    name = 'age_en_mois',
-    )
+class age_en_mois(Variable):
+    column = IntCol
+    entity_class = Individus
+    label = u"Âge (en nombre de mois)"
 
+class birth(Variable):
+    column = DateCol
+    entity_class = Individus
+    label = u"Date de naissance"
 
-reference_input_variable(
-    column = DateCol,
-    entity_class = Individus,
-    label = u"Date de naissance",
-    name = 'birth',
-    )
+class depcom(Variable):
+    column = FixedStrCol(max_length = 5)
+    entity_class = Familles
+    is_permanent = True
+    label = u"""Code INSEE "depcom" de la commune de résidence de la famille"""
 
-
-reference_input_variable(
-    column = FixedStrCol(max_length = 5),
-    entity_class = Familles,
-    is_permanent = True,
-    label = u"""Code INSEE "depcom" de la commune de résidence de la famille""",
-    name = 'depcom',
-    )
-
-
-reference_input_variable(
-    column = FloatCol,
-    entity_class = Individus,
-    label = "Salaire brut",
-    name = 'salaire_brut',
-    set_input = set_input_divide_by_period,
-    )
+class salaire_brut(Variable):
+    column = FloatCol
+    entity_class = Individus
+    label = "Salaire brut"
+    set_input = set_input_divide_by_period
 
 
 # Calculated variables


### PR DESCRIPTION
Connected to #355 
Follows #364 

I didn't deprecate `reference_input_variable`, so probably no migration needed on other repositories right now.