### PR TITLE
Add base function requested_period_last_or_next_value

### DIFF
--- a/openfisca_core/columns.py
+++ b/openfisca_core/columns.py
@@ -9,7 +9,7 @@ import re
 from biryani import strings
 import numpy as np
 
-from . import conv, periods
+from . import conv, periods, base_functions
 from .enumerations import Enum
 
 
@@ -493,11 +493,11 @@ def build_column(name = None, column = None, entity_class_by_symbol = None):
     column.entity_key_plural = entity_class.key_plural
 
     if column.is_permanent:
-        base_function = formulas.permanent_default_value
+        base_function = base_functions.permanent_default_value
     elif column.is_period_size_independent:
-        base_function = formulas.requested_period_last_value
+        base_function = base_functions.requested_period_last_value
     else:
-        base_function = formulas.requested_period_default_value
+        base_function = base_functions.requested_period_default_value
     caller_frame = inspect.currentframe().f_back
     column.formula_class = type(name.encode('utf-8'), (formulas.SimpleFormula,), dict(
         __module__ = inspect.getmodule(caller_frame).__name__,

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -13,7 +13,7 @@ import textwrap
 import numpy as np
 
 from . import columns, holders, legislations, periods
-from .base_functions import requested_period_last_value, requested_period_default_value, permanent_default_value, requested_period_default_value_neutralized
+from .base_functions import requested_period_last_value, requested_period_default_value, permanent_default_value, requested_period_default_value_neutralized, requested_period_last_or_next_value
 from .tools import empty_clone, stringify_array
 
 
@@ -1218,7 +1218,7 @@ def new_filled_column(base_function = UnboundLocalError, calculate_output = Unbo
         assert base_function is UnboundLocalError
         base_function = permanent_default_value
     elif column.is_period_size_independent:
-        assert base_function in (missing_value, requested_period_last_value, UnboundLocalError)
+        assert base_function in (missing_value, requested_period_last_value,requested_period_last_or_next_value, UnboundLocalError)
         if base_function is UnboundLocalError:
             base_function = requested_period_last_value
     elif base_function is UnboundLocalError:

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -13,6 +13,7 @@ import textwrap
 import numpy as np
 
 from . import columns, holders, legislations, periods
+from .base_functions import requested_period_last_value, requested_period_default_value, permanent_default_value, requested_period_default_value_neutralized
 from .tools import empty_clone, stringify_array
 
 
@@ -1060,23 +1061,6 @@ def dated_function(start = None, stop = None):
 
     return dated_function_decorator
 
-
-def last_duration_last_value(formula, simulation, period):
-    # This formula is used for variables that are constants between events but are period size dependent.
-    # It returns the latest known value for the requested start of period but with the last period size.
-    holder = formula.holder
-    if holder._array_by_period is not None:
-        for last_period, last_array in sorted(holder._array_by_period.iteritems(), reverse = True):
-            if last_period.start <= period.start and (formula.function is None or last_period.stop >= period.stop):
-                return periods.Period((last_period[0], period.start, last_period[2])), last_array
-    if formula.function is not None:
-        return formula.function(simulation, period)
-    column = holder.column
-    array = np.empty(holder.entity.count, dtype = column.dtype)
-    array.fill(column.default)
-    return period, array
-
-
 def add_column_to_tax_benefit_system(column, update = False):
     assert isinstance(column, columns.Column)
     assert column.formula_class is not None
@@ -1352,89 +1336,6 @@ def new_filled_column(base_function = UnboundLocalError, calculate_output = Unbo
         column.url = url
 
     return column
-
-
-def permanent_default_value(formula, simulation, period):
-    if formula.function is not None:
-        return formula.function(simulation, period)
-    holder = formula.holder
-    column = holder.column
-    array = np.empty(holder.entity.count, dtype = column.dtype)
-    array.fill(column.default)
-    return period, array
-
-
-def requested_period_added_value(formula, simulation, period):
-    # This formula is used for variables that can be added to match requested period.
-    holder = formula.holder
-    column = holder.column
-    period_size = period.size
-    period_unit = period.unit
-    if holder._array_by_period is not None and (period_size > 1 or period_unit == u'year'):
-        after_instant = period.start.offset(period_size, period_unit)
-        if period_size > 1:
-            array = formula.zeros(dtype = column.dtype)
-            sub_period = period.start.period(period_unit)
-            while sub_period.start < after_instant:
-                sub_array = holder._array_by_period.get(sub_period)
-                if sub_array is None:
-                    array = None
-                    break
-                array += sub_array
-                sub_period = sub_period.offset(1)
-            if array is not None:
-                return period, array
-        if period_unit == u'year':
-            array = formula.zeros(dtype = column.dtype)
-            month = period.start.period(u'month')
-            while month.start < after_instant:
-                month_array = holder._array_by_period.get(month)
-                if month_array is None:
-                    array = None
-                    break
-                array += month_array
-                month = month.offset(1)
-            if array is not None:
-                return period, array
-    if formula.function is not None:
-        return formula.function(simulation, period)
-    array = np.empty(holder.entity.count, dtype = column.dtype)
-    array.fill(column.default)
-    return period, array
-
-
-def requested_period_default_value(formula, simulation, period):
-    if formula.function is not None:
-        return formula.function(simulation, period)
-    holder = formula.holder
-    column = holder.column
-    array = np.empty(holder.entity.count, dtype = column.dtype)
-    array.fill(column.default)
-    return period, array
-
-
-def requested_period_default_value_neutralized(formula, simulation, period):
-    holder = formula.holder
-    column = holder.column
-    array = np.empty(holder.entity.count, dtype = column.dtype)
-    array.fill(column.default)
-    return period, array
-
-
-def requested_period_last_value(formula, simulation, period):
-    # This formula is used for variables that are constants between events and period size independent.
-    # It returns the latest known value for the requested period.
-    holder = formula.holder
-    if holder._array_by_period is not None:
-        for last_period, last_array in sorted(holder._array_by_period.iteritems(), reverse = True):
-            if last_period.start <= period.start and (formula.function is None or last_period.stop >= period.stop):
-                return period, last_array
-    if formula.function is not None:
-        return formula.function(simulation, period)
-    column = holder.column
-    array = np.empty(holder.entity.count, dtype = column.dtype)
-    array.fill(column.default)
-    return period, array
 
 
 def set_input_dispatch_by_period(formula, period, array):


### PR DESCRIPTION
Introduces a new base function requested_period_last_or_next_value, similar to requested_period_last_value except it can take a value from the future is there is none in the past.

Exemple : 
Input : `alt = True` for a child on 2016-01
If I request `alt`in 2015-12, I will get True.

It is helpful for calculating values in the past more accurately, which is useful for ppa_fictive calculations.

Depends on https://github.com/openfisca/openfisca-france/pull/427
Depends on https://github.com/openfisca/openfisca-parsers/pull/10