### PR TITLE
Implement mechanism to opt out of cache for some variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0 – [diff](https://github.com/openfisca/openfisca-core/compare/1.0.0...1.1.0)
+
+* Implement cache opt out system
+
 ## 1.0.0 – [diff](https://github.com/openfisca/openfisca-core/compare/0.5.4...1.0.0)
 
 * Remove `build_column` obsolete function. Use `Variable` class instead.

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -334,8 +334,12 @@ class Holder(object):
 
     def put_in_cache(self, value, period, extra_params = None):
         simulation = self.entity.simulation
-        if simulation.opt_out_cache and self.column.name in simulation.tax_benefit_system.cache_blacklist:
+
+        if (simulation.opt_out_cache and
+                simulation.tax_benefit_system.cache_blacklist and
+                self.column.name in simulation.tax_benefit_system.cache_blacklist):
             return DatedHolder(self, period, value = value)
+
         if self.column.is_permanent:
             self.array = value
         assert period is not None

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -334,7 +334,7 @@ class Holder(object):
 
     def put_in_cache(self, value, period, extra_params = None):
         simulation = self.entity.simulation
-        if simulation.opt_out_cache and self.column.name in simulation.cache_blacklist:
+        if simulation.opt_out_cache and self.column.name in simulation.tax_benefit_system.cache_blacklist:
             return DatedHolder(self, period, value = value)
         if self.column.is_permanent:
             self.array = value

--- a/openfisca_core/scenarios.py
+++ b/openfisca_core/scenarios.py
@@ -339,7 +339,7 @@ class AbstractScenario(object):
         return json_to_instance
 
     def new_simulation(self, debug = False, debug_all = False, reference = False, trace = False,
-            use_set_input_hooks = True):
+            use_set_input_hooks = True, opt_out_cache = False):
         assert isinstance(reference, (bool, int)), \
             'Parameter reference must be a boolean. When True, the reference tax-benefit system is used.'
         tax_benefit_system = self.tax_benefit_system
@@ -355,6 +355,7 @@ class AbstractScenario(object):
             period = self.period,
             tax_benefit_system = tax_benefit_system,
             trace = trace,
+            opt_out_cache = opt_out_cache,
             )
         self.fill_simulation(simulation, use_set_input_hooks = use_set_input_hooks)
         return simulation

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -45,8 +45,6 @@ class Simulation(object):
         if trace:
             self.trace = True
         self.opt_out_cache = opt_out_cache
-        if opt_out_cache:
-            self.cache_blacklist = set()
         if debug or trace:
             self.stack_trace = collections.deque()
             self.traceback = collections.OrderedDict()

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -23,7 +23,8 @@ class Simulation(object):
     trace = False
     traceback = None
 
-    def __init__(self, debug = False, debug_all = False, period = None, tax_benefit_system = None, trace = False):
+    def __init__(self, debug = False, debug_all = False, period = None, tax_benefit_system = None,
+    trace = False, opt_out_cache = False):
         assert isinstance(period, periods.Period)
         self.period = period
         self.holder_by_name = {}
@@ -43,6 +44,9 @@ class Simulation(object):
         self.tax_benefit_system = tax_benefit_system
         if trace:
             self.trace = True
+        self.opt_out_cache = opt_out_cache
+        if opt_out_cache:
+            self.cache_blacklist = set()
         if debug or trace:
             self.stack_trace = collections.deque()
             self.traceback = collections.OrderedDict()

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -27,6 +27,7 @@ class AbstractTaxBenefitSystem(object):
         ))
     reference = None  # Reference tax-benefit system. Used only by reforms. Note: Reforms can be chained.
     Scenario = None
+    cache_blacklist = None
 
     def __init__(self, entity_class_by_key_plural = None, legislation_json = None):
         # TODO: Currently: Don't use a weakref, because they are cleared by Paste (at least) at each call.

--- a/openfisca_core/tests/test_opt_out_cache.py
+++ b/openfisca_core/tests/test_opt_out_cache.py
@@ -49,7 +49,7 @@ def test_without_cache_opt_out():
 
 def test_with_cache_opt_out():
     simulation = scenario.new_simulation(debug = True, opt_out_cache = True)
-    simulation.add_to_cache_blacklist(cache_blacklist)
+    simulation.cache_blacklist = cache_blacklist
     simulation.calculate('output')
     intermediate_cache = simulation.get_or_new_holder('intermediate')
-    assert(len(intermediate_cache._array_by_period) == 0)
+    assert(intermediate_cache._array_by_period is None)

--- a/openfisca_core/tests/test_opt_out_cache.py
+++ b/openfisca_core/tests/test_opt_out_cache.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+
+from openfisca_core.tests import dummy_country
+from openfisca_core.formulas import Variable
+from openfisca_core.columns import IntCol
+from openfisca_core.tests.dummy_country import Individus
+
+
+class input(Variable):
+    column = IntCol
+    entity_class = Individus
+    label = u"Input variable"
+
+
+class intermediate(Variable):
+    column = IntCol
+    entity_class = Individus
+    label = u"Intermediate result that don't need to be cached"
+
+    def function(self, simulation, period):
+        return period, simulation.calculate('input', period)
+
+
+class output(Variable):
+    column = IntCol
+    entity_class = Individus
+    label = u'Output variable'
+
+    def function(self, simulation, period):
+        return period, simulation.calculate('intermediate', period)
+
+cache_blacklist = set(['intermediate'])
+
+# TaxBenefitSystem instance declared after formulas
+tax_benefit_system = dummy_country.init_tax_benefit_system()
+scenario = tax_benefit_system.new_scenario().init_from_attributes(
+    period = 2016,
+    input_variables = {
+        'input': 1,
+        },
+    )
+
+def test_without_cache_opt_out():
+    simulation = scenario.new_simulation(debug = True)
+    simulation.calculate('output')
+    intermediate_cache = simulation.get_or_new_holder('intermediate')
+    assert(len(intermediate_cache._array_by_period) > 0)
+
+def test_with_cache_opt_out():
+    simulation = scenario.new_simulation(debug = True, opt_out_cache = True)
+    simulation.add_to_cache_blacklist(cache_blacklist)
+    simulation.calculate('output')
+    intermediate_cache = simulation.get_or_new_holder('intermediate')
+    assert(len(intermediate_cache._array_by_period) == 0)

--- a/openfisca_core/tests/test_opt_out_cache.py
+++ b/openfisca_core/tests/test_opt_out_cache.py
@@ -30,10 +30,11 @@ class output(Variable):
     def function(self, simulation, period):
         return period, simulation.calculate('intermediate', period)
 
-cache_blacklist = set(['intermediate'])
 
 # TaxBenefitSystem instance declared after formulas
 tax_benefit_system = dummy_country.init_tax_benefit_system()
+tax_benefit_system.cache_blacklist = set(['intermediate'])
+
 scenario = tax_benefit_system.new_scenario().init_from_attributes(
     period = 2016,
     input_variables = {
@@ -49,7 +50,6 @@ def test_without_cache_opt_out():
 
 def test_with_cache_opt_out():
     simulation = scenario.new_simulation(debug = True, opt_out_cache = True)
-    simulation.cache_blacklist = cache_blacklist
     simulation.calculate('output')
     intermediate_cache = simulation.get_or_new_holder('intermediate')
     assert(intermediate_cache._array_by_period is None)

--- a/openfisca_core/tests/test_opt_out_cache.py
+++ b/openfisca_core/tests/test_opt_out_cache.py
@@ -42,14 +42,32 @@ scenario = tax_benefit_system.new_scenario().init_from_attributes(
         },
     )
 
+
 def test_without_cache_opt_out():
     simulation = scenario.new_simulation(debug = True)
     simulation.calculate('output')
     intermediate_cache = simulation.get_or_new_holder('intermediate')
     assert(len(intermediate_cache._array_by_period) > 0)
 
+
 def test_with_cache_opt_out():
     simulation = scenario.new_simulation(debug = True, opt_out_cache = True)
     simulation.calculate('output')
     intermediate_cache = simulation.get_or_new_holder('intermediate')
     assert(intermediate_cache._array_by_period is None)
+
+
+tax_benefit_system2 = dummy_country.init_tax_benefit_system()
+scenario2 = tax_benefit_system2.new_scenario().init_from_attributes(
+    period = 2016,
+    input_variables = {
+        'input': 1,
+        },
+    )
+
+
+def test_with_no_blacklist():
+    simulation = scenario2.new_simulation(debug = True, opt_out_cache = True)
+    simulation.calculate('output')
+    intermediate_cache = simulation.get_or_new_holder('intermediate')
+    assert(len(intermediate_cache._array_by_period) > 0)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '1.0.0',
+    version = '1.1.0',
 
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',


### PR DESCRIPTION
When using it for a large population, having too many variables in cache make openfisca performances drop.

This introduces a mechanism that enables some variables not to be cached.

The names of the variables we don't want to cache must passed to the tax benefit system in a set : 
```python
tax_benefit_system.cache_blacklist = set(['intermediate'])
```
Then an extra parameter must be given when creating the simulation to activate this behaviour:
```python
simulation = scenario.new_simulation(debug = True, opt_out_cache = True)
```

See the [test file](https://github.com/openfisca/openfisca-core/blob/cache_opt_out/openfisca_core/tests/test_opt_out_cache.py) for a full exemple.

@cbenz @eraviart @laem @benjello any feedback ? Is naming clear enough ?