### PR TITLE
Load extensions from pip packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.0 – [diff](https://github.com/openfisca/openfisca-core/compare/2.0.3...2.0.4)
+
+* Load extensions from pip packages
+
 ## 2.0.4 – [diff](https://github.com/openfisca/openfisca-core/compare/2.0.3...2.0.4)
 
 * Use DEFAULT_DECOMP_FILE attribute from reference TB system

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -6,6 +6,7 @@ import glob
 from inspect import isclass
 from os import path
 from imp import find_module, load_module
+import importlib
 # import weakref
 
 from . import conv, legislations, legislationsxml
@@ -158,10 +159,17 @@ class TaxBenefitSystem(object):
         for variable in variables:
             self.add_variable(variable)
 
-    def load_extension(self, extension_directory):
-        if not path.isdir(extension_directory):
-            raise IOError(
-                "Error loading extension: the extension directory {} doesn't exist.".format(extension_directory))
+    def load_extension(self, extension):
+        if path.isdir(extension):
+            extension_directory = extension
+        else:
+            try:
+                package = importlib.import_module(extension)
+                extension_directory = package.__path__[0]
+            except ImportError:
+                raise IOError(
+                    "Error loading extension: {} is neither a directory, nor an installed package.".format(extension))
+
         self.add_variables_from_directory(extension_directory)
         param_file = path.join(extension_directory, 'parameters.xml')
         if path.isfile(param_file):

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -8,6 +8,7 @@ from os import path
 from imp import find_module, load_module
 import importlib
 import logging
+from setuptools import find_packages
 
 from . import conv, legislations, legislationsxml
 from variables import AbstractVariable
@@ -167,8 +168,14 @@ class TaxBenefitSystem(object):
 
     def load_extension(self, extension):
         if path.isdir(extension):
-            extension_directory = extension
+            if find_packages(extension):
+                # Load extension from a package directory
+                extension_directory = path.join(extension, find_packages(extension)[0])
+            else:
+                # Load extension from a simple directory
+                extension_directory = extension
         else:
+            # Load extension from installed pip package
             try:
                 package = importlib.import_module(extension)
                 extension_directory = package.__path__[0]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '2.0.4',
+    version = '2.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Enables this usage:

```py
tax_benefit_system.load_extension('openfisca_paris')
```

Provided that `openfisca_paris` has been installed via pip before. This is useful to define the extensions to load via the api config file. See https://github.com/openfisca/openfisca-web-api/pull/61.