### PR TITLE
Implement printing trace tree from Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.2.0
+
+* Implement simulation.calculate `print_trace=True` argument. Options: `max_depth` and `show_default_values`
+
+  Examples:
+  ```python
+  simulation = scenario.new_simulation(trace=True)
+  simulation.calculate('irpp', 2014, print_trace=True)
+  simulation.calculate('irpp', 2014, print_trace=True, max_depth=-1)
+  simulation.calculate('irpp', 2014, print_trace=True, max_depth=-1, show_default_values=False)
+  ```
+
 ## 2.1.0 – [diff](https://github.com/openfisca/openfisca-core/compare/2.0.3...2.0.4)
 
 * Load extensions from pip packages

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -3,6 +3,8 @@
 
 import collections
 
+import numpy as np
+
 from . import periods, holders
 from .tools import empty_clone, stringify_array
 
@@ -138,6 +140,15 @@ class Simulation(object):
             period = self.period
         elif not isinstance(period, periods.Period):
             period = periods.period(period)
+        print_trace = parameters.pop('print_trace', False)
+        if print_trace:
+            print_trace_kwargs = {}
+            max_depth = parameters.pop('max_depth', None)
+            if max_depth is not None:
+                print_trace_kwargs['max_depth'] = max_depth
+            show_default_values = parameters.pop('show_default_values', None)
+            if show_default_values is not None:
+                print_trace_kwargs['show_default_values'] = show_default_values
         if (self.debug or self.trace) and self.stack_trace:
             variable_infos = (column_name, period)
             calling_frame = self.stack_trace[-1]
@@ -145,7 +156,10 @@ class Simulation(object):
             if variable_infos not in caller_input_variables_infos:
                 caller_input_variables_infos.append(variable_infos)
         holder = self.get_or_new_holder(column_name)
-        return holder.compute(period = period, **parameters)
+        result = holder.compute(period = period, **parameters)
+        if print_trace:
+            self.print_trace(variable_name=column_name, period=period, **print_trace_kwargs)
+        return result
 
     def compute_add(self, column_name, period = None, **parameters):
         if period is None:
@@ -246,18 +260,69 @@ class Simulation(object):
             return self.get_reference_compact_legislation(instant)
         return self.get_compact_legislation(instant)
 
+    def find_traceback_step(self, variable_name, period):
+        assert isinstance(period, periods.Period), period
+        column = self.tax_benefit_system.get_column(variable_name, check_existence=True)
+        step = self.traceback.get((variable_name, period))
+        if step is None and column.is_period_size_independent:
+            period = None
+        step = self.traceback.get((variable_name, period))
+        return step
+
+    def print_trace(self, variable_name, period, max_depth=3, show_default_values=True):
+        """
+        Print the dependencies of all the variables computed since the creation of the simulation.
+
+        The `max_depth` parameter tells how much levels of the printed tree to show. Use -1 to disable limit.
+
+        The simulation must have been initialized with `trace=True` argument.
+        """
+        def traverse(current_variable_name, current_period, depth):
+            step = self.find_traceback_step(current_variable_name, current_period)
+            assert step is not None
+            holder = self.get_holder(current_variable_name)
+            has_default_value = np.all(holder.get_array(current_period) == holder.column.default)
+            if depth == 0 or (show_default_values or not has_default_value):
+                indent = u'|     ' * (depth - 1) + u'|---> ' \
+                    if depth > 0 \
+                    else ''
+                print(indent + self.stringify_variable_for_period_with_array(current_variable_name, current_period))
+            input_variables_infos = step.get('input_variables_infos')
+            if (max_depth == -1 or depth < max_depth) and input_variables_infos is not None:
+                    for index, (child_variable_name, child_period) in enumerate(input_variables_infos):
+                        traverse(child_variable_name, child_period, depth + 1)
+        if not isinstance(max_depth, int) or max_depth < -1:
+            raise ValueError(u'`max_depth` argument must be >= -1')
+        if not self.trace:
+            raise ValueError(u'This simulation has not been initialized with `trace=True` so the computation '
+                'did not collect any trace information.')
+        assert self.traceback is not None
+        if not isinstance(period, periods.Period):
+            period = periods.period(period)
+        step = self.find_traceback_step(variable_name, period)
+        if step is None:
+            raise ValueError(u'The given `variable_name` "{0}" was not calculated for the given `period` "{1}". '
+                u'It is therefore not possible to display the trace. '
+                u'You should do `simulation.calculate({0!r}, {1}, print_trace=True)`.'.format(
+                    variable_name, period))
+        traverse(variable_name, period, depth=0)
+
+    def stringify_variable_for_period_with_array(self, variable_name, period):
+        holder = self.get_holder(variable_name)
+        return u'{}@{}<{}>{}'.format(
+            variable_name,
+            holder.entity.key_plural,
+            str(period),
+            stringify_array(holder.get_array(period)),
+            )
+
     def stringify_input_variables_infos(self, input_variables_infos):
         return u', '.join(
-            u'{}@{}<{}>{}'.format(
-                input_holder.column.name,
-                input_holder.entity.key_plural,
-                str(input_variable_period),
-                stringify_array(input_holder.get_array(input_variable_period)),
+            self.stringify_variable_for_period_with_array(
+                variable_name=input_variable_name,
+                period=input_variable_period,
                 )
-            for input_holder, input_variable_period in (
-                (self.get_holder(input_variable_name), input_variable_period1)
-                for input_variable_name, input_variable_period1 in input_variables_infos
-                )
+            for input_variable_name, input_variable_period in input_variables_infos
             )
 
     # Fixme: to rewrite

--- a/openfisca_core/tests/test_simulations.py
+++ b/openfisca_core/tests/test_simulations.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+
+from nose.tools import raises
+
+from openfisca_core.tests.test_countries import TestTaxBenefitSystem
+
+
+tax_benefit_system = TestTaxBenefitSystem()
+scenario = tax_benefit_system.new_scenario().init_single_entity(
+    parent1=dict(),
+    period=2014,
+    )
+simulation = scenario.new_simulation(trace=True)
+
+
+def test_calculate_with_print_trace():
+    simulation.calculate('revenu_disponible', 2014, print_trace=True)
+
+
+def test_calculate_with_print_trace_and_max_depth():
+    simulation.calculate('revenu_disponible', 2014, print_trace=True, max_depth=0)
+    simulation.calculate('revenu_disponible', 2014, print_trace=True, max_depth=1)
+    simulation.calculate('revenu_disponible', 2014, print_trace=True, max_depth=5)
+    simulation.calculate('revenu_disponible', 2014, print_trace=True, max_depth=1000)
+    simulation.calculate('revenu_disponible', 2014, print_trace=True, max_depth=-1)
+    simulation.calculate('revenu_disponible', 2014, print_trace=True, max_depth=None)
+
+
+@raises(ValueError)
+def test_calculate_with_print_trace_and_invalid_max_depth():
+    simulation.calculate('revenu_disponible', 2014, print_trace=True, max_depth=-2)
+
+
+@raises(ValueError)
+def test_calculate_with_print_trace_without_trace_option():
+    simulation = scenario.new_simulation()
+    simulation.calculate('revenu_disponible', 2014, print_trace=True)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '2.1.0',
+    version = '2.2.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Especially from notebooks:

```python
scenario = tax_benefit_system.new_scenario().init_single_entity(
    parent1=dict(salaire_de_base=25000),
    period=2014,
    )
simulation = scenario.new_simulation(trace=True)
simulation.calculate('irpp', 2014, print_trace=True)
```

Outputs:

```
irpp@foyers_fiscaux<2014>[-1193.05]
|---> iai@foyers_fiscaux<2014>[1193.05]
|     |---> iaidrdi@foyers_fiscaux<2014>[1193.05]
|     |     |---> ip_net@foyers_fiscaux<2014>[1193.05]
|     |     |---> reductions@foyers_fiscaux<2014>[0.0]
|     |---> plus_values@foyers_fiscaux<2014>[0.0]
|     |     |---> f3vg@foyers_fiscaux<2014>[0]
|     |     |---> f3vh@foyers_fiscaux<2014>[0]
|     |     |---> f3vl@foyers_fiscaux<2014>[0]
|     |     |---> f3vm@foyers_fiscaux<2014>[0]
|     |     |---> f3vi@individus<2014>[0]
|     |     |---> f3vf@individus<2014>[0]
|     |     |---> f3vd@individus<2014>[0]
|     |     |---> f3sa@foyers_fiscaux<2014>[0]
|     |     |---> rpns_pvce@individus<2014>[0.0]
|     |---> cont_rev_loc@foyers_fiscaux<2014>[0.0]
|     |     |---> f4bl@foyers_fiscaux<2014>[0]
|     |---> teicaa@foyers_fiscaux<2014>[0.0]
|     |     |---> f5qm@individus<2014>[0]
|---> credits_impot@foyers_fiscaux<2014>[0.0]
|     |---> accult@foyers_fiscaux<2014>[0.0]
|     |     |---> f7uo@foyers_fiscaux<2014>[0]
|     |---> aidper@foyers_fiscaux<2014>[0.0]
|     |     |---> maries_ou_pacses@foyers_fiscaux<2014>[False]
|     |     |---> nb_pac2@foyers_fiscaux<2014>[0.0]
|     |     |---> f7wj@foyers_fiscaux<2014>[0]
|     |     |---> f7wl@foyers_fiscaux<2014>[0]
|     |     |---> f7wr@foyers_fiscaux<2014>[0]
|     |---> assloy@foyers_fiscaux<2014>[0.0]
|     |     |---> f4bf@foyers_fiscaux<2014>[0]
|     |---> autent@foyers_fiscaux<2014>[0.0]
|     |     |---> f8uy@foyers_fiscaux<2014>[0]
|     |---> ci_garext@foyers_fiscaux<2014>[0.0]
|     |     |---> f7ga@foyers_fiscaux<2014>[0]
|     |     |---> f7gb@foyers_fiscaux<2014>[0]
|     |     |---> f7gc@foyers_fiscaux<2014>[0]
|     |     |---> f7ge@foyers_fiscaux<2014>[0]
|     |     |---> f7gf@foyers_fiscaux<2014>[0]
|     |     |---> f7gg@foyers_fiscaux<2014>[0]
|     |---> cotsyn@foyers_fiscaux<2014>[0.0]
|     |     |---> f7ac@individus<2014>[0]
|     |     |---> salaire_imposable@individus<2014>[20234.8]
|     |     |---> chomage_imposable@individus<2014>[0.0]
|     |     |---> retraite_imposable@individus<2014>[0.0]
|     |---> creimp@foyers_fiscaux<2014>[0.0]
|     |---> direpa@foyers_fiscaux<2014>[0.0]
|     |     |---> f2bg@foyers_fiscaux<2014>[0]
|     |---> drbail@foyers_fiscaux<2014>[0.0]
|     |     |---> f4tq@foyers_fiscaux<2014>[0]
|     |---> inthab@foyers_fiscaux<2014>[0.0]
|     |---> mecena@foyers_fiscaux<2014>[0.0]
|     |     |---> f7us@foyers_fiscaux<2014>[0]
|     |---> preetu@foyers_fiscaux<2014>[0.0]
|     |     |---> f7uk@foyers_fiscaux<2014>[0]
|     |     |---> f7vo@foyers_fiscaux<2014>[0]
|     |     |---> f7td@foyers_fiscaux<2014>[0]
|     |---> prlire@foyers_fiscaux<2014>[0.0]
|     |---> quaenv@foyers_fiscaux<2014>[0.0]
|     |---> saldom2@foyers_fiscaux<2014>[0.0]
|---> cehr@foyers_fiscaux<2014>[0.0]
|     |---> rfr@foyers_fiscaux<2014>[18211.8]
|     |     |---> rni@foyers_fiscaux<2014>[18211.8]
|     |     |---> f3va@individus<2014>[0]
|     |     |---> f3vi@individus<2014>[0]
|     |     |---> rfr_cd@foyers_fiscaux<2014>[0.0]
|     |     |---> rfr_rvcm@foyers_fiscaux<2014>[0.0]
|     |     |---> rpns_exon@individus<2014>[0.0]
|     |     |---> rpns_pvce@individus<2014>[0.0]
|     |     |---> rev_cap_lib@foyers_fiscaux<2014>[0.0]
|     |     |---> f3vz@foyers_fiscaux<2014>[0]
|     |     |---> microentreprise@foyers_fiscaux<2014>[0.0]
|     |---> nb_adult@foyers_fiscaux<2014>[1.0]
|     |     |---> maries_ou_pacses@foyers_fiscaux<2014>[False]
|     |     |---> celibataire_ou_divorce@foyers_fiscaux<2014>[True]
|     |     |---> veuf@foyers_fiscaux<2014>[False]
```

Other options available:

```python
simulation.calculate('irpp', 2014, print_trace=True, max_depth=-1)
simulation.calculate('irpp', 2014, print_trace=True, max_depth=-1, show_default_values=False)
```