### PR TITLE
Loosen versionning enforcing

### DIFF
--- a/travis-run-tests.sh
+++ b/travis-run-tests.sh
@@ -1,22 +1,24 @@
 #! /usr/bin/env bash
 
-set -x
-
 current_version=`python setup.py --version`
-if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" != false ]]
-then
-    if git rev-parse $current_version
-    then
-        set +x
-        echo "Version $version already exists. Please update version number in setup.py before merging this branch into master."
-        exit 1
-    fi
 
-    if git diff-index master --quiet CHANGELOG.md
+if ! git diff-index --quiet master openfisca_core
+then
+    if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" != false ]]
     then
-        set +x
-        echo "CHANGELOG.md has not been modified. Please update it before merging this branch into master."
-        exit 1
+        if git rev-parse $current_version
+        then
+            set +x
+            echo "Version $version already exists. Please update version number in setup.py before merging this branch into master."
+            exit 1
+        fi
+
+        if git diff-index master --quiet CHANGELOG.md
+        then
+            set +x
+            echo "CHANGELOG.md has not been modified. Please update it before merging this branch into master."
+            exit 1
+        fi
     fi
 fi
 


### PR DESCRIPTION
When only the README (or any other file that is not _in_ the package) is modified, don't force a version update.
