### PR TITLE
Fixup #421

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.1.4-Beta
+
+* Fixup 4.1.2:
+  * When building positions, handle cases where persons belonging to an entity are not grouped by entity in the persons array.
+
 ## 4.1.3-Beta
 
 * Fix bug in entity.sum

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -119,9 +119,16 @@ class GroupEntity(Entity):
     @property
     def members_position(self):
         if self._members_position is None and self.members_entity_id is not None:
-            self._members_position = np.asarray(
-                sum([range(nb_pers) for nb_pers in self.nb_persons()], [])
-                )
+            # We could use self.count and self.members.count , but with the current initilization, we are not sure count will be set before members_position is called
+            nb_entities = np.max(self.members_entity_id) + 1
+            nb_persons = len(self.members_entity_id)
+            self._members_position = np.empty_like(self.members_entity_id)
+            counter_by_entity = np.zeros(nb_entities)
+            for k in range(nb_persons):
+                entity_index = self.members_entity_id[k]
+                self._members_position[k] = counter_by_entity[entity_index]
+                counter_by_entity[entity_index] += 1
+
         return self._members_position
 
     @members_role.setter

--- a/openfisca_core/tests/test_scenarios.py
+++ b/openfisca_core/tests/test_scenarios.py
@@ -12,18 +12,28 @@ class SimulationMockUp(object):
     persons = None
 
 
-simulation = SimulationMockUp()
-famille = Famille(simulation)
-simulation.persons = Individu(simulation)
-famille.members = simulation.persons
+def get_new_famille():
+    simulation = SimulationMockUp()
+    famille = Famille(simulation)
+    simulation.persons = Individu(simulation)
+    famille.members = simulation.persons
+    return famille
 
 
 def test_role_inference():
+    famille = get_new_famille()
     famille.members_legacy_role = np.asarray([0, 1, 2, 3, 4, 0, 2, 3])
 
     assert (famille.members_role == [DEMANDEUR, CONJOINT, ENFANT, ENFANT, ENFANT, DEMANDEUR, ENFANT, ENFANT]).all()
 
 
 def test_position_inference():
+    famille = get_new_famille()
     famille.members_entity_id = np.asarray([0, 0, 0, 0, 0, 1, 1, 1])
     assert_near(famille.members_position, [0, 1, 2, 3, 4, 0, 1, 2])
+
+
+def test_position_inference_mixed():
+    famille = get_new_famille()
+    famille.members_entity_id = np.asarray([0, 0, 1, 1, 0, 2, 1, 0])
+    assert_near(famille.members_position, [0, 1, 0, 1, 2, 0, 2, 3])

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '4.1.3b1',
+    version = '4.1.4b1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Fixup 4.1.2:
  * When building positions, handle cases where persons belonging to an entity are not grouped by entity in the persons array.