### PR TITLE
Name compact node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3.6
+
+* Bug fix : handle the case when CompactNode.name is None.
+
 ## 4.3.5
 
 * Refactor decomposition TaxBenefitSystem attributes. Reform inherit the decomposition_file_path from the reference TaxBenefitSystem.

--- a/openfisca_core/legislations.py
+++ b/openfisca_core/legislations.py
@@ -178,8 +178,9 @@ class TracedCompactNode(object):
         if key in self.traced_attributes_name:
             calling_frame = self.simulation.stack_trace[-1]
             caller_parameters_infos = calling_frame['parameters_infos']
-            assert self.compact_node.name is not None
-            parameter_name = u'.'.join([self.compact_node.name, key])
+            parameter_name = u'.'.join([self.compact_node.name, key]) \
+                if self.compact_node.name is not None \
+                else key
             parameter_infos = {
                 "instant": str(self.compact_node.instant),
                 "name": parameter_name,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '4.3.5',
+    version = '4.3.6',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Always name a `CompactNode`, as otherwise traced simulations crash if a `BAREME` is directly under the root node of the xml parameteres file.


This bug was noticed working on `senegal`.

Connected to openfisca/openfisca-web-api#76.