### PR TITLE
Fix some new_filled_column kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3.1
+
+* Fix `set_input` and `default` setting in `new_filled_column`
+
 ## 4.3.0
 
 * Add reference documentation

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -676,9 +676,10 @@ def neutralize_column(column):
         )
 
 
-def new_filled_column(base_function = UnboundLocalError, calculate_output = UnboundLocalError,
+def new_filled_column(__doc__ = None, __module__ = None,
+        base_function = UnboundLocalError, calculate_output = UnboundLocalError,
         cerfa_field = UnboundLocalError, column = UnboundLocalError, comments = UnboundLocalError,
-        __doc__ = None, __module__ = None,
+        default = UnboundLocalError,
         entity = UnboundLocalError, formula_class = UnboundLocalError, is_permanent = UnboundLocalError,
         label = UnboundLocalError, law_reference = UnboundLocalError, start_line_number = UnboundLocalError,
         name = None, reference_column = None, set_input = UnboundLocalError, source_code = UnboundLocalError,
@@ -714,6 +715,9 @@ def new_filled_column(base_function = UnboundLocalError, calculate_output = Unbo
         comments = None if reference_column is None else reference_column.formula_class.comments
     elif isinstance(comments, str):
         comments = comments.decode('utf-8')
+
+    if default is UnboundLocalError:
+        default = column.default if reference_column is None else reference_column.default
 
     assert entity is not None, """Missing attribute "entity" in definition of filled column {}""".format(
         name)
@@ -902,6 +906,8 @@ def new_filled_column(base_function = UnboundLocalError, calculate_output = Unbo
     # Fill column attributes.
     if cerfa_field is not None:
         column.cerfa_field = cerfa_field
+    if default != column.default:
+        column.default = default
     if stop_date is not None:
         column.end = stop_date
     column.entity = entity

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -694,7 +694,7 @@ def new_filled_column(base_function = UnboundLocalError, calculate_output = Unbo
     assert isinstance(name, unicode)
 
     if calculate_output is UnboundLocalError:
-        calculate_output = None if reference_column is None else reference_column.formula_class.calculate_output
+        calculate_output = None if reference_column is None else reference_column.formula_class.calculate_output.im_func
 
     if cerfa_field is UnboundLocalError:
         cerfa_field = None if reference_column is None else reference_column.cerfa_field
@@ -751,7 +751,7 @@ def new_filled_column(base_function = UnboundLocalError, calculate_output = Unbo
         start_line_number = start_line_number.decode('utf-8')
 
     if set_input is UnboundLocalError:
-        set_input = None if reference_column is None else reference_column.formula_class.set_input
+        set_input = None if reference_column is None else reference_column.formula_class.set_input.im_func
 
     if source_code is UnboundLocalError:
         source_code = None if reference_column is None else reference_column.formula_class.source_code

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '4.3.0',
+    version = '4.3.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
The `new_filled_column` function takes several kwargs.

Some of them – `set_input`, `calculate_output` and `default` are not handled correctly.

This is a fix for this problem.