### PR TITLE
Fix to_json for dated variables with extra params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 4.3.2
+
+* Fix `to_value_json` for `DatedVariable` with extra parameters.
+
+This was causing a crash when calculating intermediate variables with the API.
+
+Unlike simple formulas, a `DatedVariable` have several functions. We thus need to select the right one according to the period before doing parameters introspection.
+
 ## 4.3.1
 
 * Fix `set_input` and `default` setting in `new_filled_column`

--- a/openfisca_core/tests/test_extra_params.py
+++ b/openfisca_core/tests/test_extra_params.py
@@ -65,7 +65,7 @@ def test_cache():
 
 
 def test_get_extra_param_names():
-    assert formula_3_holder.get_extra_param_names() == ('choice',)
+    assert formula_3_holder.get_extra_param_names(period = None) == ('choice',)
 
 
 def test_json_conversion():

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '4.3.1',
+    version = '4.3.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
There is a bug when computing intermediate variables with the API.

`DatedVariables.to_value_json ` method was not compatible with extra parameter.