### PR TITLE
Extend run_test to read country.country_tax_benefit_system too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.3.5
+
+* Refactor decomposition TaxBenefitSystem attributes. Reform inherit the decomposition_file_path from the reference TaxBenefitSystem.
+  This does not require changing anything from the caller, which should use the `decompositions.get_decomposition_json` function instead of those attributes.
+
 ## 4.3.4
 
 * Fix occasionnal `NaN` creation in `MarginalRateTaxScale.calc` resulting from `0 * np.inf`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3.4
+
+* Fix occasionnal `NaN` creation in `MarginalRateTaxScale.calc` resulting from `0 * np.inf`
+
 ## 4.3.3
 
 * Use the actual TaxBenefitSystem and not its reference when neutralizing a column.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 4.3.6
 
-* Extend `run_test` to use `CountryTaxBenefiSystem` _or_ `country_tax_benefit_system` from country openfisca package
+* Extend `run_test` to use `CountryTaxBenefiSystem` _or_ `country_tax_benefit_system` from country openfisca package.
+This is useful when your country pakcage doesn't provide a `CountryTaxBenefiSystem` class but a `country_tax_benefit_system` instance.
 
 ## 4.3.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3.6
+
+* Extend `run_test` to use `CountryTaxBenefiSystem` _or_ `country_tax_benefit_system` from country openfisca package
+
 ## 4.3.5
 
 * Refactor decomposition TaxBenefitSystem attributes. Reform inherit the decomposition_file_path from the reference TaxBenefitSystem.

--- a/openfisca_core/decompositions.py
+++ b/openfisca_core/decompositions.py
@@ -3,7 +3,6 @@
 
 import collections
 import copy
-import os
 import xml
 
 from . import conv, decompositionsxml, legislations
@@ -37,7 +36,7 @@ def calculate(simulations, decomposition_json):
 
 def get_decomposition_json(tax_benefit_system, xml_file_path = None):
     if xml_file_path is None:
-        xml_file_path = os.path.join(tax_benefit_system.DECOMP_DIR, tax_benefit_system.DEFAULT_DECOMP_FILE)
+        xml_file_path = tax_benefit_system.decomposition_file_path
     decomposition_tree = xml.etree.ElementTree.parse(xml_file_path)
     decomposition_xml_json = conv.check(decompositionsxml.xml_decomposition_to_json)(decomposition_tree.getroot(),
         state = conv.State)

--- a/openfisca_core/reforms.py
+++ b/openfisca_core/reforms.py
@@ -30,6 +30,7 @@ class Reform(TaxBenefitSystem):
         self._legislation_json = reference.get_legislation()
         self.compact_legislation_by_instant_cache = reference.compact_legislation_by_instant_cache
         self.column_by_name = reference.column_by_name.copy()
+        self.decomposition_file_path = reference.decomposition_file_path
         self.Scenario = reference.Scenario
         self.key = unicode(self.__class__.__name__)
         if not hasattr(self, 'apply'):

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -53,7 +53,7 @@ def main():
         tax_benefit_system = country_package.country_tax_benefit_system
     else:
         print('ERROR: Cannot find CountryTaxBenefitSystem nor country_tax_benefit_system in `{}` __init__ file.\n\
-            On of them should be present for this package to be a valid Openfisca country package.'.format(args.country_package))
+            One of them should be present for this package to be a valid OpenFisca country package.'.format(args.country_package))
         sys.exit(1)
 
     if args.extensions:

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -47,7 +47,13 @@ def main():
         if len(installed_country_packages) > 1:
             print('WARNING: Several country packages detected : `{}`. Using `{}` by default. To use another package, please use the --country_package option.'.format(', '.join(installed_country_packages), country_package_name))
 
-    tax_benefit_system = country_package.CountryTaxBenefitSystem()
+    try:
+        tax_benefit_system = country_package.CountryTaxBenefitSystem()
+    except AttributeError:
+        print('{}_tax_benefit_system'.format(country_package.__name__[10:]))
+        tax_benefit_system = getattr(
+            country_package, '{}_tax_benefit_system'.format(country_package.__name__[10:])
+            )
 
     if args.extensions:
         extensions = [name.strip(' ') for name in args.extensions.split(',')]

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -50,10 +50,7 @@ def main():
     try:
         tax_benefit_system = country_package.CountryTaxBenefitSystem()
     except AttributeError:
-        print('{}_tax_benefit_system'.format(country_package.__name__[10:]))
-        tax_benefit_system = getattr(
-            country_package, '{}_tax_benefit_system'.format(country_package.__name__[10:])
-            )
+        tax_benefit_system = country_package.country_tax_benefit_system
 
     if args.extensions:
         extensions = [name.strip(' ') for name in args.extensions.split(',')]

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -47,10 +47,14 @@ def main():
         if len(installed_country_packages) > 1:
             print('WARNING: Several country packages detected : `{}`. Using `{}` by default. To use another package, please use the --country_package option.'.format(', '.join(installed_country_packages), country_package_name))
 
-    try:
+    if hasattr(country_package, 'CountryTaxBenefitSystem'):
         tax_benefit_system = country_package.CountryTaxBenefitSystem()
-    except AttributeError:
+    elif hasattr(country_package, 'country_tax_benefit_system'):
         tax_benefit_system = country_package.country_tax_benefit_system
+    else:
+        print('ERROR: Cannot find CountryTaxBenefitSystem nor country_tax_benefit_system in `{}` __init__ file.\n\
+            On of them should be present for this package to be a valid Openfisca country package.'.format(args.country_package))
+        sys.exit(1)
 
     if args.extensions:
         extensions = [name.strip(' ') for name in args.extensions.split(',')]

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -38,7 +38,7 @@ class TaxBenefitSystem(object):
     reference = None  # Reference tax-benefit system. Used only by reforms. Note: Reforms can be chained.
     Scenario = None
     cache_blacklist = None
-    DEFAULT_DECOMP_FILE = None
+    decomposition_file_path = None
 
     def __init__(self, entities, legislation_json = None):
         # TODO: Currently: Don't use a weakref, because they are cleared by Paste (at least) at each call.

--- a/openfisca_core/taxscales.py
+++ b/openfisca_core/taxscales.py
@@ -194,7 +194,8 @@ class MarginalRateTaxScale(AbstractRateTaxScale):
         base1 = np.tile(base, (len(self.thresholds), 1)).T
         if isinstance(factor, (float, int)):
             factor = np.ones(len(base)) * factor
-        thresholds1 = np.outer(factor, np.array(self.thresholds + [np.inf]))
+        # np.finfo(np.float).eps is used to avoid np.nan = 0 * np.inf creation
+        thresholds1 = np.outer(factor + np.finfo(np.float).eps, np.array(self.thresholds + [np.inf]))
         if round_base_decimals is not None:
             thresholds1 = np.round(thresholds1, round_base_decimals)
         a = max_(min_(base1, thresholds1[:, 1:]) - thresholds1[:, :-1], 0)

--- a/openfisca_core/tests/test_opt_out_cache.py
+++ b/openfisca_core/tests/test_opt_out_cache.py
@@ -40,8 +40,12 @@ def get_filled_tbs():
 
 # TaxBenefitSystem instance declared after formulas
 
+
 tax_benefit_system = get_filled_tbs()
+
+
 tax_benefit_system.cache_blacklist = set(['intermediate'])
+
 
 scenario = tax_benefit_system.new_scenario().init_from_attributes(
     period = 2016,

--- a/openfisca_core/tests/test_tax_scales.py
+++ b/openfisca_core/tests/test_tax_scales.py
@@ -25,7 +25,7 @@ def test_linear_average_rate_tax_scale():
     marginal_tax_scale.add_bracket(0, 0)
     marginal_tax_scale.add_bracket(1, 0.1)
     marginal_tax_scale.add_bracket(2, 0.2)
-    assert_near(marginal_tax_scale.calc(base), [0, .05, .1, .2], absolute_error_margin = 0)
+    assert_near(marginal_tax_scale.calc(base), [0, .05, .1, .2], absolute_error_margin = 1e-16)
 
     average_tax_scale = marginal_tax_scale.to_average()
     # Note: assert_near doesn't work for inf.

--- a/openfisca_core/tools/__init__.py
+++ b/openfisca_core/tools/__init__.py
@@ -60,7 +60,7 @@ def detect_country_packages():
             packages = find_packages(distribution.location)
             main_package = packages[0]
             module = import_module(main_package)
-            if hasattr(module, 'CountryTaxBenefitSystem'):
+            if hasattr(module, 'CountryTaxBenefitSystem') or hasattr(module, 'country_tax_benefit_system'):
                 result.append(main_package)
 
     return result

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '4.3.3',
+    version = '4.3.4',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '4.3.5',
+    version = '4.3.6',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '4.3.4',
+    version = '4.3.5',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
As user of a derived country package like [this one](https://github.com/openfisca/openfisca-france-data/blob/taxipp/openfisca_france_data/__init__.py#L172-L173) (`taxipp` branch), i need to be able to run tests.