### PR TITLE
Fix occasionnal `NaN` creation in `MarginalRateTaxScale.calc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3.4
+
+* Fix occasionnal `NaN` creation in `MarginalRateTaxScale.calc` resulting from `0 * np.inf`
+
 ## 4.3.3
 
 * Use the actual TaxBenefitSystem and not its reference when neutralizing a column.

--- a/openfisca_core/taxscales.py
+++ b/openfisca_core/taxscales.py
@@ -194,7 +194,8 @@ class MarginalRateTaxScale(AbstractRateTaxScale):
         base1 = np.tile(base, (len(self.thresholds), 1)).T
         if isinstance(factor, (float, int)):
             factor = np.ones(len(base)) * factor
-        thresholds1 = np.outer(factor, np.array(self.thresholds + [np.inf]))
+        # np.finfo(np.float).eps is used to avoid np.nan = 0 * np.inf creation
+        thresholds1 = np.outer(factor + np.finfo(np.float).eps, np.array(self.thresholds + [np.inf]))
         if round_base_decimals is not None:
             thresholds1 = np.round(thresholds1, round_base_decimals)
         a = max_(min_(base1, thresholds1[:, 1:]) - thresholds1[:, :-1], 0)

--- a/openfisca_core/tests/test_tax_scales.py
+++ b/openfisca_core/tests/test_tax_scales.py
@@ -25,7 +25,7 @@ def test_linear_average_rate_tax_scale():
     marginal_tax_scale.add_bracket(0, 0)
     marginal_tax_scale.add_bracket(1, 0.1)
     marginal_tax_scale.add_bracket(2, 0.2)
-    assert_near(marginal_tax_scale.calc(base), [0, .05, .1, .2], absolute_error_margin = 0)
+    assert_near(marginal_tax_scale.calc(base), [0, .05, .1, .2], absolute_error_margin = 1e-16)
 
     average_tax_scale = marginal_tax_scale.to_average()
     # Note: assert_near doesn't work for inf.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '4.3.3',
+    version = '4.3.4',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Clean version of #427