### PR TITLE
Improve test runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 5.0.1
+
+* Improve `openfisca-run-test` script
+  - Make country package detection more robust (it only worked for packages installed in editable mode)
+  - Use spaces instead of commas as separator in the script arguments when loading several extensions or reforms (this is more standard)
+* Refactor the `scripts` module to seperate the logic specific to yaml test running from the one that can be re-used by any script which needs to build a tax and benefit system.
+
 ## 5.0.0
 
 * Move `json_or_python_to_test_case` from country packages to core

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 
-import sys
 import importlib
+import logging
+import sys
+
+log = logging.getLogger(__name__)
+logging.basicConfig(format='%(levelname)s: %(message)s')
 
 
 def add_tax_benefit_system_arguments(parser):
@@ -18,7 +22,7 @@ def build_tax_benefit_sytem(country_package_name, extensions, reforms):
             country_package = importlib.import_module(country_package_name)
             assert hasattr(country_package, 'CountryTaxBenefitSystem')
         except (ImportError, AssertionError):
-            print('ERROR: `{}` does not seem to be a valid Openfisca country package.'.format(country_package_name))
+            log.error('`{}` does not seem to be a valid Openfisca country package.'.format(country_package_name))
             sys.exit(1)
     else:
         country_package_name = detect_country_package()
@@ -38,7 +42,7 @@ def build_tax_benefit_sytem(country_package_name, extensions, reforms):
                 reform = getattr(reform_module, reform_name)
                 tax_benefit_system = reform(tax_benefit_system)
             except:
-                print('ERROR: `{}` does not seem to be a valid Openfisca reform for `{}`.'.format(reform_path, country_package.__name__))
+                log.error('`{}` does not seem to be a valid Openfisca reform for `{}`.'.format(reform_path, country_package.__name__))
                 raise
 
     return tax_benefit_system
@@ -58,8 +62,8 @@ def detect_country_package():
                 installed_country_packages.append(module_name)
 
     if len(installed_country_packages) == 0:
-        print('ERROR: No country package has been detected on your environment. If your country package is installed but not detected, please use the --country_package option.')
+        log.error('No country package has been detected on your environment. If your country package is installed but not detected, please use the --country_package option.')
         sys.exit(1)
     if len(installed_country_packages) > 1:
-        print('WARNING: Several country packages detected : `{}`. Using `{}` by default. To use another package, please use the --country_package option.'.format(', '.join(installed_country_packages), installed_country_packages[0]))
+        log.warning('Several country packages detected : `{}`. Using `{}` by default. To use another package, please use the --country_package option.'.format(', '.join(installed_country_packages), installed_country_packages[0]))
     return installed_country_packages[0]

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -12,12 +12,13 @@ def add_tax_benefit_system_arguments(parser):
     return parser
 
 
-def build_tax_benefit_sytem(country_package, extensions, reforms):
-    if country_package:
+def build_tax_benefit_sytem(country_package_name, extensions, reforms):
+    if country_package_name:
         try:
-            country_package = importlib.import_module(country_package)
-        except:
-            print('ERROR: `{}` does not seem to be a valid Openfisca country package.'.format(country_package))
+            country_package = importlib.import_module(country_package_name)
+            assert hasattr(country_package, 'CountryTaxBenefitSystem')
+        except (ImportError, AssertionError):
+            print('ERROR: `{}` does not seem to be a valid Openfisca country package.'.format(country_package_name))
             sys.exit(1)
     else:
         country_package_name = detect_country_package()

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -2,6 +2,7 @@
 
 import importlib
 import logging
+import pkgutil
 import sys
 
 from openfisca_core.reforms import Reform
@@ -64,15 +65,11 @@ def build_tax_benefit_sytem(country_package_name, extensions, reforms):
 
 
 def detect_country_package():
-    import pkgutil
-    from importlib import import_module
-
     installed_country_packages = []
-
     for module_description in pkgutil.iter_modules():
         module_name = module_description[1]
         if 'openfisca' in module_name.lower():
-            module = import_module(module_name)
+            module = importlib.import_module(module_name)
             if hasattr(module, 'CountryTaxBenefitSystem'):
                 installed_country_packages.append(module_name)
 

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -4,8 +4,15 @@ import importlib
 import logging
 import sys
 
+from openfisca_core.reforms import Reform
+
 log = logging.getLogger(__name__)
 logging.basicConfig(format='%(levelname)s: %(message)s')
+
+
+def handle_error(error_message):
+    log.error(error_message)
+    sys.exit(1)
 
 
 def add_tax_benefit_system_arguments(parser):
@@ -17,13 +24,14 @@ def add_tax_benefit_system_arguments(parser):
 
 
 def build_tax_benefit_sytem(country_package_name, extensions, reforms):
+
     if country_package_name:
         try:
             country_package = importlib.import_module(country_package_name)
-            assert hasattr(country_package, 'CountryTaxBenefitSystem')
-        except (ImportError, AssertionError):
-            log.error('`{}` does not seem to be a valid Openfisca country package.'.format(country_package_name))
-            sys.exit(1)
+        except ImportError:
+            handle_error('Could not import module `{}`. Make sure it is installed in your environment.'.format(country_package_name))
+        if not hasattr(country_package, 'CountryTaxBenefitSystem'):
+            handle_error('`{}` does not seem to be a valid Openfisca country package.'.format(country_package_name))
     else:
         country_package_name = detect_country_package()
         country_package = importlib.import_module(country_package_name)
@@ -37,13 +45,20 @@ def build_tax_benefit_sytem(country_package_name, extensions, reforms):
     if reforms:
         for reform_path in reforms:
             try:
-                [reform_package, reform_name] = reform_path.rsplit('.', 1)
+                reform_package, reform_name = reform_path.rsplit('.', 1)
+            except ValueError:
+                handle_error('`{}` does not seem to be a path pointing to a reform. A path looks like `some_country_package.reforms.some_reform.`'.format(reform_path))
+            try:
                 reform_module = importlib.import_module(reform_package)
+            except ImportError:
+                handle_error('Could not import `{}`.'.format(reform_package))
+            try:
                 reform = getattr(reform_module, reform_name)
-                tax_benefit_system = reform(tax_benefit_system)
-            except:
-                log.error('`{}` does not seem to be a valid Openfisca reform for `{}`.'.format(reform_path, country_package.__name__))
-                raise
+            except AttributeError:
+                handle_error('{} has no attribute {}'.format(reform_package, reform_name))
+            if not isinstance(reform, Reform):
+                handle_error('`{}` does not seem to be a valid Openfisca reform for `{}`.'.format(reform_path, country_package.__name__))
+            tax_benefit_system = reform(tax_benefit_system)
 
     return tax_benefit_system
 
@@ -62,8 +77,7 @@ def detect_country_package():
                 installed_country_packages.append(module_name)
 
     if len(installed_country_packages) == 0:
-        log.error('No country package has been detected on your environment. If your country package is installed but not detected, please use the --country_package option.')
-        sys.exit(1)
+        handle_error('No country package has been detected on your environment. If your country package is installed but not detected, please use the --country_package option.')
     if len(installed_country_packages) > 1:
         log.warning('Several country packages detected : `{}`. Using `{}` by default. To use another package, please use the --country_package option.'.format(', '.join(installed_country_packages), installed_country_packages[0]))
     return installed_country_packages[0]

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -4,33 +4,10 @@ import sys
 import importlib
 
 
-TAX_BENEFIT_SYSTEM_OPTIONS = {
-    'country_package': {
-        'short': 'c',
-        'help': 'country package to use. If not provided, an automatic detection will be attempted by scanning the python packages installed in your environment which name contains the word "openfisca".'
-        },
-    'extensions': {
-        'short': 'e',
-        'help': 'extensions to load',
-        'nargs': '*'
-        },
-    'reforms': {
-        'short': 'r',
-        'help': 'reforms to apply to the country package',
-        'nargs': '*'
-        }
-    }
-
-
 def add_tax_benefit_system_arguments(parser):
-    for option, properties in TAX_BENEFIT_SYSTEM_OPTIONS.iteritems():
-        parser.add_argument(
-            '-{}'.format(properties['short']),
-            '--{}'.format(option),
-            action = 'store',
-            help = properties['help'],
-            nargs = properties.get('nargs')
-            )
+    parser.add_argument('-c', '--country_package', action = 'store', help = 'country package to use. If not provided, an automatic detection will be attempted by scanning the python packages installed in your environment which name contains the word "openfisca".')
+    parser.add_argument('-e', '--extensions', action = 'store', help = 'extensions to load', nargs = '*')
+    parser.add_argument('-r', '--reforms', action = 'store', help = 'reforms to apply to the country package', nargs = '*')
 
     return parser
 

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -2,6 +2,7 @@
 
 import importlib
 import sys
+import importlib
 
 
 TAX_BENEFIT_SYSTEM_OPTIONS = {
@@ -33,6 +34,37 @@ def add_tax_benefit_system_arguments(parser):
             )
 
     return parser
+
+
+def build_tax_benefit_sytem(country_package, extensions, reforms):
+    if country_package:
+        try:
+            country_package = importlib.import_module(country_package)
+        except:
+            print('ERROR: `{}` does not seem to be a valid Openfisca country package.'.format(country_package))
+            sys.exit(1)
+    else:
+        country_package_name = detect_country_package()
+        country_package = importlib.import_module(country_package_name)
+
+    tax_benefit_system = country_package.CountryTaxBenefitSystem()
+
+    if extensions:
+        for extension in extensions:
+            tax_benefit_system.load_extension(extension)
+
+    if reforms:
+        for reform_path in reforms:
+            try:
+                [reform_package, reform_name] = reform_path.rsplit('.', 1)
+                reform_module = importlib.import_module(reform_package)
+                reform = getattr(reform_module, reform_name)
+                tax_benefit_system = reform(tax_benefit_system)
+            except:
+                print('ERROR: `{}` does not seem to be a valid Openfisca reform for `{}`.'.format(reform_path, country_package.__name__))
+                raise
+
+    return tax_benefit_system
 
 
 def detect_country_package():

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -3,12 +3,6 @@
 import importlib
 import sys
 
-def parse_coma_separated_args(input):
-    if input:
-        return [name.strip(' ') for name in input.split(',')]
-    else:
-        return []
-
 
 TAX_BENEFIT_SYSTEM_OPTIONS = {
     'country_package': {
@@ -17,11 +11,13 @@ TAX_BENEFIT_SYSTEM_OPTIONS = {
         },
     'extensions': {
         'short': 'e',
-        'help': 'extensions to load, separated by commas (e.g -e "extension_1, extension_2")',
+        'help': 'extensions to load',
+        'nargs': '*'
         },
     'reforms': {
         'short': 'r',
-        'help': 'reforms to apply to the country package, separated by commas (e.g -r openfisca_france.reforms.some_reform)',
+        'help': 'reforms to apply to the country package',
+        'nargs': '*'
         }
 }
 
@@ -32,7 +28,9 @@ def add_tax_benefit_system_arguments(parser):
             '-{}'.format(properties['short']),
             '--{}'.format(option),
             action = 'store',
-            help = properties['help'])
+            help = properties['help'],
+            nargs = properties.get('nargs')
+            )
 
     return parser
 

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -17,9 +17,9 @@ def handle_error(error_message):
 
 
 def add_tax_benefit_system_arguments(parser):
-    parser.add_argument('-c', '--country_package', action = 'store', help = 'country package to use. If not provided, an automatic detection will be attempted by scanning the python packages installed in your environment which name contains the word "openfisca".')
-    parser.add_argument('-e', '--extensions', action = 'store', help = 'extensions to load', nargs = '*')
-    parser.add_argument('-r', '--reforms', action = 'store', help = 'reforms to apply to the country package', nargs = '*')
+    parser.add_argument('-c', '--country_package', action = 'store', help = u'country package to use. If not provided, an automatic detection will be attempted by scanning the python packages installed in your environment which name contains the word "openfisca".')
+    parser.add_argument('-e', '--extensions', action = 'store', help = u'extensions to load', nargs = '*')
+    parser.add_argument('-r', '--reforms', action = 'store', help = u'reforms to apply to the country package', nargs = '*')
 
     return parser
 
@@ -30,9 +30,9 @@ def build_tax_benefit_sytem(country_package_name, extensions, reforms):
         try:
             country_package = importlib.import_module(country_package_name)
         except ImportError:
-            handle_error('Could not import module `{}`. Make sure it is installed in your environment.'.format(country_package_name))
+            handle_error(u'Could not import module `{}`. Make sure it is installed in your environment.'.format(country_package_name))
         if not hasattr(country_package, 'CountryTaxBenefitSystem'):
-            handle_error('`{}` does not seem to be a valid Openfisca country package.'.format(country_package_name))
+            handle_error(u'`{}` does not seem to be a valid Openfisca country package.'.format(country_package_name))
     else:
         country_package_name = detect_country_package()
         country_package = importlib.import_module(country_package_name)
@@ -48,17 +48,17 @@ def build_tax_benefit_sytem(country_package_name, extensions, reforms):
             try:
                 reform_package, reform_name = reform_path.rsplit('.', 1)
             except ValueError:
-                handle_error('`{}` does not seem to be a path pointing to a reform. A path looks like `some_country_package.reforms.some_reform.`'.format(reform_path))
+                handle_error(u'`{}` does not seem to be a path pointing to a reform. A path looks like `some_country_package.reforms.some_reform.`'.format(reform_path))
             try:
                 reform_module = importlib.import_module(reform_package)
             except ImportError:
-                handle_error('Could not import `{}`.'.format(reform_package))
+                handle_error(u'Could not import `{}`.'.format(reform_package))
             try:
                 reform = getattr(reform_module, reform_name)
             except AttributeError:
-                handle_error('{} has no attribute {}'.format(reform_package, reform_name))
+                handle_error(u'{} has no attribute {}'.format(reform_package, reform_name))
             if not isinstance(reform, Reform):
-                handle_error('`{}` does not seem to be a valid Openfisca reform for `{}`.'.format(reform_path, country_package.__name__))
+                handle_error(u'`{}` does not seem to be a valid Openfisca reform for `{}`.'.format(reform_path, country_package.__name__))
             tax_benefit_system = reform(tax_benefit_system)
 
     return tax_benefit_system
@@ -74,7 +74,7 @@ def detect_country_package():
                 installed_country_packages.append(module_name)
 
     if len(installed_country_packages) == 0:
-        handle_error('No country package has been detected on your environment. If your country package is installed but not detected, please use the --country_package option.')
+        handle_error(u'No country package has been detected on your environment. If your country package is installed but not detected, please use the --country_package option.')
     if len(installed_country_packages) > 1:
-        log.warning('Several country packages detected : `{}`. Using `{}` by default. To use another package, please use the --country_package option.'.format(', '.join(installed_country_packages), installed_country_packages[0]))
+        log.warning(u'Several country packages detected : `{}`. Using `{}` by default. To use another package, please use the --country_package option.'.format(', '.join(installed_country_packages), installed_country_packages[0]))
     return installed_country_packages[0]

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -25,18 +25,16 @@ def add_tax_benefit_system_arguments(parser):
 
 
 def build_tax_benefit_sytem(country_package_name, extensions, reforms):
-
-    if country_package_name:
-        try:
-            country_package = importlib.import_module(country_package_name)
-        except ImportError:
-            handle_error(u'Could not import module `{}`. Make sure it is installed in your environment.'.format(country_package_name))
-        if not hasattr(country_package, 'CountryTaxBenefitSystem'):
-            handle_error(u'`{}` does not seem to be a valid Openfisca country package.'.format(country_package_name))
-    else:
+    if country_package_name is None:
         country_package_name = detect_country_package()
+    try:
         country_package = importlib.import_module(country_package_name)
+    except ImportError:
+        handle_error(u'Could not import module `{}`. Make sure it is installed in your environment.'.format(country_package_name))
+    if not hasattr(country_package, 'CountryTaxBenefitSystem'):
+        handle_error(u'`{}` does not seem to be a valid Openfisca country package.'.format(country_package_name))
 
+    country_package = importlib.import_module(country_package_name)
     tax_benefit_system = country_package.CountryTaxBenefitSystem()
 
     if extensions:

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import importlib
 import sys
 import importlib
 
@@ -20,7 +19,7 @@ TAX_BENEFIT_SYSTEM_OPTIONS = {
         'help': 'reforms to apply to the country package',
         'nargs': '*'
         }
-}
+    }
 
 
 def add_tax_benefit_system_arguments(parser):
@@ -68,19 +67,17 @@ def build_tax_benefit_sytem(country_package, extensions, reforms):
 
 
 def detect_country_package():
-    from pip import get_installed_distributions
-    from setuptools import find_packages
+    import pkgutil
     from importlib import import_module
 
     installed_country_packages = []
 
-    for distribution in get_installed_distributions():
-        if distribution.key.lower().find('openfisca') >= 0:
-            packages = find_packages(distribution.location)
-            main_package = packages[0]
-            module = import_module(main_package)
+    for module_description in pkgutil.iter_modules():
+        module_name = module_description[1]
+        if 'openfisca' in module_name.lower():
+            module = import_module(module_name)
             if hasattr(module, 'CountryTaxBenefitSystem'):
-                installed_country_packages.append(main_package)
+                installed_country_packages.append(module_name)
 
     if len(installed_country_packages) == 0:
         print('ERROR: No country package has been detected on your environment. If your country package is installed but not detected, please use the --country_package option.')

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -53,9 +53,8 @@ def build_tax_benefit_sytem(country_package_name, extensions, reforms):
                 reform_module = importlib.import_module(reform_package)
             except ImportError:
                 handle_error(u'Could not import `{}`.'.format(reform_package))
-            try:
-                reform = getattr(reform_module, reform_name)
-            except AttributeError:
+            reform = getattr(reform_module, reform_name, None)
+            if reform is None:
                 handle_error(u'{} has no attribute {}'.format(reform_package, reform_name))
             if not isinstance(reform, Reform):
                 handle_error(u'`{}` does not seem to be a valid Openfisca reform for `{}`.'.format(reform_path, country_package.__name__))

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+import importlib
+import sys
+
+def parse_coma_separated_args(input):
+    if input:
+        return [name.strip(' ') for name in input.split(',')]
+    else:
+        return []
+
+
+TAX_BENEFIT_SYSTEM_OPTIONS = {
+    'country_package': {
+        'short': 'c',
+        'help': 'country package to use. If not provided, an automatic detection will be attempted by scanning the python packages installed in your environment which name contains the word "openfisca".'
+        },
+    'extensions': {
+        'short': 'e',
+        'help': 'extensions to load, separated by commas (e.g -e "extension_1, extension_2")',
+        },
+    'reforms': {
+        'short': 'r',
+        'help': 'reforms to apply to the country package, separated by commas (e.g -r openfisca_france.reforms.some_reform)',
+        }
+}
+
+
+def add_tax_benefit_system_arguments(parser):
+    for option, properties in TAX_BENEFIT_SYSTEM_OPTIONS.iteritems():
+        parser.add_argument(
+            '-{}'.format(properties['short']),
+            '--{}'.format(option),
+            action = 'store',
+            help = properties['help'])
+
+    return parser
+
+
+def detect_country_package():
+    from pip import get_installed_distributions
+    from setuptools import find_packages
+    from importlib import import_module
+
+    installed_country_packages = []
+
+    for distribution in get_installed_distributions():
+        if distribution.key.lower().find('openfisca') >= 0:
+            packages = find_packages(distribution.location)
+            main_package = packages[0]
+            module = import_module(main_package)
+            if hasattr(module, 'CountryTaxBenefitSystem'):
+                installed_country_packages.append(main_package)
+
+    if len(installed_country_packages) == 0:
+        print('ERROR: No country package has been detected on your environment. If your country package is installed but not detected, please use the --country_package option.')
+        sys.exit(1)
+    if len(installed_country_packages) > 1:
+        print('WARNING: Several country packages detected : `{}`. Using `{}` by default. To use another package, please use the --country_package option.'.format(', '.join(installed_country_packages), installed_country_packages[0]))
+    return installed_country_packages[0]

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -7,7 +7,7 @@ import os
 import importlib
 
 from openfisca_core.tools.test_runner import run_tests
-from openfisca_core.scripts import add_tax_benefit_system_arguments, detect_country_package, parse_coma_separated_args
+from openfisca_core.scripts import add_tax_benefit_system_arguments, detect_country_package
 
 
 def build_parser():
@@ -37,20 +37,20 @@ def build_tax_benefit_sytem(country_package, extensions, reforms):
 
     tax_benefit_system = country_package.CountryTaxBenefitSystem()
 
-    extensions = parse_coma_separated_args(extensions)
-    for extension in extensions:
-        tax_benefit_system.load_extension(extension)
+    if extensions:
+        for extension in extensions:
+            tax_benefit_system.load_extension(extension)
 
-    reforms = parse_coma_separated_args(reforms)
-    for reform_path in reforms:
-        try:
-            [reform_package, reform_name] = reform_path.rsplit('.', 1)
-            reform_module = importlib.import_module(reform_package)
-            reform = getattr(reform_module, reform_name)
-            tax_benefit_system = reform(tax_benefit_system)
-        except:
-            print('ERROR: `{}` does not seem to be a valid Openfisca reform for `{}`.'.format(reform_path, country_package.__name__))
-            raise
+    if reforms:
+        for reform_path in reforms:
+            try:
+                [reform_package, reform_name] = reform_path.rsplit('.', 1)
+                reform_module = importlib.import_module(reform_package)
+                reform = getattr(reform_module, reform_name)
+                tax_benefit_system = reform(tax_benefit_system)
+            except:
+                print('ERROR: `{}` does not seem to be a valid Openfisca reform for `{}`.'.format(reform_path, country_package.__name__))
+                raise
 
     return tax_benefit_system
 

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -4,10 +4,9 @@ import argparse
 import logging
 import sys
 import os
-import importlib
 
 from openfisca_core.tools.test_runner import run_tests
-from openfisca_core.scripts import add_tax_benefit_system_arguments, detect_country_package
+from openfisca_core.scripts import add_tax_benefit_system_arguments, build_tax_benefit_sytem
 
 
 def build_parser():
@@ -22,37 +21,6 @@ def build_parser():
     parser.add_argument('-M', '--default_absolute_error_margin', help = u"absolute error margin to use for tests that don't define any", action = 'store', type = float)
 
     return parser
-
-
-def build_tax_benefit_sytem(country_package, extensions, reforms):
-    if country_package:
-        try:
-            country_package = importlib.import_module(country_package)
-        except:
-            print('ERROR: `{}` does not seem to be a valid Openfisca country package.'.format(country_package))
-            sys.exit(1)
-    else:
-        country_package_name = detect_country_package()
-        country_package = importlib.import_module(country_package_name)
-
-    tax_benefit_system = country_package.CountryTaxBenefitSystem()
-
-    if extensions:
-        for extension in extensions:
-            tax_benefit_system.load_extension(extension)
-
-    if reforms:
-        for reform_path in reforms:
-            try:
-                [reform_package, reform_name] = reform_path.rsplit('.', 1)
-                reform_module = importlib.import_module(reform_package)
-                reform = getattr(reform_module, reform_name)
-                tax_benefit_system = reform(tax_benefit_system)
-            except:
-                print('ERROR: `{}` does not seem to be a valid Openfisca reform for `{}`.'.format(reform_path, country_package.__name__))
-                raise
-
-    return tax_benefit_system
 
 
 def main():

--- a/openfisca_core/tools/__init__.py
+++ b/openfisca_core/tools/__init__.py
@@ -46,21 +46,3 @@ def get_trace_tool_link(scenario, variables, api_url, trace_tool_url):
         'api_url': api_url,
         })
     return url
-
-
-def detect_country_packages():
-    from pip import get_installed_distributions
-    from setuptools import find_packages
-    from importlib import import_module
-
-    result = []
-
-    for distribution in get_installed_distributions():
-        if distribution.key.lower().find('openfisca') >= 0:
-            packages = find_packages(distribution.location)
-            main_package = packages[0]
-            module = import_module(main_package)
-            if hasattr(module, 'CountryTaxBenefitSystem'):
-                result.append(main_package)
-
-    return result

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '5.0.0',
+    version = '5.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Improve `openfisca-run-test` script
  - Make country package detection more robust (it only worked for packages installed in editable mode)
  - Use spaces instead of commas as separator in the script arguments when loading several extensions or reforms (this is more standard)
* Refactor the `scripts` module to seperate the logic specific to yaml test running from the one that can be re-used by any script which needs to build a tax and benefit system.