### PR TITLE
Simplify periods amendment

### DIFF
--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -239,8 +239,8 @@ class Holder(object):
             return None
         return formula.real_formula
 
-    def set_input(self, period, array, behavior=None):
-        self.formula.set_input(period, array, behavior=behavior)
+    def set_input(self, period, array):
+        self.formula.set_input(period, array)
 
     def put_in_cache(self, value, period, extra_params = None):
         simulation = self.simulation

--- a/openfisca_core/scenarios.py
+++ b/openfisca_core/scenarios.py
@@ -41,10 +41,8 @@ class AbstractScenario(object):
                     )
         return value, None
 
-    def fill_simulation(self, simulation, variables_name_to_skip = None):
+    def fill_simulation(self, simulation):
         assert isinstance(simulation, simulations.Simulation)
-        if variables_name_to_skip is None:
-            variables_name_to_skip = set()
         tbs = self.tax_benefit_system
         simulation_period = simulation.period
         test_case = self.test_case
@@ -112,7 +110,7 @@ class AbstractScenario(object):
                     key
                     for entity_member in test_case[entity.plural]
                     for key, value in entity_member.iteritems()
-                    if value is not None and key not in variables_name_to_skip
+                    if value is not None
                     )
 
                 if not entity.is_person:

--- a/openfisca_core/scenarios.py
+++ b/openfisca_core/scenarios.py
@@ -9,7 +9,6 @@ import itertools
 import numpy as np
 
 from . import conv, periods, simulations, json_to_test_case
-from formulas import SET_INPUT_FILL
 
 
 def N_(message):
@@ -85,11 +84,22 @@ class AbstractScenario(object):
         else:
             steps_count = 1
             if self.axes is not None:
+                # See set_input function comment below
+                # defaultdict(dict) is like dict but returns {} when calling d[k] if d[k] is not yet defined
+                cache_buffer = collections.defaultdict(dict)
                 for parallel_axes in self.axes:
                     # All parallel axes have the same count, entity and period.
                     axis = parallel_axes[0]
                     steps_count *= axis['count']
             simulation.steps_count = steps_count
+
+            # When we use axes, we use a buffer for the cache, to avoid collisions between several calls of holder.set_input.
+            def set_input(variable_name, period, value):
+                if self.axes is not None:
+                    cache_buffer[variable_name][period] = value
+                else:
+                    holder = simulation.get_or_new_holder(variable_name)
+                    holder.set_input(period, value)
 
             for entity in simulation.entities.itervalues():
                 step_size = len(test_case[entity.plural])
@@ -153,7 +163,6 @@ class AbstractScenario(object):
                                     variable_periods.update(cell.iterkeys())
                             elif cell is not None:
                                 variable_periods.add(simulation_period)
-                        holder = simulation.get_or_new_holder(variable_name)
                         variable_default_value = column.default
                         # Note: For set_input to work, handle days, before months, before years => use sorted().
                         for variable_period in sorted(variable_periods):
@@ -176,12 +185,9 @@ class AbstractScenario(object):
                             array = np.fromiter(variable_values_iter, dtype = column.dtype) \
                                 if column.dtype is not object \
                                 else np.array(list(variable_values_iter), dtype = column.dtype)
-                            holder.set_input(variable_period, array)
+                            set_input(variable_name, variable_period, array)
 
             if self.axes is not None:
-                # defaultdict(dict) returns {} when calling d[k] if d[k] is not yet defined
-                cache_buffer = collections.defaultdict(dict)
-
                 if len(self.axes) == 1:
                     parallel_axes = self.axes[0]
                     # All parallel axes have the same count and entity.
@@ -190,20 +196,16 @@ class AbstractScenario(object):
                     axis_entity = simulation.get_variable_entity(first_axis['name'])
                     axis_entity_count = axis_entity.count
                     axis_entity_step_size = axis_entity.step_size
-                    # ici rien n'a encore été défini (sauf pour l'enfant)
-                    for axis in parallel_axes: # BUG si deux axes sont les mêmes
+                    for axis in parallel_axes:
                         axis_period = axis['period'] or simulation_period
                         axis_name = axis['name']
-                        # holder = simulation.get_or_new_holder(axis['name'])
-                        # column = holder.column
-                        # array = holder.get_array(axis_period)
                         array = cache_buffer[axis_name].get(axis_period)
                         if array is None:
-                            array = np.empty(axis_entity_count)#, dtype = column.dtype)
+                            column = tbs.column_by_name[axis_name]
+                            array = np.empty(axis_entity_count, dtype = column.dtype)
                             array.fill(column.default)
                         array[axis['index']:: axis_entity_step_size] = np.linspace(axis['min'], axis['max'], axis_count)
                         cache_buffer[axis_name][axis_period] = array
-                        # holder.set_input(axis_period, array, behavior=SET_INPUT_FILL)
                 else:
                     axes_linspaces = [
                         np.linspace(0, first_axis['count'] - 1, first_axis['count'])
@@ -223,17 +225,16 @@ class AbstractScenario(object):
                         for axis in parallel_axes:
                             axis_period = axis['period'] or simulation_period
                             axis_name = axis['name']
-                            # holder = simulation.get_or_new_holder(axis['name'])
-                            # column = holder.column
-                            # array = holder.get_array(axis_period)
                             array = cache_buffer[axis_name].get(axis_period)
                             if array is None:
-                                array = np.empty(axis_entity_count)
+                                column = tbs.column_by_name[axis_name]
+                                array = np.empty(axis_entity_count, dtype = column.dtype)
+                                array.fill(column.default)
                             array[axis['index']:: axis_entity_count] = axis['min'] \
                                 + mesh.reshape(steps_count) * (axis['max'] - axis['min']) / (axis_count - 1)
                             cache_buffer[axis_name][axis_period] = array
-                            # holder.set_input(axis_period, array, behavior=SET_INPUT_FILL)
 
+                # We pour the buffer in the real cache
                 for variable, values in cache_buffer.iteritems():
                     holder = simulation.get_or_new_holder(variable)
                     for period, array in values.iteritems():

--- a/openfisca_core/tests/test_axes.py
+++ b/openfisca_core/tests/test_axes.py
@@ -1,0 +1,40 @@
+from openfisca_core.tools import assert_near
+from dummy_country import DummyTaxBenefitSystem
+
+
+tax_benefit_system = DummyTaxBenefitSystem()
+
+
+# Test introduced following a bug with set_input in the case of parallel axes
+def test_set_input_parallel_axes():
+    year = 2013
+    simulation = tax_benefit_system.new_scenario().init_single_entity(
+        axes = [
+            [
+                dict(
+                    count = 3,
+                    index = 0,
+                    name = 'salaire_brut',
+                    max = 100000,
+                    min = 0,
+                    ),
+                dict(
+                    count = 3,
+                    index = 1,
+                    name = 'salaire_brut',
+                    max = 100000,
+                    min = 0,
+                    ),
+                ],
+            ],
+        period = year,
+        parent1 = {},
+        parent2 = {},
+        enfants = [{"salaire_brut": 2000}]
+        ).new_simulation()
+
+    assert_near(
+        simulation.calculate_add('salaire_brut', year),
+        [0, 0, 2000, 50000, 50000, 2000, 100000, 100000, 2000],
+        absolute_error_margin = 0.01
+        )


### PR DESCRIPTION
@michelbl 

Here is my solution to avoid using options for `set_input`.

We keep the current behaviour of `set_input`, which is to "fill" the wholes. The underlying assumption is that when you build a scenario, `set_input` should only be called once per variable. 

This was the case by conception for regular simulations, but axes were calling `set_input`  potentially several times on the same variable, and potentially and variables that had already been `set_input`ed before in the regular initialisation.

My fix is, when they are axes, to build a buffer containing the inputs, and only in the end to call the `set_input`.

It would be simpler to just use the buffer in all cases, but I'm not sure about the performance impact for axes-less big simulations.

I opened the PR to ease the dialog, but if it's GTM we should not merge it and commit the content in the regular branch.