### PR TITLE
Simplify boilerplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.1.0
+
+* Move `base.py` content (file usually located in country packages) to core module `formula_toolbox` so that it can be reused by all countries
+* Use `AbstractScenario` if no custom scenario is defined for a tax and benefit sytem
+
 ## 6.0.0
 
 #### Breaking changes

--- a/openfisca_core/model_api.py
+++ b/openfisca_core/model_api.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from datetime import date  # noqa analysis:ignore
+
+from numpy import maximum as max_, minimum as min_, logical_not as not_, where, select   # noqa analysis:ignore
+
+from .columns import (  # noqa analysis:ignore
+    AgeCol,
+    BoolCol,
+    DateCol,
+    EnumCol,
+    FixedStrCol,
+    FloatCol,
+    IntCol,
+    PeriodSizeIndependentIntCol,
+    StrCol,
+    )
+from .enumerations import Enum  # noqa analysis:ignore
+from .formulas import (  # noqa analysis:ignore
+    ADD,
+    calculate_output_add,
+    calculate_output_divide,
+    dated_function,
+    DIVIDE,
+    set_input_dispatch_by_period,
+    set_input_divide_by_period,
+    missing_value
+    )
+from .base_functions import (   # noqa analysis:ignore
+    requested_period_added_value,
+    requested_period_default_value,
+    requested_period_last_or_next_value,
+    requested_period_last_value,
+    )
+from .variables import DatedVariable, Variable  # noqa analysis:ignore
+from .formula_helpers import apply_thresholds, switch  # noqa analysis:ignore
+from .periods import MONTH, YEAR, ETERNITY  # noqa analysis:ignore

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -13,6 +13,7 @@ from setuptools import find_packages
 
 from . import conv, legislations, legislationsxml
 from variables import AbstractVariable
+from scenarios import AbstractScenario
 from formulas import neutralize_column
 
 log = logging.getLogger(__name__)
@@ -42,7 +43,7 @@ class TaxBenefitSystem(object):
         conv.struct({}),
         ))
     reference = None  # Reference tax-benefit system. Used only by reforms. Note: Reforms can be chained.
-    Scenario = None
+    Scenario = AbstractScenario
     cache_blacklist = None
     decomposition_file_path = None
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '6.0.0',
+    version = '6.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Move `base.py` content (file usually located in country packages) to core module `formula_toolbox` so that it can be reused by all countries
* Use `AbstractScenario` if no custom scenario is defined for a tax and benefit sytem

See impact on https://github.com/openfisca/openfisca-france/pull/697
