### PR TITLE
Document neutralize_variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 9.1.0
+
+* Rename `neutralize_column` to `neutralize_variable`
+  - Deprecate `neutralize_column` without removing it
+* Document `neutralize_variable`
+
 ## 9.0.2
 
 * Fix spelling in error messages

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
 # pip doesn't handle well dependencies with a relative path inside a requirements.txt file.
-# If we put .. instead of 'openfisca_core >= 4.2.0, < 5.0', it will look for a setup.py in the parent directory relatively to where the instruction is executed from, and not where the requirements file is.
-openfisca_core >= 4.2.0, < 6.0
+# If we put .. instead of the first line, it will look for a setup.py in the parent directory relatively to where the instruction is executed from, and not where the requirements file is.
+--editable git+https://github.com/openfisca/openfisca-core.git@master#egg=OpenFisca-Core
 sphinx-argparse

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -8,6 +8,7 @@ import datetime
 import inspect
 import itertools
 import logging
+import warnings
 
 import numpy as np
 
@@ -981,4 +982,8 @@ def set_input_divide_by_period(formula, period, array):
 
 
 def set_input_neutralized(formula, period, array):
-    pass
+    warnings.warn(
+        u"You cannot set a value for the variable {}, as it has been neutralized. The value you provided ({}) will be ignored."
+        .format(formula.holder.column.name, array).encode('utf-8'),
+        Warning
+        )

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -655,7 +655,7 @@ def missing_value(formula, simulation, period):
     raise ValueError(u"Missing value for variable {} at {}".format(column.name, period))
 
 
-def neutralize_column(column):
+def get_neutralized_column(column):
     """Return a new neutralized column (to be used by reforms)."""
     return new_filled_column(
         base_function = requested_period_default_value_neutralized,

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -10,6 +10,7 @@ import importlib
 import logging
 import inspect
 import pkg_resources
+import warnings
 
 from setuptools import find_packages
 
@@ -250,15 +251,16 @@ class TaxBenefitSystem(object):
 
         A neutralized variable always returns its default value when computed.
 
-        Trying to set inputs for a neutralized variable has no effect.
+        Trying to set inputs for a neutralized variable has no effect except raising a warning.
         """
         self.update_column(variable_name, neutralize_column(self.get_column(variable_name)))
 
     def neutralize_column(self, column_name):
-        print(
-            u"Warning: the neutralize_column method has been renamed to neutralize_variable. "
+        warnings.warn(
+            u"The neutralize_column method has been renamed to neutralize_variable. "
             u"neutralize_column has thus been deprecated and will be removed in the next major version. "
-            u"Please update your code."
+            u"Please update your code.",
+            Warning
             )
         self.neutralize_variable(column_name)
 

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -244,8 +244,16 @@ class TaxBenefitSystem(object):
     def update_column(self, column_name, new_column):
         self.column_by_name[column_name] = new_column
 
+    def neutralize_variable(self, variable_name):
+        self.update_column(variable_name, neutralize_column(self.get_column(variable_name)))
+
     def neutralize_column(self, column_name):
-        self.update_column(column_name, neutralize_column(self.get_column(column_name)))
+        print(
+            u"Warning: the neutralize_column method has been renamed to neutralize_variable. "
+            u"neutralize_column has thus been deprecated and will be removed soon. "
+            u"Please update your code."
+            )
+        self.neutralize_variable(column_name)
 
     def add_legislation_params(self, path_to_xml_file, path_in_legislation_tree = None):
         """

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -17,7 +17,7 @@ from setuptools import find_packages
 from . import conv, legislations, legislationsxml
 from variables import AbstractVariable
 from scenarios import AbstractScenario
-from formulas import neutralize_column
+from formulas import get_neutralized_column
 
 log = logging.getLogger(__name__)
 
@@ -253,7 +253,7 @@ class TaxBenefitSystem(object):
 
         Trying to set inputs for a neutralized variable has no effect except raising a warning.
         """
-        self.update_column(variable_name, neutralize_column(self.get_column(variable_name)))
+        self.update_column(variable_name, get_neutralized_column(self.get_column(variable_name)))
 
     def neutralize_column(self, column_name):
         warnings.warn(

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -245,12 +245,19 @@ class TaxBenefitSystem(object):
         self.column_by_name[column_name] = new_column
 
     def neutralize_variable(self, variable_name):
+        """
+        Neutralizes an OpenFisca variable existing in the tax and benefit system.
+
+        A neutralized variable always returns its default value when computed.
+
+        Trying to set inputs for a neutralized variable has no effect.
+        """
         self.update_column(variable_name, neutralize_column(self.get_column(variable_name)))
 
     def neutralize_column(self, column_name):
         print(
             u"Warning: the neutralize_column method has been renamed to neutralize_variable. "
-            u"neutralize_column has thus been deprecated and will be removed soon. "
+            u"neutralize_column has thus been deprecated and will be removed in the next major version. "
             u"Please update your code."
             )
         self.neutralize_variable(column_name)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
             ],
         'test': [
             'nose',
-            'openfisca-dummy-country >= 0.1.2'
+            'openfisca-dummy-country == 0.1.2',
             ],
         },
     include_package_data = True,  # Will read MANIFEST.in

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '9.0.2',
+    version = '9.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/test_reforms.py
+++ b/tests/test_reforms.py
@@ -22,7 +22,7 @@ def test_formula_neutralization():
 
     class test_rsa_neutralization(Reform):
         def apply(self):
-            self.neutralize_column('rsa')
+            self.neutralize_variable('rsa')
 
     reform = test_rsa_neutralization(tax_benefit_system)
 
@@ -50,7 +50,7 @@ def test_input_variable_neutralization():
 
     class test_salaire_brut_neutralization(Reform):
         def apply(self):
-            self.neutralize_column('salaire_brut')
+            self.neutralize_variable('salaire_brut')
 
     reform = test_salaire_brut_neutralization(tax_benefit_system)
 
@@ -86,7 +86,7 @@ def test_permanent_variable_neutralization():
 
     class test_date_naissance_neutralization(Reform):
         def apply(self):
-            self.neutralize_column('birth')
+            self.neutralize_variable('birth')
 
     reform = test_date_naissance_neutralization(tax_benefit_system)
 

--- a/tests/test_reforms.py
+++ b/tests/test_reforms.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import datetime
+import warnings
+
 
 from nose.tools import raises
 from nose.tools import assert_equal
@@ -65,6 +67,7 @@ def test_input_variable_neutralization():
             salaire_brut = 60000,
             ),
         )
+
     simulation = scenario.new_simulation(reference = True)
     salaire_brut_annuel = simulation.calculate_add('salaire_brut', period = year)
     assert_near(salaire_brut_annuel, [120000, 60000], absolute_error_margin = 0)
@@ -73,7 +76,9 @@ def test_input_variable_neutralization():
     revenu_disponible = simulation.calculate('revenu_disponible', period = year)
     assert_near(revenu_disponible, [60480, 30240], absolute_error_margin = 0)
 
-    reform_simulation = scenario.new_simulation()
+    with warnings.catch_warnings(record=True) as raised_warnings:
+        reform_simulation = scenario.new_simulation()
+        assert 'You cannot set a value for the variable' in raised_warnings[0].message.message
     salaire_brut_annuel_reform = reform_simulation.calculate_add('salaire_brut', period = year)
     assert_near(salaire_brut_annuel_reform, [0, 0], absolute_error_margin = 0)
     salaire_brut_mensuel_reform = reform_simulation.calculate('salaire_brut', period = '2013-01')
@@ -100,7 +105,9 @@ def test_permanent_variable_neutralization():
             ),
         )
     simulation = scenario.new_simulation(reference = True)
-    reform_simulation = scenario.new_simulation()
+    with warnings.catch_warnings(record=True) as raised_warnings:
+        reform_simulation = scenario.new_simulation()
+        assert 'You cannot set a value for the variable' in raised_warnings[0].message.message
     assert str(simulation.calculate('birth', None)[0]) == '1980-01-01'
     assert str(reform_simulation.calculate('birth', None)[0]) == '1970-01-01'
 


### PR DESCRIPTION
Connected to openfisca/openfisca-doc#43

I tried something new as an experiment: deprecating without removing a function.

My motivation is to avoid the fixed cost of publishing a major (updating all the dependencies) for something small where retro-compatibility is easy to implement.

The workflow I imagine would be wait for the next major bumps to remove it for good. Either we:
- Remove it in the next PR that brings a major bump. Doesn't respect the one PR = one goal principle.
- Publish the next major bump as a pre-release. Then all deprecated stuff can be removed right after.

To be discussed later with @MattiSG @cbenz, this is not a priority.