### PR TITLE
Upgrade ref doc requirements

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
 # pip doesn't handle well dependencies with a relative path inside a requirements.txt file.
 # If we put .. instead of the first line, it will look for a setup.py in the parent directory relatively to where the instruction is executed from, and not where the requirements file is.
---editable git+https://github.com/openfisca/openfisca-core.git@master#egg=OpenFisca-Core
+openfisca_core >= 10.0.0
 sphinx-argparse


### PR DESCRIPTION
It seems that we need to explicit the minimal version we want. Otherwise and old cached version is used by readthedocs.