### PR TITLE
Handle parallel testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 12.2.0
+
+* Improve the `openfisca-run-test` script
+  - Add a `--nose` option to run the tests with nose.
+    - This avoids boilerplate code on country packages, and makes parallelism easier to set on Circle CI.
+
 ## 12.1.4
 
 * Fix package naming conflict between the preview API and the official one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## 12.2.0
 
-* Improve the `openfisca-run-test` script
-  - Add a `--nose` option to run the tests with nose.
-    - This avoids boilerplate code on country packages, and makes parallelism easier to set on Circle CI.
+* Use `nose` in the `openfisca-run-test` script
+  - This avoids boilerplate code on country packages, and makes parallelism easier to set on Circle CI.
 
 ## 12.1.4
 

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -31,11 +31,8 @@ def main():
         'name_filter': args.name_filter,
         }
 
-    tests_ok = True
-    for path in args.path:
-        path = os.path.abspath(path)
-        test_ok = run_tests(tax_benefit_system, path, options)
-        tests_ok = tests_ok and test_ok
+    paths = map(os.path.abspath, args.path)
+    tests_ok = run_tests(tax_benefit_system, paths, options)
 
     if not tests_ok:
         sys.exit(1)

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -15,7 +15,6 @@ def build_parser():
     parser = add_tax_benefit_system_arguments(parser)
     parser.add_argument('-n', '--name_filter', default = None, help = "partial name of tests to execute. Only tests with the given name_filter in their name, file name, or keywords will be run.")
     parser.add_argument('-v', '--verbose', action = 'store_true', default = False, help = "increase output verbosity")
-    parser.add_argument('--nose', action = 'store_true', default = False, help = "use nosetests to run the tests")
 
     return parser
 
@@ -30,29 +29,16 @@ def main():
     options = {
         'verbose': args.verbose,
         'name_filter': args.name_filter,
-        'nose': args.nose,
         }
 
-    if args.nose:
-        tests_ok = True
-        for path in args.path:
-            path = os.path.abspath(path)
-        output = run_tests(tax_benefit_system, path, options)
-        tests_ok = tests_ok and output
+    tests_ok = True
+    for path in args.path:
+        path = os.path.abspath(path)
+        test_ok = run_tests(tax_benefit_system, path, options)
+        tests_ok = tests_ok and test_ok
 
-        if not tests_ok:
-            sys.exit(1)
-
-    else:
-        tests_found = False
-        for path in args.path:
-            path = os.path.abspath(path)
-            nb_tests = run_tests(tax_benefit_system, path, options)
-            tests_found = tests_found or nb_tests > 0
-
-        if not tests_found:
-            print("No tests found!")
-            sys.exit(1)
+    if not tests_ok:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -33,18 +33,26 @@ def main():
         'nose': args.nose,
         }
 
-    tests_found = False
+    if args.nose:
+        tests_ok = True
+        for path in args.path:
+            path = os.path.abspath(path)
+        output = run_tests(tax_benefit_system, path, options)
+        tests_ok = tests_ok and output
 
-    for path in args.path:
-        path = os.path.abspath(path)
-        nb_tests = run_tests(tax_benefit_system, path, options)
-        tests_found = tests_found or nb_tests > 0
+        if not tests_ok:
+            sys.exit(1)
 
-    if not tests_found and not args.nose:
-        print("No tests found!")
-        sys.exit(1)
+    else:
+        tests_found = False
+        for path in args.path:
+            path = os.path.abspath(path)
+            nb_tests = run_tests(tax_benefit_system, path, options)
+            tests_found = tests_found or nb_tests > 0
 
-    sys.exit(0)
+        if not tests_found:
+            print("No tests found!")
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -15,6 +15,7 @@ def build_parser():
     parser = add_tax_benefit_system_arguments(parser)
     parser.add_argument('-n', '--name_filter', default = None, help = "partial name of tests to execute. Only tests with the given name_filter in their name, file name, or keywords will be run.")
     parser.add_argument('-v', '--verbose', action = 'store_true', default = False, help = "increase output verbosity")
+    parser.add_argument('--nose', action = 'store_true', default = False, help = "use nosetests to run the tests")
 
     return parser
 
@@ -29,6 +30,7 @@ def main():
     options = {
         'verbose': args.verbose,
         'name_filter': args.name_filter,
+        'nose': args.nose,
         }
 
     tests_found = False
@@ -38,7 +40,7 @@ def main():
         nb_tests = run_tests(tax_benefit_system, path, options)
         tests_found = tests_found or nb_tests > 0
 
-    if not tests_found:
+    if not tests_found and not args.nose:
         print("No tests found!")
         sys.exit(1)
 

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -60,7 +60,7 @@ _config_yaml(yaml)
 
 # Exposed methods
 
-def generate_tests(tax_benefit_system, path, options = {}):
+def generate_tests(tax_benefit_system, paths, options = {}):
     """
     Generates a lazy iterator of all the YAML tests contained in a file or a directory.
 
@@ -70,20 +70,26 @@ def generate_tests(tax_benefit_system, path, options = {}):
 
     """
 
-    if os.path.isdir(path):
-        return _generate_tests_from_directory(tax_benefit_system, path, options)
-    else:
-        return _generate_tests_from_file(tax_benefit_system, path, options)
+    if isinstance(paths, str):
+        paths = [paths]
+
+    for path in paths:
+        if os.path.isdir(path):
+            for test in _generate_tests_from_directory(tax_benefit_system, path, options):
+                yield test
+        else:
+            for test in _generate_tests_from_file(tax_benefit_system, path, options):
+                yield test
 
 
-def run_tests(tax_benefit_system, path, options = {}):
+def run_tests(tax_benefit_system, paths, options = {}):
     """
     Runs all the YAML tests contained in a file or a directory.
 
     If `path` is a directory, subdirectories will be recursively explored.
 
     :param TaxBenefitSystem tax_benefit_system: the tax-benefit system to use to run the tests
-    :param str path: the path towards the file or directory containing thes tests. If it is a directory, subdirectories will be recursively explored.
+    :param (str/list) paths: A path, or a list of paths, towards the files or directories containing the tests to run. If a path is a directory, subdirectories will be recursively explored.
     :param dict options: See more details below.
 
     :raises AssertionError: if a test does not pass
@@ -103,7 +109,7 @@ def run_tests(tax_benefit_system, path, options = {}):
     """
     return nose.run(
         # The suite argument must be a lambda for nose to run the tests lazily
-        suite = lambda: generate_tests(tax_benefit_system, path, options),
+        suite = lambda: generate_tests(tax_benefit_system, paths, options),
         # Nose crashes if it gets any unexpected argument.
         argv = sys.argv[:1],
         # testRunner = nose.core.TextTestRunner(stream = open(os.devnull, 'w')),

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -103,7 +103,7 @@ def run_tests(tax_benefit_system, path, options = {}):
     """
     if options.get('nose'):
         import nose
-        nose.run(
+        return nose.run(
             # The suite argument must be a lambda for nose to run the tests lazily
             suite = lambda: generate_tests(tax_benefit_system, path, options),
             # Nose crashes if it gets any unexpected argument.

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -8,10 +8,12 @@ import collections
 import copy
 import glob
 import os
-import yaml
-import numpy as np
 import sys
 import unittest
+
+import nose
+import numpy as np
+import yaml
 
 from openfisca_core import conv, periods, scenarios
 from openfisca_core.tools import assert_near
@@ -94,28 +96,18 @@ def run_tests(tax_benefit_system, path, options = {}):
     | Key                           | Type      | Role                                      |
     +===============================+===========+===========================================+
     | verbose                       | ``bool``  |                                           |
-    +-------------------------------+-----------+                                           +
-    | name_filter                   | ``str``   | See :any:`openfisca-run-test` options doc |
-    +-------------------------------+-----------+                                           +
-    | nose                          | ``bool``  |                                           |
+    +-------------------------------+-----------+ See :any:`openfisca-run-test` options doc +
+    | name_filter                   | ``str``   |                                           |
     +-------------------------------+-----------+-------------------------------------------+
 
     """
-    if options.get('nose'):
-        import nose
-        return nose.run(
-            # The suite argument must be a lambda for nose to run the tests lazily
-            suite = lambda: generate_tests(tax_benefit_system, path, options),
-            # Nose crashes if it gets any unexpected argument.
-            argv = sys.argv[:1]
-            )
-    else:
-        nb_tests = 0
-        for test in generate_tests(tax_benefit_system, path, options):
-            test()
-            nb_tests += 1
-
-        return nb_tests  # Nb of sucessful tests
+    return nose.run(
+        # The suite argument must be a lambda for nose to run the tests lazily
+        suite = lambda: generate_tests(tax_benefit_system, path, options),
+        # Nose crashes if it gets any unexpected argument.
+        argv = sys.argv[:1],
+        # testRunner = nose.core.TextTestRunner(stream = open(os.devnull, 'w')),
+        )
 
 
 # Internal methods
@@ -149,10 +141,7 @@ def _generate_tests_from_file(tax_benefit_system, path_to_file, options):
             print("=" * len(title))
             _run_test(period_str, test, verbose, options)
 
-        if options.get('nose'):
-            yield unittest.FunctionTestCase(check)
-        else:
-            yield check
+        yield unittest.FunctionTestCase(check)
 
 
 def _generate_tests_from_directory(tax_benefit_system, path_to_dir, options):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '12.1.4',
+    version = '12.2.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/core/test_countries.py
+++ b/tests/core/test_countries.py
@@ -8,9 +8,9 @@ from openfisca_core.taxbenefitsystems import VariableNameConflict, VariableNotFo
 from openfisca_core import periods
 from openfisca_core.formulas import DIVIDE
 from openfisca_country_template import CountryTaxBenefitSystem
+from openfisca_country_template.entities import Person
 from openfisca_core.tools import assert_near
 from openfisca_core.columns import FloatCol
-from openfisca_dummy_country.entities import Individu
 
 
 tax_benefit_system = CountryTaxBenefitSystem()
@@ -18,7 +18,7 @@ tax_benefit_system = CountryTaxBenefitSystem()
 
 class income_tax_no_period(Variable):
     column = FloatCol
-    entity = Individu
+    entity = Person
     label = u"Salaire net (buggy)"
     definition_period = MONTH
 

--- a/tests/core/test_yaml.py
+++ b/tests/core/test_yaml.py
@@ -2,6 +2,7 @@
 
 import pkg_resources
 import os
+import sys
 import subprocess
 
 from nose.tools import nottest, raises
@@ -28,84 +29,85 @@ nottest(generate_tests)
 
 
 @nottest
-def run_yaml_test(file_name, options = {}):
-    yaml_path = os.path.join(yaml_tests_dir, '{}.yaml'.format(file_name))
-    return run_tests(tax_benefit_system, yaml_path, options)
+def run_yaml_test(path, options = {}):
+    yaml_path = os.path.join(yaml_tests_dir, path)
+
+    # We are testing tests, and don't want the latter to print anything, so we temporarily deactivate stderr.
+    old_stderr = sys.stderr
+    sys.stderr = open(os.devnull, 'w')
+    result = run_tests(tax_benefit_system, yaml_path, options)
+    sys.stderr = old_stderr
+    return result
 
 
 def test_success():
-    run_yaml_test('test_success')
+    assert run_yaml_test('test_success.yaml')
 
 
-@raises(AssertionError)
 def test_fail():
-    run_yaml_test('test_failure')
+    assert run_yaml_test('test_failure.yaml') is False
 
 
 def test_relative_error_margin_success():
-    run_yaml_test('test_relative_error_margin')
+    assert run_yaml_test('test_relative_error_margin.yaml')
 
 
-@raises(AssertionError)
 def test_relative_error_margin_fail():
-    run_yaml_test('failing_test_relative_error_margin')
+    assert run_yaml_test('failing_test_relative_error_margin.yaml') is False
 
 
 def test_absolute_error_margin_success():
-    run_yaml_test('test_absolute_error_margin')
+    assert run_yaml_test('test_absolute_error_margin.yaml')
 
 
-@raises(AssertionError)
 def test_absolute_error_margin_fail():
-    run_yaml_test('failing_test_absolute_error_margin')
+    assert run_yaml_test('failing_test_absolute_error_margin.yaml') is False
 
 
 def test_run_tests_from_directory():
     dir_path = os.path.join(yaml_tests_dir, 'directory')
-    assert run_tests(tax_benefit_system, dir_path) == 4
+    assert run_yaml_test(dir_path)
 
 
 def test_with_reform():
-    run_yaml_test('test_with_reform')
+    assert run_yaml_test('test_with_reform.yaml')
 
 
-@raises(AssertionError)
 def test_run_tests_from_directory_fail():
-    run_tests(tax_benefit_system, yaml_tests_dir)
+    assert run_yaml_test(yaml_tests_dir) is False
 
 
 def test_name_filter():
-    nb_tests = run_tests(
-        tax_benefit_system,
+    assert run_yaml_test(
         yaml_tests_dir,
         options = {'name_filter': 'success'}
         )
-
-    assert nb_tests == 3
-
-
-def test_nose_style():
-    dir_path = os.path.join(yaml_tests_dir, 'directory')
-    for test in generate_tests(tax_benefit_system, dir_path):
-        yield test
 
 
 def test_shell_script():
     yaml_path = os.path.join(yaml_tests_dir, 'test_success.yaml')
     command = ['openfisca-run-test', yaml_path, '-c', 'openfisca_country_template']
     with open(os.devnull, 'wb') as devnull:
-        subprocess.check_call(command, stdout = devnull)
+        subprocess.check_call(command, stdout = devnull, stderr = devnull)
+
+
+@raises(subprocess.CalledProcessError)
+def test_failing_shell_script():
+    yaml_path = os.path.join(yaml_tests_dir, 'test_failure.yaml')
+    command = ['openfisca-run-test', yaml_path, '-c', 'openfisca_dummy_country']
+    with open(os.devnull, 'wb') as devnull:
+        subprocess.check_call(command, stdout = devnull, stderr = devnull)
 
 
 def test_shell_script_with_reform():
     yaml_path = os.path.join(yaml_tests_dir, 'test_with_reform_2.yaml')
     command = ['openfisca-run-test', yaml_path, '-c', 'openfisca_country_template', '-r', 'openfisca_country_template.reforms.removal_basic_income.removal_basic_income']
     with open(os.devnull, 'wb') as devnull:
-        subprocess.check_call(command, stdout = devnull)
+        subprocess.check_call(command, stdout = devnull, stderr = devnull)
 
 
 def test_shell_script_with_extension():
     extension_dir = openfisca_extension_template.__path__[0]
     command = ['openfisca-run-test', extension_dir, '-c', 'openfisca_country_template', '-e', extension_dir]
     with open(os.devnull, 'wb') as devnull:
-        subprocess.check_call(command, stdout = devnull)
+        subprocess.check_call(command, stdout = devnull, stderr = devnull)


### PR DESCRIPTION
Connected to openfisca/openfisca-france#734

#### New features

* Use `nose` in the `openfisca-run-test` script
  - This avoids boilerplate code on country packages, and makes parallelism easier to set on Circle CI.