### PR TITLE
Require numpy < 1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 13.0.1 - [#526](https://github.com/openfisca/openfisca-core/pull/526)
+
+### Bug fix
+
+* Require numpy < 1.13.
+  - Openfisca is not yet compatible with the new numpy version 1.13.
+
 ## 13.0.0
 
 #### Breaking changes

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '13.0.0',
+    version = '13.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [
@@ -42,7 +42,7 @@ setup(
     include_package_data = True,  # Will read MANIFEST.in
     install_requires = [
         'Biryani[datetimeconv] >= 0.10.4',
-        'numpy >= 1.11',
+        'numpy >= 1.11, < 1.13',
         'PyYAML >= 3.10',
         'flask == 0.12',
         'flask-cors == 3.0.2',


### PR DESCRIPTION
numpy 1.13 breaks openfisca