### PR TITLE
Do not hide error at module import failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 14.0.1 - [#527](https://github.com/openfisca/openfisca-core/pull/527)
 
-* Improve error message when a module import fails at `openfisca-run-test`
+* Improve error message and add stack trace when a module import fails
 
 ## 14.0.0 - [#522](https://github.com/openfisca/openfisca-core/pull/522)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 14.0.1
+
+* Improve the error message at module import failure.
+
 ## 14.0.0 - [#522](https://github.com/openfisca/openfisca-core/pull/522)
 
 #### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 14.0.1
+## 14.0.1 - [#527](https://github.com/openfisca/openfisca-core/pull/527)
 
-* Improve the error message at module import failure.
+* Improve error message when a module import fails at `openfisca-run-test`
 
 ## 14.0.0 - [#522](https://github.com/openfisca/openfisca-core/pull/522)
 

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -5,6 +5,7 @@ import importlib
 import logging
 import pkgutil
 import sys
+from os import linesep
 
 log = logging.getLogger(__name__)
 logging.basicConfig(format='%(levelname)s: %(message)s')
@@ -29,10 +30,13 @@ def build_tax_benefit_sytem(country_package_name, extensions, reforms):
     try:
         country_package = importlib.import_module(country_package_name)
     except ImportError:
-        handle_error(u'{}\nCould not import module `{}`.\n'.format(traceback.format_exc(), country_package_name)
-        + u'Are you sure it is installed in your environment? '
-        + u'If so, look at the stack trace above to determine the origin of this error.\n'
-        + u'See more at <https://github.com/openfisca/country-template#installing>.')
+        message = linesep.join([traceback.format_exc(),
+                                u'Could not import module `{}`.'.format(country_package_name),
+                                u'Are you sure it is installed in your environment? '
+                                + u'If so, look at the stack trace above to determine the origin of this error.\n'
+                                + u'See more at <https://github.com/openfisca/country-template#installing>.'])
+
+        handle_error(message)
     if not hasattr(country_package, 'CountryTaxBenefitSystem'):
         handle_error(u'`{}` does not seem to be a valid Openfisca country package.'.format(country_package_name))
 
@@ -58,8 +62,10 @@ def detect_country_package():
             try:
                 module = importlib.import_module(module_name)
             except ImportError:
-                handle_error(u'{}\nCould not import module `{}`.\n'.format(traceback.format_exc(), module_name)
-                + u'Look at the stack trace above to determine the error that stopped installed modules detection.')
+                message = linesep.join([traceback.format_exc(),
+                                        u'Could not import module `{}`.'.format(module_name),
+                                        u'Look at the stack trace above to determine the error that stopped installed modules detection.'])
+                handle_error(message)
             if hasattr(module, 'CountryTaxBenefitSystem'):
                 installed_country_packages.append(module_name)
 

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -29,7 +29,10 @@ def build_tax_benefit_sytem(country_package_name, extensions, reforms):
     try:
         country_package = importlib.import_module(country_package_name)
     except ImportError:
-        handle_error(u'{}\nCould not import module `{}`.\nAre you sure it is installed in your environment? If so, look at the stack trace above to determine the origin of this error.\nSee more at <https://github.com/openfisca/country-template#installing>.'.format(traceback.format_exc(sys.exc_info()), country_package_name))
+        handle_error(u'{}\nCould not import module `{}`.\n'.format(traceback.format_exc(), country_package_name)
+        + u'Are you sure it is installed in your environment? '
+        + u'If so, look at the stack trace above to determine the origin of this error.\n'
+        + u'See more at <https://github.com/openfisca/country-template#installing>.')
     if not hasattr(country_package, 'CountryTaxBenefitSystem'):
         handle_error(u'`{}` does not seem to be a valid Openfisca country package.'.format(country_package_name))
 
@@ -52,7 +55,11 @@ def detect_country_package():
     for module_description in pkgutil.iter_modules():
         module_name = module_description[1]
         if 'openfisca' in module_name.lower():
-            module = importlib.import_module(module_name)
+            try:
+                module = importlib.import_module(module_name)
+            except ImportError:
+                handle_error(u'{}\nCould not import module `{}`.\n'.format(traceback.format_exc(), module_name)
+                + u'Look at the stack trace above to determine the error that stopped installed modules detection.')
             if hasattr(module, 'CountryTaxBenefitSystem'):
                 installed_country_packages.append(module_name)
 

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import traceback
 import importlib
 import logging
 import pkgutil
@@ -28,7 +29,7 @@ def build_tax_benefit_sytem(country_package_name, extensions, reforms):
     try:
         country_package = importlib.import_module(country_package_name)
     except ImportError:
-        handle_error(u'Could not import module `{}`. Make sure it is installed in your environment.'.format(country_package_name))
+        handle_error(u'{}\nCould not import module `{}`.\nAre you sure it is installed in your environment? If so, look at the stack trace above to determine the origin of this error.\nSee more at <https://github.com/openfisca/country-template#installing>.'.format(traceback.format_exc(sys.exc_info()), country_package_name))
     if not hasattr(country_package, 'CountryTaxBenefitSystem'):
         handle_error(u'`{}` does not seem to be a valid Openfisca country package.'.format(country_package_name))
 

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -32,9 +32,8 @@ def build_tax_benefit_sytem(country_package_name, extensions, reforms):
     except ImportError:
         message = linesep.join([traceback.format_exc(),
                                 u'Could not import module `{}`.'.format(country_package_name),
-                                u'Are you sure it is installed in your environment? '
-                                + u'If so, look at the stack trace above to determine the origin of this error.\n'
-                                + u'See more at <https://github.com/openfisca/country-template#installing>.'])
+                                u'Are you sure it is installed in your environment? If so, look at the stack trace above to determine the origin of this error.',
+                                u'See more at <https://github.com/openfisca/country-template#installing>.'])
 
         handle_error(message)
     if not hasattr(country_package, 'CountryTaxBenefitSystem'):

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -3,13 +3,14 @@
 
 import glob
 from inspect import isclass
-from os import path
+from os import path, linesep
 from imp import find_module, load_module
 import importlib
 import logging
 import inspect
 import pkg_resources
 import warnings
+import traceback
 
 from setuptools import find_packages
 
@@ -234,8 +235,11 @@ class TaxBenefitSystem(object):
                 package = importlib.import_module(extension)
                 extension_directory = package.__path__[0]
             except ImportError:
-                raise IOError(
-                    "Error loading extension: {} is neither a directory, nor an installed package.".format(extension))
+                message = linesep.join([traceback.format_exc(),
+                                        u'Error loading extension: `{}` is neither a directory, nor a package.'.format(extension),
+                                        u'Are you sure it is installed in your environment? If so, look at the stack trace above to determine the origin of this error.',
+                                        u'See more at <https://github.com/openfisca/openfisca-extension-template#installing>.'])
+                raise IOError(message)
 
         self.add_variables_from_directory(extension_directory)
         param_file = path.join(extension_directory, 'parameters.xml')
@@ -265,7 +269,10 @@ class TaxBenefitSystem(object):
         try:
             reform_module = importlib.import_module(reform_package)
         except ImportError:
-            raise ValueError(u'Could not import `{}`.'.format(reform_package).encode('utf-8'))
+            message = linesep.join([traceback.format_exc(),
+                                    u'Could not import `{}`.'.format(reform_package).encode('utf-8'),
+                                    u'Are you sure of this reform module name? If so, look at the stack trace above to determine the origin of this error.'])
+            raise ValueError(message)
         reform = getattr(reform_module, reform_name, None)
         if reform is None:
             raise ValueError(u'{} has no attribute {}'.format(reform_package, reform_name).encode('utf-8'))

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -239,7 +239,7 @@ class TaxBenefitSystem(object):
                                         u'Error loading extension: `{}` is neither a directory, nor a package.'.format(extension),
                                         u'Are you sure it is installed in your environment? If so, look at the stack trace above to determine the origin of this error.',
                                         u'See more at <https://github.com/openfisca/openfisca-extension-template#installing>.'])
-                raise IOError(message)
+                raise ValueError(message)
 
         self.add_variables_from_directory(extension_directory)
         param_file = path.join(extension_directory, 'parameters.xml')

--- a/openfisca_web_api_preview/loader/tax_benefit_system.py
+++ b/openfisca_web_api_preview/loader/tax_benefit_system.py
@@ -12,9 +12,7 @@ def build_tax_benefit_system(country_package_name):
         message = linesep.join([traceback.format_exc(),
                                 u'Could not import module `{}`.'.format(country_package_name).encode('utf-8'),
                                 u'Are you sure it is installed in your environment? If so, look at the stack trace above to determine the origin of this error.',
-                                u'See more at:',
-                                u'- <https://github.com/openfisca/country-template#installing>',
-                                u'- <https://github.com/openfisca/openfisca-extension-template#installing>.',
+                                u'See more at <https://github.com/openfisca/country-template#installing>.',
                                 linesep])
         raise ValueError(message)
     return country_package.CountryTaxBenefitSystem()

--- a/openfisca_web_api_preview/loader/tax_benefit_system.py
+++ b/openfisca_web_api_preview/loader/tax_benefit_system.py
@@ -1,12 +1,20 @@
 # -*- coding: utf-8 -*-
 
 import importlib
+import traceback
+from os import linesep
 
 
 def build_tax_benefit_system(country_package_name):
     try:
         country_package = importlib.import_module(country_package_name)
     except ImportError:
-        raise ValueError(
-            u"{} is not installed in your current environment".format(country_package_name).encode('utf-8'))
+        message = linesep.join([traceback.format_exc(),
+                                u'Could not import module `{}`.'.format(country_package_name).encode('utf-8'),
+                                u'Are you sure it is installed in your environment? If so, look at the stack trace above to determine the origin of this error.',
+                                u'See more at:',
+                                u'- <https://github.com/openfisca/country-template#installing>',
+                                u'- <https://github.com/openfisca/openfisca-extension-template#installing>.',
+                                linesep])
+        raise ValueError(message)
     return country_package.CountryTaxBenefitSystem()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '14.0.0',
+    version = '14.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/core/test_extensions.py
+++ b/tests/core/test_extensions.py
@@ -19,6 +19,6 @@ def test_unload_extensions():
     assert tbs.get_column('local_town_child_allowance') is None
 
 
-@raises(IOError)
+@raises(ValueError)
 def test_failure_to_load_extension_when_directory_doesnt_exist():
     tbs.load_extension('/this/is/not/a/real/path')


### PR DESCRIPTION
Connected to #464 

#### New features

- Add stack trace when a module import fails at `openfisca-run-test`
   - Improve error message whether import is called with `-c` option or not
