### PR TITLE
Make missing_value base function compatible with v4 syntax and extra params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 15.0.1 - [#538](https://github.com/openfisca/openfisca-core/pull/538)
+
+#### Bug fix
+
+- Make `missing_value` base function compatible with v4 syntax and extra params
+
 # 15.0.0
 
 #### Breaking changes - [#525](https://github.com/openfisca/openfisca-core/pull/525)

--- a/openfisca_core/base_functions.py
+++ b/openfisca_core/base_functions.py
@@ -94,3 +94,12 @@ def requested_period_last_or_next_value(formula, simulation, period, *extra_para
     # This formula is used for variables that are constants between events and period size independent.
     # It returns the latest known value for the requested period, or the next value if there is no past value.
     return requested_period_last_value(formula, simulation, period, *extra_params, accept_future_value = True)
+
+
+def missing_value(formula, simulation, period, *extra_params):
+    function = formula.find_function(period)
+    if function is not None:
+        return formula.exec_function(simulation, period, *extra_params)
+    holder = formula.holder
+    column = holder.column
+    raise ValueError(u"Missing value for variable {} at {}".format(column.name, period))

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -610,10 +610,10 @@ def calculate_output_divide(formula, period):
     return formula.holder.compute_divide(period).array
 
 
-def missing_value(formula, simulation, period):
+def missing_value(formula, simulation, period, *extra_params):
     function = formula.find_function(period)
     if function is not None:
-        return function(simulation, period)
+        return formula.exec_function(simulation, period, *extra_params)
     holder = formula.holder
     column = holder.column
     raise ValueError(u"Missing value for variable {} at {}".format(column.name, period))

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -15,6 +15,7 @@ import numpy as np
 from . import columns, holders, legislations, periods
 from .periods import MONTH, YEAR, ETERNITY
 from .base_functions import (
+    missing_value,
     permanent_default_value,
     requested_period_default_value,
     requested_period_last_or_next_value,
@@ -608,15 +609,6 @@ def calculate_output_add(formula, period):
 
 def calculate_output_divide(formula, period):
     return formula.holder.compute_divide(period).array
-
-
-def missing_value(formula, simulation, period, *extra_params):
-    function = formula.find_function(period)
-    if function is not None:
-        return formula.exec_function(simulation, period, *extra_params)
-    holder = formula.holder
-    column = holder.column
-    raise ValueError(u"Missing value for variable {} at {}".format(column.name, period))
 
 
 def get_neutralized_column(column):

--- a/openfisca_core/model_api.py
+++ b/openfisca_core/model_api.py
@@ -30,9 +30,9 @@ from .formulas import (  # noqa analysis:ignore
     DIVIDE,
     set_input_dispatch_by_period,
     set_input_divide_by_period,
-    missing_value
     )
 from .base_functions import (   # noqa analysis:ignore
+    missing_value,
     requested_period_added_value,
     requested_period_default_value,
     requested_period_last_or_next_value,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '15.0.0',
+    version = '15.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
This `base_function` was hidden in `openfisca_core/formulas.py` instead of `openfisca_core/base_functions.py`.

Therefore several changes applied to base functions were not applied to it. This PR fixes it, and make this base function work [like the others](https://github.com/openfisca/openfisca-core/blob/master/openfisca_core/base_functions.py#L11)

This bug was without consequences, as this base function is rarely used. We however need to fix that to keep migrating france code towards the `v4` syntax.

