### PR TITLE
Deprecate parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+# 16.0.0
+
+#### Breaking changes - [#545](https://github.com/openfisca/openfisca-core/pull/545)
+
+* Deprecate `parsers`
+  - They can no longer be installed through `pip install openfisca_core[parsers]`
+  - They can still install them directly with `pip install openfisca_parsers`, but they won't be maintained.
+
 ### 15.0.1 - [#538](https://github.com/openfisca/openfisca-core/pull/538)
 
 #### Bug fix

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '15.0.1',
+    version = '16.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [
@@ -29,9 +29,6 @@ setup(
         'console_scripts': ['openfisca-run-test=openfisca_core.scripts.run_test:main'],
         },
     extras_require = {
-        'parsers': [
-            'OpenFisca-Parsers >= 1.0.2, < 2.0',
-            ],
         'test': [
             'nose',
             'flake8',


### PR DESCRIPTION
Connected to #500 

#### Breaking changes

* Deprecate `parsers`
  - They can no longer be installed through `pip install openfisca_core[parsers]`
  - They can still install them directly with `pip install openfisca_parsers`, but they won't be maintained.