### PR TITLE
Add Enum possible values to the web API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 16.2.0
+
+In the preview web API, for variables of type `Enum`:
+
+* Accept and recommand to use strings as simulation inputs, instead of the enum indices.
+  - For instance, `{"housing_occupancy_status": {"2017-01": "Tenant"}}` is now accepted and prefered to `{"housing_occupancy_status": {"2017-01": 0}}`).
+  - Using the enum indices as inputs is _still accepted_ for backward compatibility, but _should not_ be encouraged.
+* Return strings instead of enum indices.
+  - For instance, is `housing_occupancy_status` is calculated for `2017-01`, `{"housing_occupancy_status": {"2017-01": "Tenant"}}` is now returned, instead of `{"housing_occupancy_status": {"2017-01": 0}}`.
+* In the `/variable/<variable_name>` route, document possible values. 
+* In the Open API specification, document possible values following JSON schema. 
+
 ### 16.1.1
 
 #### Minor Change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ In the preview web API, for variables of type `Enum`:
   - For instance, is `housing_occupancy_status` is calculated for `2017-01`, `{"housing_occupancy_status": {"2017-01": "Tenant"}}` is now returned, instead of `{"housing_occupancy_status": {"2017-01": 0}}`.
 * In the `/variable/<variable_name>` route, document possible values. 
 * In the Open API specification, document possible values following JSON schema. 
+* In the `/variable/<variable_name>` route:
+  - Document possible values
+  - Use a string as a default value (instead of the enum default indice)
+* In the Open API specification, document possible values following JSON schema.  
 
 ### 16.1.1
 

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -13,6 +13,7 @@ from simulations import check_type, SituationParsingError
 from holders import Holder, PeriodMismatchError
 from periods import compare_period_size, period as make_period
 from taxbenefitsystems import VariableNotFound
+from columns import EnumCol
 
 
 class Entity(object):
@@ -79,6 +80,8 @@ class Entity(object):
                     array = holder.buffer.get(period)
                     if array is None:
                         array = holder.default_array()
+                    if isinstance(holder.column, EnumCol) and isinstance(value, basestring):
+                        value = holder.column.enum[value]
 
                     try:
                         array[entity_index] = value

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -59,34 +59,42 @@ class Entity(object):
     def init_variable_values(self, entity_object, entity_id):
         entity_index = self.ids.index(entity_id)
         for variable_name, variable_values in entity_object.iteritems():
+            path_in_json = [self.plural, entity_id, variable_name]
             try:
                 self.check_variable_defined_for_entity(variable_name)
             except ValueError as e:  # The variable is defined for another entity
-                raise SituationParsingError([self.plural, entity_id, variable_name], e.message)
+                raise SituationParsingError(path_in_json, e.message)
             except VariableNotFound as e:  # The variable doesn't exist
-                raise SituationParsingError([self.plural, entity_id, variable_name], e.message, code = 404)
+                raise SituationParsingError(path_in_json, e.message, code = 404)
 
             if not isinstance(variable_values, dict):
-                raise SituationParsingError([self.plural, entity_id, variable_name],
+                raise SituationParsingError(path_in_json,
                     'Invalid type: must be of type object. Input variables must be set for specific periods. For instance: {"salary": {"2017-01": 2000, "2017-02": 2500}}')
 
             holder = self.get_holder(variable_name)
             for date, value in variable_values.iteritems():
+                path_in_json.append(date)
                 try:
                     period = make_period(date)
                 except ValueError as e:
-                    raise SituationParsingError([self.plural, entity_id, variable_name, date], e.message)
+                    raise SituationParsingError(path_in_json, e.message)
                 if value is not None:
                     array = holder.buffer.get(period)
                     if array is None:
                         array = holder.default_array()
                     if isinstance(holder.column, EnumCol) and isinstance(value, basestring):
-                        value = holder.column.enum[value]
-
+                        try:
+                            value = holder.column.enum[value]
+                        except KeyError:
+                            raise SituationParsingError(path_in_json,
+                                "'{}' is not a valid value for '{}'. Possible values are ['{}'].".format(
+                                    value, variable_name, "', '".join(holder.column.enum.list)
+                                    ).encode('utf-8')
+                                )
                     try:
                         array[entity_index] = value
                     except (ValueError, TypeError) as e:
-                        raise SituationParsingError([self.plural, entity_id, variable_name, date],
+                        raise SituationParsingError(path_in_json,
                     'Invalid type: must be of type {}.'.format(holder.column.json_type))
 
                     holder.buffer[period] = array

--- a/openfisca_core/enumerations.py
+++ b/openfisca_core/enumerations.py
@@ -6,6 +6,7 @@ class Enum(object):
         self._vars = {}
         self._nums = {}
         self._count = 0
+        self.list = varlist
         for var in varlist:
             self._vars.update({self._count + start: var})
             self._nums.update({var: self._count + start})

--- a/openfisca_web_api_preview/loader/spec.py
+++ b/openfisca_web_api_preview/loader/spec.py
@@ -4,6 +4,8 @@ import os
 
 import yaml
 
+from openfisca_core.columns import EnumCol
+
 
 OPEN_API_CONFIG_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), os.path.pardir, 'openAPI.yml')
 
@@ -28,10 +30,15 @@ def build_openAPI_specification(tax_benefit_system, country_package_metadata):
 
 
 def get_variable_json_schema(variable):
-    return {
+    result = {
         'type': 'object',
         'additionalProperties': {'type': variable.json_type},
         }
+
+    if isinstance(variable, EnumCol):
+        result['additionalProperties']['enum'] = variable.enum.list
+
+    return result
 
 
 def get_entity_json_schema(entity, tax_benefit_system):

--- a/openfisca_web_api_preview/loader/variables.py
+++ b/openfisca_web_api_preview/loader/variables.py
@@ -13,10 +13,13 @@ def get_next_day(date):
     return next_day.isoformat().split('T')[0]
 
 
-def format_value(value):
-    if isinstance(value, datetime.date):
-        return value.isoformat()
-    return value
+def get_default_value(variable):
+    default_value = variable.default
+    if isinstance(default_value, datetime.date):
+        return default_value.isoformat()
+    if isinstance(variable, EnumCol):
+        return variable.enum._vars[default_value]
+    return default_value
 
 
 def build_source_url(country_package_metadata, source_file_path, start_line_number, source_code):
@@ -68,7 +71,7 @@ def build_variable(variable, country_package_metadata):
         'id': variable.name,
         'description': variable.label,
         'valueType': get_variable_type(variable),
-        'defaultValue': format_value(variable.default),
+        'defaultValue': get_default_value(variable),
         'definitionPeriod': variable.definition_period.upper(),
         'entity': variable.entity.key,
         'source': build_source_url(

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '16.1.1',
+    version = '16.2.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'test': [
             'nose',
             'flake8',
-            'openfisca-country-template >= 1.2.3rc0, <= 1.2.3',
+            'openfisca-country-template == 1.2.4',
             'openfisca-extension-template == 1.1.0',
             ],
         'tracker': [

--- a/tests/web_api/test_calculate.py
+++ b/tests/web_api/test_calculate.py
@@ -163,3 +163,24 @@ def test_enums_sending_string():
     assert_equal(response.status_code, OK)
     response_json = json.loads(response.data)
     assert_equal(dpath.get(response_json, 'households/_/housing_tax/2017'), 0)
+
+
+def test_enum_output():
+    simulation_json = json.dumps({
+        "persons": {
+            "bill": {},
+            },
+        "households": {
+            "_": {
+                "parents": ["bill"],
+                "housing_occupancy_status": {
+                    "2017-01": None
+                    }
+                },
+            }
+        })
+
+    response = post_json(simulation_json)
+    assert_equal(response.status_code, OK)
+    response_json = json.loads(response.data)
+    assert_equal(dpath.get(response_json, "households/_/housing_occupancy_status/2017-01"), "Tenant")

--- a/tests/web_api/test_calculate.py
+++ b/tests/web_api/test_calculate.py
@@ -109,3 +109,30 @@ def test_basic_calculation():
     assert_equal(dpath.get(response_json, 'persons/bob/basic_income/2017-12'), 600)
     assert_equal(dpath.get(response_json, 'persons/bob/social_security_contribution/2017-12'), 816)  # From social_security_contribution.yaml test
     assert_equal(dpath.get(response_json, 'households/first_household/housing_tax/2017'), 3000)
+
+
+def test_enums_sending_index():
+    simulation_json = json.dumps({
+        "persons": {
+            "bill": {},
+            },
+        "households": {
+            "_": {
+                "parents": ['bill'],
+                "housing_tax": {
+                    "2017": None
+                    },
+                "accomodation_size": {
+                    "2017-01": 300
+                    },
+                "housing_occupancy_status": {
+                    "2017-01": 2  # Free lodger
+                    }
+                },
+            }
+        })
+
+    response = post_json(simulation_json)
+    assert_equal(response.status_code, OK)
+    response_json = json.loads(response.data)
+    assert_equal(dpath.get(response_json, 'households/_/housing_tax/2017'), 0)

--- a/tests/web_api/test_calculate.py
+++ b/tests/web_api/test_calculate.py
@@ -184,3 +184,27 @@ def test_enum_output():
     assert_equal(response.status_code, OK)
     response_json = json.loads(response.data)
     assert_equal(dpath.get(response_json, "households/_/housing_occupancy_status/2017-01"), "Tenant")
+
+
+def test_enum_wrong_value():
+    simulation_json = json.dumps({
+        "persons": {
+            "bill": {},
+            },
+        "households": {
+            "_": {
+                "parents": ["bill"],
+                "housing_occupancy_status": {
+                    "2017-01": "Unknown value logder"
+                    }
+                },
+            }
+        })
+
+    response = post_json(simulation_json)
+    assert_equal(response.status_code, BAD_REQUEST)
+    response_json = json.loads(response.data)
+    assert_in(
+        "Possible values are ['Tenant', 'Owner', 'Free logder', 'Homeless']",
+        dpath.get(response_json, "households/_/housing_occupancy_status/2017-01")
+        )

--- a/tests/web_api/test_calculate.py
+++ b/tests/web_api/test_calculate.py
@@ -136,3 +136,30 @@ def test_enums_sending_index():
     assert_equal(response.status_code, OK)
     response_json = json.loads(response.data)
     assert_equal(dpath.get(response_json, 'households/_/housing_tax/2017'), 0)
+
+
+def test_enums_sending_string():
+    simulation_json = json.dumps({
+        "persons": {
+            "bill": {},
+            },
+        "households": {
+            "_": {
+                "parents": ["bill"],
+                "housing_tax": {
+                    "2017": None
+                    },
+                "accomodation_size": {
+                    "2017-01": 300
+                    },
+                "housing_occupancy_status": {
+                    "2017-01": "Free logder"
+                    }
+                },
+            }
+        })
+
+    response = post_json(simulation_json)
+    assert_equal(response.status_code, OK)
+    response_json = json.loads(response.data)
+    assert_equal(dpath.get(response_json, 'households/_/housing_tax/2017'), 0)

--- a/tests/web_api/test_variables.py
+++ b/tests/web_api/test_variables.py
@@ -109,6 +109,19 @@ def test_variable_with_start_and_stop_date():
     assert_in('formula', variable['formulas']['1980-01-01']['content'])
 
 
+def test_variable_with_enum():
+    response = subject.get('/variable/housing_occupancy_status')
+    variable = json.loads(response.data)
+    assert_equal(variable['valueType'], 'String')
+    assert_in('possibleValues', variable.keys())
+    assert_equal(variable['possibleValues'], [
+        u'Tenant',
+        u'Owner',
+        u'Free logder',
+        u'Homeless']
+        )
+
+
 dated_variable_response = subject.get('/variable/basic_income')
 dated_variable = json.loads(dated_variable_response.data)
 

--- a/tests/web_api/test_variables.py
+++ b/tests/web_api/test_variables.py
@@ -2,7 +2,7 @@
 
 from httplib import OK, NOT_FOUND
 import json
-from nose.tools import assert_equal, assert_regexp_matches, assert_items_equal, assert_in, assert_is_none
+from nose.tools import assert_equal, assert_regexp_matches, assert_items_equal, assert_in, assert_is_none, assert_not_in
 from . import subject
 
 # /variables
@@ -86,11 +86,6 @@ def test_variable_value():
         yield check_variable_value, key, expected_value
 
 
-# def test_null_values_are_dropped():
-#     # TODO: use age
-#     assert_not_in('references', variable.keys())
-
-
 def test_variable_formula_github_link():
     assert_regexp_matches(variable['formulas']['0001-01-01']['source'], GITHUB_URL_REGEX)
 
@@ -98,6 +93,12 @@ def test_variable_formula_github_link():
 def test_variable_formula_content():
     formula_code = "def formula(person, period, legislation):\n    return person('salary', period) * legislation(period).taxes.income_tax_rate\n"
     assert_equal(variable['formulas']['0001-01-01']['content'], formula_code)
+
+
+def test_null_values_are_dropped():
+    variable_response = subject.get('/variable/age')
+    variable = json.loads(variable_response.data)
+    assert_not_in('references', variable.keys())
 
 
 def test_variable_with_start_and_stop_date():

--- a/tests/web_api/test_variables.py
+++ b/tests/web_api/test_variables.py
@@ -113,6 +113,7 @@ def test_variable_with_enum():
     response = subject.get('/variable/housing_occupancy_status')
     variable = json.loads(response.data)
     assert_equal(variable['valueType'], 'String')
+    assert_equal(variable['defaultValue'], 'Tenant')
     assert_in('possibleValues', variable.keys())
     assert_equal(variable['possibleValues'], [
         u'Tenant',


### PR DESCRIPTION
Connected to openfisca/legislation-explorer#95

Depends on https://github.com/openfisca/country-template/pull/16

In the preview web API, for variables of type `Enum`:

* Accept and recommand to use strings as simulation inputs, instead of the enum indices.
  - For instance, `{"housing_occupancy_status": {"2017-01": "Tenant"}}` is now accepted and prefered to `{"housing_occupancy_status": {"2017-01": 0}}`).
  - Using the enum indices as inputs is _still accepted_ for backward compatibility, but _should not_ be encouraged.
* Return strings instead of enum indices.
  - For instance, is `housing_occupancy_status` is calculated for `2017-01`, `{"housing_occupancy_status": {"2017-01": "Tenant"}}` is now returned, instead of `{"housing_occupancy_status": {"2017-01": 0}}`.
* In the `/variable/<variable_name>` route, document possible values. 
* In the Open API specification, document possible values following JSON schema.  