### PR TITLE
Support reference attributes on all parameter node types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 16.3.0
+
+- Support `reference` attributes on all parameter XML nodes.
+  - You can now add a `reference` on a `<VALUE>`, for example.
+
 ## 16.2.0
 
 In the preview web API, for variables of type `Enum`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,17 @@
 
 In the preview web API, for variables of type `Enum`:
 
-* Accept and recommand to use strings as simulation inputs, instead of the enum indices.
+* Accept and recommend to use strings as simulation inputs, instead of the enum indices.
   - For instance, `{"housing_occupancy_status": {"2017-01": "Tenant"}}` is now accepted and prefered to `{"housing_occupancy_status": {"2017-01": 0}}`).
   - Using the enum indices as inputs is _still accepted_ for backward compatibility, but _should not_ be encouraged.
 * Return strings instead of enum indices.
   - For instance, is `housing_occupancy_status` is calculated for `2017-01`, `{"housing_occupancy_status": {"2017-01": "Tenant"}}` is now returned, instead of `{"housing_occupancy_status": {"2017-01": 0}}`.
-* In the `/variable/<variable_name>` route, document possible values. 
-* In the Open API specification, document possible values following JSON schema. 
+* In the `/variable/<variable_name>` route, document possible values.
+* In the Open API specification, document possible values following JSON schema.
 * In the `/variable/<variable_name>` route:
   - Document possible values
   - Use a string as a default value (instead of the enum default indice)
-* In the Open API specification, document possible values following JSON schema.  
+* In the Open API specification, document possible values following JSON schema.
 
 ### 16.1.1
 
@@ -75,7 +75,7 @@ In the preview web API, for variables of type `Enum`:
 
 #### Minor Change
 
-- Rewrite `/calculate` example in the Open API spec so that it works for `Openfisca-France` 
+- Rewrite `/calculate` example in the Open API spec so that it works for `Openfisca-France`
 
 ### 14.1.2 - [#535](https://github.com/openfisca/openfisca-core/pull/535)
 
@@ -133,7 +133,7 @@ In the preview web API, for variables of type `Enum`:
 - In variables:
   - Merge `Variable` and `DatedVariable`.
     - `Variable` can now handle formula evolution over time.
-  - Remove `start_date` attribute 
+  - Remove `start_date` attribute
   - Rename `stop_date` attribute to `end`
     - Introduce end string format `end = 'YYYY-MM-DD'`
 - In formulas:

--- a/openfisca_core/legislation.xsd
+++ b/openfisca_core/legislation.xsd
@@ -29,7 +29,7 @@
 
     <xs:complexType name="codeType">
         <xs:group ref="valuesHistory"/>
-        <xs:attribute name="code"  type="xs:string" use="required"/>
+        <xs:attribute name="code" type="xs:string" use="required"/>
         <xs:attribute name="description" type="xs:string"/>
         <xs:attribute name="format" type="xs:string"/>
         <xs:attribute name="origin" type="xs:string"/>

--- a/openfisca_core/legislation.xsd
+++ b/openfisca_core/legislation.xsd
@@ -40,11 +40,13 @@
 
     <xs:complexType name="endType">
         <xs:attribute name="deb" type="xs:date" use="required"/>
+        <xs:attribute name="reference" type="xs:string"/>
     </xs:complexType>
 
     <xs:complexType name="valueType">
         <xs:attribute name="deb" type="xs:date" use="required"/>
         <xs:attribute name="valeur" type="xs:float" use="required"/>
+        <xs:attribute name="reference" type="xs:string"/>
     </xs:complexType>
 
     <xs:complexType name="baremeType">
@@ -68,27 +70,33 @@
             <xs:element name="MONTANT" type="montantType" minOccurs="0"/>
         </xs:all>
         <xs:attribute name="code" type="xs:string"/>
+        <xs:attribute name="reference" type="xs:string"/>
     </xs:complexType>
 
     <xs:complexType name="assietteType">
         <xs:group ref="valuesHistory"/>
+        <xs:attribute name="reference" type="xs:string"/>
     </xs:complexType>
 
     <xs:complexType name="tauxType">
         <xs:group ref="valuesHistory"/>
+        <xs:attribute name="reference" type="xs:string"/>
     </xs:complexType>
 
     <xs:complexType name="montantType">
         <xs:group ref="valuesHistory"/>
+        <xs:attribute name="reference" type="xs:string"/>
     </xs:complexType>
 
     <xs:complexType name="seuilType">
         <xs:group ref="valuesHistory"/>
         <xs:attribute name="conflicts" type="xs:string"/>
+        <xs:attribute name="reference" type="xs:string"/>
     </xs:complexType>
 
     <xs:complexType name="placeholderType">
         <xs:attribute name="deb" type="xs:date" use="required"/>
+        <xs:attribute name="reference" type="xs:string"/>
     </xs:complexType>
 
 </xs:schema>

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '16.2.0',
+    version = '16.3.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/core/parameter_validation/references.xml
+++ b/tests/core/parameter_validation/references.xml
@@ -1,0 +1,19 @@
+<NODE code="root">
+  <NODE code="impot">
+    <CODE code="taux" description="Taux d'impôt sur les salaires" format="percent">
+      <VALUE deb="2016-01-01" valeur="0.3" reference="http://reference.example" />
+    </CODE>
+  </NODE>
+  <NODE code="salaire" description="Contribution sur les salaires" reference="http://reference.example">
+    <BAREME code="bareme" description="Bareme progressif de contribution sociale sur les salaires">
+      <TRANCHE code="tranche0" reference="http://reference.example" >
+        <SEUIL reference="http://reference.example">
+          <VALUE deb="2013-01-01" valeur="0" reference="http://reference.example" />
+        </SEUIL>
+        <TAUX reference="http://reference.example">
+          <VALUE deb="2017-01-01" valeur="0.02" reference="http://reference.example" />
+        </TAUX>
+      </TRANCHE>
+    </BAREME>
+  </NODE>
+</NODE>

--- a/tests/core/parameter_validation/test_parameter_validation.py
+++ b/tests/core/parameter_validation/test_parameter_validation.py
@@ -81,3 +81,9 @@ def test_wrong_bareme():
             assert keyword in content
     else:
         assert False, "This test should raise a ValueError."
+
+
+def test_references():
+    path_to_xml = os.path.join(BASE_DIR, 'references.xml')
+    tbs = TestTaxBenefitSystem(path_to_xml)
+    tbs.compute_legislation()


### PR DESCRIPTION
#### New features

- Add support for `reference` attributes on all parameter node types.
  - Allows for https://github.com/openfisca/openfisca-france/pull/789 to be merged.

Fix #557.