### PR TITLE
Check type reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 17.0.1
+
+#### Minor Change
+
+- Handle the case where the user accidentally puts a coma at the end of a variable reference so it has no consequence on the API output.
+- All variable references are transformed into lists of strings.
+
 # 17.0.0 - [#552](https://github.com/openfisca/openfisca-core/pull/552)
 
 #### Breaking changes
@@ -192,7 +199,6 @@
 * In the API preview, update the internal transformation of the parameters.
 
 * In the directory `script`, add a subdirectory `migrations`.
-
 
 ## 16.3.0
 

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -58,7 +58,7 @@ class Variable(object):
 
         reference = self.attributes.pop('reference', None)
         if reference:
-            if isinstance(reference, unicode) or isinstance(reference, str):
+            if isinstance(reference, basestring):
                 reference = [reference]
             elif isinstance(reference, list):
                 pass
@@ -66,6 +66,12 @@ class Variable(object):
                 reference = list(reference)
             else:
                 raise TypeError('The reference of the variable {} is a {} instead of a String or a List of Strings.'.format(self.name, type(reference)))
+
+            for element in reference:
+                if not isinstance(element, basestring):
+                    raise TypeError(
+                        'The reference of the variable {} is a {} instead of a String or a List of Strings.'.format(
+                            self.name, type(reference)))
 
         return new_filled_column(
             name = self.name,

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -56,6 +56,17 @@ class Variable(object):
             except ValueError:
                 raise ValueError(u"Incorrect 'end' attribute format in '{}'. 'YYYY-MM-DD' expected where YYYY, MM and DD are year, month and day. Found: {}".format(self.name, end).encode('utf-8'))
 
+        reference = self.attributes.pop('reference', None)
+        if reference:
+            if isinstance(reference, unicode) or isinstance(reference, str):
+                reference = [reference]
+            elif isinstance(reference, list):
+                reference = reference
+            elif isinstance(reference, tuple):
+                reference = list(reference)
+            else:
+                raise TypeError('The reference of the variable {} is a {} instead of a String.'.format(self.name, type(reference)))
+
         return new_filled_column(
             name = self.name,
             entity = entity,
@@ -65,5 +76,6 @@ class Variable(object):
             start_line_number = start_line_number,
             source_code = source_code,
             source_file_path = source_file_path,
+            reference = reference,
             **self.attributes
             )

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -61,11 +61,11 @@ class Variable(object):
             if isinstance(reference, unicode) or isinstance(reference, str):
                 reference = [reference]
             elif isinstance(reference, list):
-                reference = reference
+                pass
             elif isinstance(reference, tuple):
                 reference = list(reference)
             else:
-                raise TypeError('The reference of the variable {} is a {} instead of a String.'.format(self.name, type(reference)))
+                raise TypeError('The reference of the variable {} is a {} instead of a String or a List of Strings.'.format(self.name, type(reference)))
 
         return new_filled_column(
             name = self.name,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '17.0.0',
+    version = '17.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Fixes #556 

#### Technical changes

- Allows for user to put a coma at the end of a variable reference, without consequence to the API output.
- All variable references are transformed into lists of strings.
