### PR TITLE
Document entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 17.1.0
+
+- Allow to document entities and entities roles
+  - Add attribute `Entity.doc` (e.g. `Household.doc`)
+  - Add attribute `Role.doc` (e.g. `Household.CHILD.doc`)
+
 ### 17.0.1
 
 #### Minor Change

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -20,6 +20,7 @@ class Entity(object):
     key = None
     plural = None
     label = None
+    doc = None
     is_person = False
 
     def __init__(self, simulation, entities_json = None):
@@ -153,6 +154,7 @@ class Entity(object):
             'key': cls.key,
             'label': cls.label,
             'plural': cls.plural,
+            'doc': cls.doc,
             'roles': cls.roles_description,
             }
 
@@ -478,6 +480,7 @@ class Role(object):
         self.key = description['key']
         self.label = description.get('label')
         self.plural = description.get('plural')
+        self.doc = description.get('doc')
         self.max = description.get('max')
         self.subroles = None
 
@@ -543,9 +546,9 @@ class UniqueRoleToEntityProjector(Projector):
         return self.target_entity.value_from_person(result, self.role)
 
 
-def build_entity(key, plural, label, roles = None, is_person = False):
+def build_entity(key, plural, label, doc, roles = None, is_person = False):
     entity_class_name = key.title()
-    attributes = {'key': key, 'plural': plural, 'label': label, 'roles_description': roles}
+    attributes = {'key': key, 'plural': plural, 'label': label, 'doc': doc, 'roles_description': roles}
     if is_person:
         entity_class = type(entity_class_name, (PersonEntity,), attributes)
     elif roles:

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -20,7 +20,7 @@ class Entity(object):
     key = None
     plural = None
     label = None
-    doc = None
+    doc = ""
     is_person = False
 
     def __init__(self, simulation, entities_json = None):
@@ -546,7 +546,7 @@ class UniqueRoleToEntityProjector(Projector):
         return self.target_entity.value_from_person(result, self.role)
 
 
-def build_entity(key, plural, label, doc, roles = None, is_person = False):
+def build_entity(key, plural, label, doc = "", roles = None, is_person = False):
     entity_class_name = key.title()
     attributes = {'key': key, 'plural': plural, 'label': label, 'doc': doc, 'roles_description': roles}
     if is_person:

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -2,6 +2,7 @@
 
 import traceback
 import warnings
+import textwrap
 from os import linesep
 
 import numpy as np
@@ -480,7 +481,7 @@ class Role(object):
         self.key = description['key']
         self.label = description.get('label')
         self.plural = description.get('plural')
-        self.doc = description.get('doc')
+        self.doc = textwrap.dedent(description.get('doc', ""))
         self.max = description.get('max')
         self.subroles = None
 
@@ -548,7 +549,7 @@ class UniqueRoleToEntityProjector(Projector):
 
 def build_entity(key, plural, label, doc = "", roles = None, is_person = False):
     entity_class_name = key.title()
-    attributes = {'key': key, 'plural': plural, 'label': label, 'doc': doc, 'roles_description': roles}
+    attributes = {'key': key, 'plural': plural, 'label': label, 'doc': textwrap.dedent(doc), 'roles_description': roles}
     if is_person:
         entity_class = type(entity_class_name, (PersonEntity,), attributes)
     elif roles:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '17.0.1',
+    version = '17.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Connected to openfisca/country-template#19

#### New features

- Introduce `doc` attribute on `entities`
  - Allows for documentation definition on every entity instance. Default value set to empty string.


