### PR TITLE
Improve parameters navigating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ tax_benefit_system.parameters.benefits.basic_income
 >>>2015-12-01: 600.0
 ```
 
+- Request parameter at a given date with the `parameters.benefits('2015-07-01')` notation.
+
 - Be more flexible about parameters definitions
 
 The two following expressions are for instance striclty equivalent:
@@ -30,7 +32,6 @@ Parameter("taxes.rate", {"2015-01-01": 2000})
 Parameter("taxes.rate", {"values": {"2015-01-01":{"value": 2000}}})
 ```
 
-- Request parameter at a given date with the `parameters.benefits('2015-07-01')` notation.
 - Make sure `parameters.benefits('2015-07-01')` and `parameters.benefits('2015-07')` return the same value.
 - Raise an error when calling `parameters.benefits('invalid_key')`.
 - Improve errors when `parameter.update` is used with wrong arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 18.1.0 [#578](https://github.com/openfisca/openfisca-core/pull/578)
+
+#### New features
+
+- Improve the representations of parameters when navigating the legislation in Python.
+
+For instance:
+```
+tax_benefit_system.parameters.benefits
+
+>>> basic_income:
+>>>   2015-12-01: 600.0
+>>> housing_allowance:
+>>>   2016-12-01: None
+>>>   2010-01-01: 0.25
+
+tax_benefit_system.parameters.benefits.basic_income
+
+>>>2015-12-01: 600.0
+```
+
+- Be more flexible about parameters definitions
+
+The two following expressions are for instance striclty equivalent:
+
+```
+Parameter("taxes.rate", {"2015-01-01": 2000})
+Parameter("taxes.rate", {"values": {"2015-01-01":{"value": 2000}}})
+```
+
+- Request parameter at a given date with the `parameters.benefits('2015-07-01')` notation.
+- Make sure `parameters.benefits('2015-07-01')` and `parameters.benefits('2015-07')` return the same value.
+- Raise an error when calling `parameters.benefits('invalid_key')`.
+- Improve errors when `parameter.update` is used with wrong arguments
+
+#### Deprecations
+
+- Deprecate `ValuesHistory` class. Use `Parameter` instead.
+- Deprecate `parameter.values_history`. Just use `parameter` instead.
+
 ### 18.0.2 [#585](https://github.com/openfisca/openfisca-core/pull/585)
 
 - Track the real visitor IP in the web API

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -309,8 +309,8 @@ class Parameter(ValidableParameter, DatableParameter):
     def _calculate_at_instant(self, instant_str):
         return self.values_history.get_at_instant(instant_str)
 
-    def update(self, **args):
-        return self.values_history.update(**args)
+    def update(self, *args, **kwargs):
+        return self.values_history.update(*args, **kwargs)
 
     def __repr__(self):
         return self.values_history.__repr__()

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -363,17 +363,6 @@ class Scale(object):
             ])
 
 
-def _parse_child(child_name, child, child_path):
-    if 'values' in child:
-        return Parameter(child_name, child, child_path)
-    elif 'brackets' in child:
-        return Scale(child_name, child, child_path)
-    elif isinstance(child, dict) and all([INSTANT_PATTERN.match(key) for key in child.keys()]):
-        return Parameter(child_name, child, child_path)
-    else:
-        return ParameterNode(child_name, data = child, file_path = child_path)
-
-
 class ParameterNode(object):
     """
         A node in the legislation `parameter tree <http://openfisca.org/doc/coding-the-legislation/legislation_parameters.html>`_.
@@ -717,6 +706,17 @@ class VectorialParameterNodeAtInstant(object):
                 return VectorialParameterNodeAtInstant(self._name, result.view(np.recarray), self._instant_str)
 
             return result
+
+
+def _parse_child(child_name, child, child_path):
+    if 'values' in child:
+        return Parameter(child_name, child, child_path)
+    elif 'brackets' in child:
+        return Scale(child_name, child, child_path)
+    elif isinstance(child, dict) and all([INSTANT_PATTERN.match(key) for key in child.keys()]):
+        return Parameter(child_name, child, child_path)
+    else:
+        return ParameterNode(child_name, data = child, file_path = child_path)
 
 
 def _compose_name(path, child_name):

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -14,6 +14,7 @@ import numpy as np
 from . import taxscales
 from . import periods
 from periods import INSTANT_PATTERN
+from tools import indent
 
 log = logging.getLogger(__name__)
 
@@ -758,5 +759,3 @@ def contains_nan(vector):
         return np.isnan(np.min(vector))
 
 
-def indent(text):
-    return "  {}".format(text.replace("\n", "\n  "))

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -104,7 +104,6 @@ class ValidableParameter(object):
                         )
 
 
-
 class DatableParameter(object):
 
     def __call__(self, instant):
@@ -138,8 +137,9 @@ class ValueAtInstant(ValidableParameter):
         self.instant_str = instant_str
         self.file_path = file_path
 
-        if data is None:
-            self.value = None
+        # Accept { 2015-01-01: 4000 }
+        if not isinstance(data, dict) and type(data) in self._allowed_value_data_types:
+            self.value = data
             return
 
         self.validate(data)
@@ -185,7 +185,6 @@ class Parameter(ValidableParameter, DatableParameter):
         self.file_path = file_path
         self.validate(data, data_type = dict)
         self.values_history = self  # Only for retro-compatibility
-
 
         if data.get('values'):
             self.validate(data, allowed_keys = set(['values', 'description', 'unit', 'reference']))

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -169,11 +169,29 @@ class ValueAtInstant(ValidableParameter):
 
 class Parameter(ValidableParameter, DatableParameter):
     """
-        This history of a parameter values.
+        A parameter of the legislation. Parameters can change over time.
 
         :param name: name of the parameter, e.g. "taxes.some_tax.some_param"
         :param data: Data loaded from a YAML file.
         :param file_path: File the parameter was loaded from.
+
+
+        Instantiate a parameter without metadata:
+
+        >>>  Parameter('rate', data = {
+                "2015-01-01": 550,
+                "2016-01-01": 600
+                })
+
+        Instantiate a parameter with metadata:
+
+        >>>  Parameter('rate', data = {
+                'description': 'Income tax rate applied on salaries'
+                'values': {
+                    "2015-01-01": {'value': 550, reference = 'http://taxes.gov/income_tax/2015'},
+                    "2016-01-01": {'value': 600, reference = 'http://taxes.gov/income_tax/2016'}
+                    }
+                })
 
         .. py:attribute:: values_list
 

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -234,8 +234,10 @@ class ValuesHistory(ValidableParameter, DatableParameter):
         :param value: New value. If `None`, the parameter is removed from the legislation parameters for the given period.
         """
         if period is not None:
-            if start is not None and stop is not None:
-                raise ValueError(u"period parameter can't be used with start and stop")
+            if start is not None or stop is not None:
+                raise TypeError(u"Wrong input for 'update' method: use either 'update(period, value = value)' or 'update(start = start, stop = stop, value = value)'. You cannot both use 'period' and 'start' or 'stop'.")
+            if isinstance(period, basestring):
+                period = periods.period(period)
             start = period.start
             stop = period.stop
         if start is None:

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -420,8 +420,30 @@ class ParameterNode(ValidableParameter, DatableParameter):
 
         :param string name: Name of the node, eg "taxes.some_tax".
         :param string directory_path: Directory containing YAML files describing the node.
-        :param string data: Object representing the parameter node. It usually has been extracted from a YAML file.
+        :param dict data: Object representing the parameter node. It usually has been extracted from a YAML file.
         :param string file_path: YAML file from which the `data` has been extracted from.
+
+
+        Instantiate a ParameterNode from a dict:
+
+        >>> node = ParameterNode('basic_income', data = {
+            'amount': {
+              'values': {
+                "2015-01-01": {'value': 550},
+                "2016-01-01": {'value': 600}
+                }
+              },
+            'min_age': {
+              'values': {
+                "2015-01-01": {'value': 25},
+                "2016-01-01": {'value': 18}
+                }
+              },
+            })
+
+        Instantiate a ParameterNode from a directory containing YAML parameter files:
+
+        >>> node = ParameterNode('benefits', directory_path = '/path/to/country_package/parameters/benefits')
         """
         self.name = name
 

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -79,7 +79,7 @@ class ParameterParsingError(Exception):
         super(ParameterParsingError, self).__init__(message)
 
 
-class ValueAtInstant(object):
+class ParameterAtInstant(object):
     """
         A value of a parameter at a given instant.
     """
@@ -124,7 +124,7 @@ class ValueAtInstant(object):
         return (self.name == other.name) and (self.instant_str == other.instant_str) and (self.value == other.value)
 
     def __repr__(self):
-        return "ValueAtInstant({})".format({self.instant_str: self.value}).encode('utf-8')
+        return "ParameterAtInstant({})".format({self.instant_str: self.value}).encode('utf-8')
 
 
 class Parameter(object):
@@ -187,7 +187,7 @@ class Parameter(object):
                 continue
 
             value_name = _compose_name(name, instant_str)
-            value_at_instant = ValueAtInstant(value_name, instant_str, data = instant_info, file_path = file_path)
+            value_at_instant = ParameterAtInstant(value_name, instant_str, data = instant_info, file_path = file_path)
             values_list.append(value_at_instant)
 
         self.values_list = values_list
@@ -249,16 +249,16 @@ class Parameter(object):
                 if i < n:
                     overlapped_value = old_values[i].value
                     value_name = _compose_name(self.name, stop_str)
-                    new_interval = ValueAtInstant(value_name, stop_str, data = {'value': overlapped_value})
+                    new_interval = ParameterAtInstant(value_name, stop_str, data = {'value': overlapped_value})
                     new_values.append(new_interval)
                 else:
                     value_name = _compose_name(self.name, stop_str)
-                    new_interval = ValueAtInstant(value_name, stop_str, data = {'value': None})
+                    new_interval = ParameterAtInstant(value_name, stop_str, data = {'value': None})
                     new_values.append(new_interval)
 
         # Insert new interval
         value_name = _compose_name(self.name, start_str)
-        new_interval = ValueAtInstant(value_name, start_str, data = {'value': value})
+        new_interval = ParameterAtInstant(value_name, start_str, data = {'value': value})
         new_values.append(new_interval)
 
         # Remove covered intervals

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -106,7 +106,7 @@ class ValueAtInstant(object):
         self.value = data['value']
 
     def validate(self, data):
-        validate_parameter(self, data, data_type = dict, allowed_keys = self._allowed_keys)
+        _validate_parameter(self, data, data_type = dict, allowed_keys = self._allowed_keys)
         try:
             value = data['value']
         except KeyError:
@@ -161,14 +161,14 @@ class Parameter(object):
     def __init__(self, name, data, file_path = None):
         self.name = name
         self.file_path = file_path
-        validate_parameter(self, data, data_type = dict)
+        _validate_parameter(self, data, data_type = dict)
         self.values_history = self  # Only for retro-compatibility
 
         if data.get('values'):
-            validate_parameter(self, data, allowed_keys = set(['values', 'description', 'unit', 'reference']))
+            _validate_parameter(self, data, allowed_keys = set(['values', 'description', 'unit', 'reference']))
             self.description = data.get('description')
             data = data['values']
-            validate_parameter(self, data, data_type = dict)
+            _validate_parameter(self, data, data_type = dict)
 
         instants = sorted(data.keys(), reverse = True)  # sort by antechronological order
 
@@ -292,7 +292,7 @@ class Scale(object):
         """
         self.name = name
         self.file_path = file_path
-        validate_parameter(self, data, data_type = dict, allowed_keys = self._allowed_keys)
+        _validate_parameter(self, data, data_type = dict, allowed_keys = self._allowed_keys)
         self.description = data.get('description')
 
         if not isinstance(data['brackets'], list):
@@ -438,7 +438,7 @@ class ParameterNode(object):
 
         else:
             self.file_path = file_path
-            validate_parameter(self, data, data_type = dict, allowed_keys = self._allowed_keys)
+            _validate_parameter(self, data, data_type = dict, allowed_keys = self._allowed_keys)
             self.children = {}
             # We allow to set a reference and a description for a node. It is however not recommanded, as it's only metadata and is not exposed in the legislation explorer.
             data.pop('reference', None)
@@ -728,7 +728,7 @@ def _compose_name(path, child_name):
         return child_name
 
 
-def validate_parameter(parameter, data, data_type = None, allowed_keys = None):
+def _validate_parameter(parameter, data, data_type = None, allowed_keys = None):
     type_map = {
         dict: 'object',
         list: 'array',

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -53,8 +53,8 @@ class ParameterNotFound(AttributeError):
         if variable_name is not None:
             message += u" requested by variable '{}'".format(variable_name)
         message += (
-            u" was not found in the {2} tax and benefit system."
-            ).format(name, variable_name, instant_str)
+            u" was not found in the {} tax and benefit system."
+            ).format(instant_str)
         super(ParameterNotFound, self).__init__(message)
 
 

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -108,6 +108,9 @@ class ValidableParameter(object):
 
 class DatableParameter(object):
 
+    def __call__(self, instant):
+        return self.get_at_instant(instant)
+
     def get_at_instant(self, instant):
         instant = str(instant)
         if not INSTANT_PATTERN.match(instant):

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -156,7 +156,7 @@ class Parameter(object):
 
         .. py:attribute:: values_list
 
-           List of the values, in anti-chronological order
+           List of the values, in reverse chronological order
     """
 
     def __init__(self, name, data, file_path = None):
@@ -171,7 +171,7 @@ class Parameter(object):
             data = data['values']
             _validate_parameter(self, data, data_type = dict)
 
-        instants = sorted(data.keys(), reverse = True)  # sort by antechronological order
+        instants = sorted(data.keys(), reverse = True)  # sort in reverse chronological order
 
         values_list = []
         for instant_str in instants:
@@ -373,7 +373,7 @@ class ParameterNode(object):
 
     def __init__(self, name = "", directory_path = None, data = None, file_path = None):
         """
-        Instanciate a ParameterNode either from a dict, (using `data`), or from a directory containing YAML files (using `directory_path`).
+        Instantiate a ParameterNode either from a dict, (using `data`), or from a directory containing YAML files (using `directory_path`).
 
         :param string name: Name of the node, eg "taxes.some_tax".
         :param string directory_path: Directory containing YAML files describing the node.
@@ -757,5 +757,4 @@ def contains_nan(vector):
         return any([contains_nan(vector[name]) for name in vector.dtype.names])
     else:
         return np.isnan(np.min(vector))
-
 

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -197,10 +197,7 @@ class ValuesHistory(AbstractParameter):
 
     def __repr__(self):
         return os.linesep.join([
-            'ValuesHistory "{}"'.format(self.name),
-            os.linesep.join([
-                '  {}: {}'.format(value.instant_str, value.value) for value in self.values_list
-                ])
+            '{}: {}'.format(value.instant_str, value.value) for value in self.values_list
             ])
 
     def __eq__(self, other):
@@ -298,6 +295,9 @@ class Parameter(AbstractParameter):
 
     def update(self, **args):
         return self.values_history.update(**args)
+
+    def __repr__(self):
+        return self.values_history.__repr__()
 
 
 class Bracket(AbstractParameter):
@@ -509,6 +509,12 @@ class ParameterNode(AbstractParameter):
         self.children[name] = child
         setattr(self, name, child)
 
+    def __repr__(self):
+        return os.linesep.join(
+            [os.linesep.join(
+                ["{}:", "{}"]).format(name, indent(repr(value))).encode('utf-8')
+                for name, value in self.children.iteritems()]
+            )
 
 def load_parameter_file(file_path, name = ''):
     """
@@ -570,6 +576,12 @@ class ParameterNodeAtInstant(object):
     def __iter__(self):
         return iter(self._children)
 
+    def __repr__(self):
+        return os.linesep.join(
+            [os.linesep.join(
+                ["{}:", "{}"]).format(name, indent(repr(value))).encode('utf-8')
+                for name, value in self._children.iteritems()]
+            )
 
 class VectorialParameterNodeAtInstant(object):
     """
@@ -741,3 +753,7 @@ def contains_nan(vector):
         return any([contains_nan(vector[name]) for name in vector.dtype.names])
     else:
         return np.isnan(np.min(vector))
+
+
+def indent(text):
+    return "  {}".format(text.replace("\n", "\n  "))

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -316,14 +316,23 @@ class Bracket(AbstractParameter):
         self.name = name
         self.file_path = file_path
         self.validate(data)
+        self.children = {}
 
         for key, value in data.items():
             new_child_name = _compose_name(name, key)
             new_child = ValuesHistory(new_child_name, value, file_path)
+            self.children[key] = new_child
             setattr(self, key, new_child)
 
     def _get_at_instant(self, instant_str):
         return BracketAtInstant(self.name, self, instant_str)
+
+    def __repr__(self):
+        return os.linesep.join(
+            [os.linesep.join(
+                ["{}:", "{}"]).format(name, indent(repr(value))).encode('utf-8')
+                for name, value in self.children.iteritems()]
+            )
 
 
 class BracketAtInstant(AbstractParameter):

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -374,6 +374,12 @@ class Scale(AbstractParameter):
         else:
             raise KeyError(key)
 
+    def __repr__(self):
+        return os.linesep.join([
+            '-' + indent(repr(bracket))[1:]
+            for bracket in self.brackets
+            ])
+
 
 def _parse_child(child_name, child, child_path):
     if 'values' in child:

--- a/openfisca_core/periods.py
+++ b/openfisca_core/periods.py
@@ -23,6 +23,8 @@ MONTH = u'month'
 YEAR = u'year'
 ETERNITY = u'eternity'
 
+INSTANT_PATTERN = re.compile('^\d{4}(?:-\d{1,2}){0,2}$')  # matches '2015', '2015-01', '2015-01'
+
 
 def N_(message):
     return message
@@ -697,7 +699,11 @@ def instant(instant):
     """
     if instant is None:
         return None
+    if isinstance(instant, Instant):
+        return instant
     if isinstance(instant, basestring):
+        if not INSTANT_PATTERN.match(instant):
+            raise ValueError("'{}' is not a valid instant. Instants are described using the 'YYYY-MM-DD' format, for instance '2015-06-15'.".format(instant).encode('utf-8'))
         instant = Instant(
             int(fragment)
             for fragment in instant.split(u'-', 2)[:3]

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -339,7 +339,7 @@ class TaxBenefitSystem(object):
 
     def get_parameters_at_instant(self, instant):
         """
-        Compute the parameters of the legislation at a given instant
+        Get the parameters of the legislation at a given instant
 
         :param instant: string of the format 'YYYY-MM-DD' or `openfisca_core.periods.Instant` instance.
         :returns: The parameters of the legislation at a given instant.

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -338,7 +338,8 @@ class TaxBenefitSystem(object):
         return baseline._get_baseline_parameters_at_instant(instant)
 
     def get_parameters_at_instant(self, instant):
-        """Compute the parameters of the legislation at a given instant
+        """
+        Compute the parameters of the legislation at a given instant
 
         :param instant: string of the format 'YYYY-MM-DD' or `openfisca_core.periods.Instant` instance.
         :returns: The parameters of the legislation at a given instant.
@@ -348,7 +349,7 @@ class TaxBenefitSystem(object):
         instant_str = str(instant)
         parameters_at_instant = self._parameters_at_instant_cache.get(instant)
         if parameters_at_instant is None and parameters is not None:
-            parameters_at_instant = parameters._get_at_instant(instant_str)
+            parameters_at_instant = parameters.get_at_instant(instant_str)
             self._parameters_at_instant_cache[instant] = parameters_at_instant
         return parameters_at_instant
 

--- a/openfisca_core/taxscales.py
+++ b/openfisca_core/taxscales.py
@@ -13,6 +13,7 @@ import numpy as np
 from numpy import maximum as max_, minimum as min_
 
 from .commons import empty_clone
+from tools import indent
 
 log = logging.getLogger(__name__)
 
@@ -67,7 +68,6 @@ class AbstractRateTaxScale(AbstractTaxScale):
         self.rates = []
 
     def __repr__(self):
-        from .parameters import indent  # Need to import here to avoid a circular dependency
         return indent(os.linesep.join([
             '- threshold: {}{}  rate: {}'.format(threshold, os.linesep, rate)
             for (threshold, rate) in zip(self.thresholds, self.rates)

--- a/openfisca_core/taxscales.py
+++ b/openfisca_core/taxscales.py
@@ -7,6 +7,7 @@ from bisect import bisect_left, bisect_right
 import copy
 import logging
 import itertools
+import os
 
 import numpy as np
 from numpy import maximum as max_, minimum as min_
@@ -73,6 +74,12 @@ class AbstractRateTaxScale(AbstractTaxScale):
                 for threshold, rate in itertools.izip(self.thresholds, self.rates)
                 ),
             ))
+    def __repr__(self):
+        from .parameters import indent  # Need to import here to avoid a circular dependency
+        return indent(os.linesep.join([
+                '- threshold: {}{}  rate: {}'.format(threshold, os.linesep, rate)
+                for (threshold, rate) in zip(self.thresholds, self.rates)
+                ]))
 
     def add_bracket(self, threshold, rate):
         if threshold in self.thresholds:

--- a/openfisca_core/taxscales.py
+++ b/openfisca_core/taxscales.py
@@ -46,8 +46,8 @@ class AbstractTaxScale(object):
     def __ne__(self, other):
         raise NotImplementedError('Method "__ne__" is not implemented for {}'.format(self.__class__.__name__))
 
-    def __str__(self):
-        raise NotImplementedError('Method "__str__" is not implemented for {}'.format(self.__class__.__name__))
+    def __repr__(self):
+        raise NotImplementedError('Method "__repr__" is not implemented for {}'.format(self.__class__.__name__))
 
     def calc(self, base):
         raise NotImplementedError('Method "calc" is not implemented for {}'.format(self.__class__.__name__))
@@ -66,20 +66,12 @@ class AbstractRateTaxScale(AbstractTaxScale):
         super(AbstractRateTaxScale, self).__init__(name = name, option = option, unit = unit)
         self.rates = []
 
-    def __str__(self):
-        return '\n'.join(itertools.chain(
-            ['{}: {}'.format(self.__class__.__name__, self.name)],
-            (
-                '- {}  {}'.format(threshold, rate)
-                for threshold, rate in itertools.izip(self.thresholds, self.rates)
-                ),
-            ))
     def __repr__(self):
         from .parameters import indent  # Need to import here to avoid a circular dependency
         return indent(os.linesep.join([
-                '- threshold: {}{}  rate: {}'.format(threshold, os.linesep, rate)
-                for (threshold, rate) in zip(self.thresholds, self.rates)
-                ]))
+            '- threshold: {}{}  rate: {}'.format(threshold, os.linesep, rate)
+            for (threshold, rate) in zip(self.thresholds, self.rates)
+            ]))
 
     def add_bracket(self, threshold, rate):
         if threshold in self.thresholds:
@@ -131,14 +123,12 @@ class AmountTaxScale(AbstractTaxScale):
         super(AmountTaxScale, self).__init__(name = name, option = option, unit = unit)
         self.amounts = []
 
-    def __str__(self):
-        return '\n'.join(itertools.chain(
-            ['{}: {}'.format(self.__class__.__name__, self.name)],
-            (
-                '- {}  {}'.format(threshold, amount)
-                for threshold, amount in itertools.izip(self.thresholds, self.amounts)
-                ),
-            ))
+    def __repr__(self):
+        from .parameters import indent  # Need to import here to avoid a circular dependency
+        return indent(os.linesep.join([
+            '- threshold: {}{}  amount: {}'.format(threshold, os.linesep, amount)
+            for (threshold, amount) in zip(self.thresholds, self.amounts)
+            ]))
 
     def add_bracket(self, threshold, amount):
         if threshold in self.thresholds:

--- a/openfisca_core/tools/__init__.py
+++ b/openfisca_core/tools/__init__.py
@@ -2,6 +2,7 @@
 
 import os
 
+
 def assert_near(value, target_value, absolute_error_margin = None, message = '', relative_error_margin = None):
     import numpy as np
 

--- a/openfisca_core/tools/__init__.py
+++ b/openfisca_core/tools/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import os
 
 def assert_near(value, target_value, absolute_error_margin = None, message = '', relative_error_margin = None):
     import numpy as np
@@ -30,6 +31,10 @@ def assert_near(value, target_value, absolute_error_margin = None, message = '',
             assert abs(target_value - value) <= abs(relative_error_margin * target_value), \
                 '{}{} differs from {} with a relative margin {} > {}'.format(message, value, target_value,
                     abs(target_value - value), abs(relative_error_margin * target_value))
+
+
+def indent(text):
+    return "  {}".format(text.replace(os.linesep, "{}  ".format(os.linesep)))
 
 
 def get_trace_tool_link(scenario, variables, api_url, trace_tool_url):

--- a/openfisca_web_api_preview/loader/parameters.py
+++ b/openfisca_web_api_preview/loader/parameters.py
@@ -68,7 +68,7 @@ def walk_node(node, parameters, path_fragments):
             if isinstance(child, Scale):
                 object_transformed['brackets'] = transform_scale(child)
             elif isinstance(child, Parameter):
-                object_transformed['values'] = transform_values_history(child.values_history)
+                object_transformed['values'] = transform_values_history(child)
             parameters.append(object_transformed)
 
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'test': [
             'nose',
             'flake8',
-            'openfisca-country-template == 1.3.0',
+            'openfisca-country-template == 1.3.1',
             'openfisca-extension-template == 1.1.1',
             ],
         'tracker': [

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '18.0.2',
+    version = '18.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/core/parameter_validation/test_parameter_validation.py
+++ b/tests/core/parameter_validation/test_parameter_validation.py
@@ -48,12 +48,12 @@ def test_parsing_errors():
 def test_filesystem_hierarchy():
     path = os.path.join(BASE_DIR, 'filesystem_hierarchy')
     parameters = ParameterNode('', directory_path = path)
-    parameters_at_instant = parameters._get_at_instant('2016-01-01')
+    parameters_at_instant = parameters('2016-01-01')
     assert parameters_at_instant.node1.param == 1.0
 
 
 def test_yaml_hierarchy():
     path = os.path.join(BASE_DIR, 'yaml_hierarchy')
     parameters = ParameterNode('', directory_path = path)
-    parameters_at_instant = parameters._get_at_instant('2016-01-01')
+    parameters_at_instant = parameters('2016-01-01')
     assert parameters_at_instant.node1.param == 1.0

--- a/tests/core/test_parameters.py
+++ b/tests/core/test_parameters.py
@@ -9,7 +9,7 @@ from test_countries import tax_benefit_system
 def test_get_at_instant():
     parameters = tax_benefit_system.parameters
     assert isinstance(parameters, ParameterNode), parameters
-    parameters_at_instant = parameters._get_at_instant('2016-01-01')
+    parameters_at_instant = parameters('2016-01-01')
     assert isinstance(parameters_at_instant, ParameterNodeAtInstant), parameters_at_instant
     assert_equal(parameters_at_instant.taxes.income_tax_rate, 0.15)
     assert_equal(parameters_at_instant.benefits.basic_income, 600)
@@ -53,3 +53,14 @@ def test_stopped_parameter_before_end_value():
 @raises(ParameterNotFound)
 def test_stopped_parameter_after_end_value():
     tax_benefit_system.get_parameters_at_instant('2016-12-01').benefits.housing_allowance
+
+
+def test_parameter_for_period():
+    income_tax_rate = tax_benefit_system.parameters.taxes.income_tax_rate
+    assert_equal(income_tax_rate("2015"), income_tax_rate("2015-01-01"))
+
+
+@raises(ValueError)
+def test_wrong_value():
+    income_tax_rate = tax_benefit_system.parameters.taxes.income_tax_rate
+    income_tax_rate("test")

--- a/tests/web_api/test_helpers.py
+++ b/tests/web_api/test_helpers.py
@@ -18,7 +18,7 @@ def test_transform_values_history():
         '2015-01-01': 0.04,
         '2013-01-01': 0.03,
         }
-    assert_equal(transform_values_history(parameter.values_history), values)
+    assert_equal(transform_values_history(parameter), values)
 
 
 def test_transform_values_history_with_stop_date():
@@ -32,7 +32,7 @@ def test_transform_values_history_with_stop_date():
         '2013-01-01': 0.03,
         }
 
-    assert_equal(transform_values_history(parameter.values_history), values)
+    assert_equal(transform_values_history(parameter), values)
 
 
 def test_get_value():


### PR DESCRIPTION
Depends on https://github.com/openfisca/country-template/pull/23

While working on #573  , I did a few changes to fix some bugs and make navigating the legislation more pleasant. I didn't include it in #575 to stay focused, but here they are 🙂 .

# Changes

- Improve the representations of parameters when navigating the legislation in Python.

For instance:
```
tax_benefit_system.parameters.benefits

>>> basic_income:
>>>   2015-12-01: 600.0
>>> housing_allowance:
>>>   2016-12-01: None
>>>   2010-01-01: 0.25
```

- Be more flexible about parameters definitions

The two following expressions are for instance striclty equivalent:

```
Parameter("taux", {"2015-01-01": 2000})
Parameter("taux", {"values": {"2015-01-01":{"value": 2000}}})
```

- Request parameter at a given date with the `parameters.benefits('2015-07-01')` notation.
- Make sure `parameters.benefits('2015-07-01')` and `parameters.benefits('2015-07')` return the same value.
- Raise an error when calling `parameters.benefits('invalid_key')`.
- Improve errors when `parameter.update` is used with wrong arguments