### PR TITLE
Clean references to old api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,7 @@ test:
 	flake8
 	nosetests
 
+# To activate the Piwik tracking, configure TRACKER_URL and TRACKER_IDSITE variables.
+# For more information: https://github.com/openfisca/tracker/blob/master/README.md
 api:
-	COUNTRY_PACKAGE=openfisca_country_template TRACKER_URL="https://openfisca.innocraft.cloud/piwik.php" TRACKER_IDSITE=1 gunicorn "openfisca_web_api_preview.app:create_app()" --bind localhost:5000 --workers 3
+	COUNTRY_PACKAGE=openfisca_country_template gunicorn "openfisca_web_api_preview.app:create_app()" --bind localhost:5000 --workers 3

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,5 @@ test:
 	flake8
 	nosetests
 
-# To activate the Piwik tracking, configure TRACKER_URL and TRACKER_IDSITE variables.
-# For more information: https://github.com/openfisca/tracker/blob/master/README.md
 api:
 	COUNTRY_PACKAGE=openfisca_country_template gunicorn "openfisca_web_api_preview.app:create_app()" --bind localhost:5000 --workers 3

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Test it by running:
 ```sh
 curl http://localhost:5000/parameters
 ```
-For more information about endpoints and input formatting, see the [official documentation](http://openfisca.org/doc/openfisca-web-api/index.html).
+For more information about endpoints and input formatting, see the [official documentation](http://openfisca.org/doc/openfisca-web-api).
 
 ### Tracker
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,14 @@ OpenFisca-Core provides a Web-API. To run it with the mock country package `open
 COUNTRY_PACKAGE=openfisca_country_template gunicorn "openfisca_web_api_preview.app:create_app()" --bind localhost:5000 --workers 3
 ```
 
-The `--workers k` (with `k >= 3`) option is necessary to avoid [this issue](http://stackoverflow.com/questions/11150343/slow-requests-on-local-flask-server). Without it, AJAX requests from Chrome sometimes take more than 20s to process.
+The `--workers k` (with `k >= 3`) option is necessary to avoid [this issue](http://stackoverflow.com/questions/11150343/slow-requests-on-local-flask-server). Without it, AJAX requests from Chrome sometimes take more than 20s to process.  
+
+Test it by running:
+
+```sh
+curl http://localhost:5000/parameters
+```
+For more information about endpoints and input formatting, see the [official documentation](http://openfisca.org/doc/openfisca-web-api/index.html).
 
 ### Tracker
 

--- a/deploy-if-version-bump.sh
+++ b/deploy-if-version-bump.sh
@@ -6,7 +6,7 @@ if ! git rev-parse `python setup.py --version` 2>/dev/null ; then
     git push --tags  # update the repository version
     python setup.py bdist_wheel  # build this package in the dist directory
     twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD  # publish
-    ssh deploy-new-api@api-test.openfisca.fr
+    ssh deploy-new-api@fr.openfisca.org
 else
     echo "No deployment - Only non-functional elements were modified in this change"
 fi


### PR DESCRIPTION
Connected to #577 

#### Technical change

- Stop deployment on `api-test.openfisca.fr`.
  - The functionality is now provided by `fr.openfisca.org`
