### PR TITLE
Track IPs from API visitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 17.2.1 [#581](https://github.com/openfisca/openfisca-core/pull/581)
+
+- Add the possibility to track API visitor's IP
+
 ## 17.2.0 [#570](https://github.com/openfisca/openfisca-core/pull/570)
 
 - Enable to calculate parameters according to a variable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ For more information, check the [documentation](http://openfisca.org/doc/coding-
   <NODE code="root">
     <NODE code="impot">
       <CODE code="taux" description="" format="percent">
-        <END deb="2016-01-01"/>   
+        <END deb="2016-01-01"/>
         <VALUE deb="2015-01-01" valeur="0.32" />
         <VALUE deb="1998-01-01" valeur="0.3" />
       </CODE>

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The tracker is activated when these two environment variables are set:
 
 * `TRACKER_URL`: An URL ending with `piwik.php`. It defines the Piwik instance that will receive the tracking information. To use the main OpenFisca Piwik instance, use `https://stats.data.gouv.fr/piwik.php`.
 * `TRACKER_IDSITE`: An integer. It defines the identifier of the tracked site on your Piwik instance. To use the main OpenFisca piwik instance, use `4`.
+* `TRACKER_TOKEN`: A string. It defines the Piwik API Authentification token to differentiate API calls based on the user IP. Otherwise, all API calls will seem to come from your server. The Piwik API Authentification token can be found in your Piwik interface, when you are logged.
 
 For instance, to run the Web API with the mock country package `openfisca_country_template` and the tracker activated, run:
 

--- a/openfisca_web_api_preview/app.py
+++ b/openfisca_web_api_preview/app.py
@@ -128,7 +128,7 @@ def create_app(country_package = os.environ.get('COUNTRY_PACKAGE'),
     @app.after_request
     def track_requests(response):
         if tracker:
-            tracker.track(request.url)
+            tracker.track(request.url, request.remote_addr)
         return response
 
     @app.errorhandler(500)

--- a/openfisca_web_api_preview/app.py
+++ b/openfisca_web_api_preview/app.py
@@ -129,7 +129,10 @@ def create_app(country_package = os.environ.get('COUNTRY_PACKAGE'),
     @app.after_request
     def track_requests(response):
         if tracker:
-            tracker.track(request.url, request.remote_addr)
+            if request.headers.get('dnt'):
+                tracker.track(request.url)
+            else:
+                tracker.track(request.url, request.remote_addr)
         return response
 
     @app.errorhandler(500)

--- a/openfisca_web_api_preview/app.py
+++ b/openfisca_web_api_preview/app.py
@@ -16,10 +16,10 @@ import logging
 log = logging.getLogger('gunicorn.error')
 
 
-def init_tracker(url, idsite):
+def init_tracker(url, idsite, tracker_token):
     try:
         from openfisca_tracker.piwik import PiwikTracker
-        tracker = PiwikTracker(url, idsite)
+        tracker = PiwikTracker(url, idsite, tracker_token)
 
         info = linesep.join([u'You chose to activate the `tracker` module. ',
                              u'Tracking data will be sent to: ' + url,
@@ -36,6 +36,7 @@ def init_tracker(url, idsite):
 
 def create_app(country_package = os.environ.get('COUNTRY_PACKAGE'),
                tracker_url = os.environ.get('TRACKER_URL'),
+               tracker_token = os.environ.get('TRACKER_TOKEN'),
                tracker_idsite = os.environ.get('TRACKER_IDSITE')):
     if country_package is None:
         raise ValueError(
@@ -47,7 +48,7 @@ def create_app(country_package = os.environ.get('COUNTRY_PACKAGE'),
     if not tracker_url or not tracker_idsite:
         tracker = None
     else:
-        tracker = init_tracker(tracker_url, tracker_idsite)
+        tracker = init_tracker(tracker_url, tracker_idsite, tracker_token)
 
     app = Flask(__name__)
     CORS(app, origins = '*')

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '17.2.0',
+    version = '17.2.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Connected to openfisca/openfisca-france#821

#### Technical changes

- By adding your Piwik AUTH token to the gunicorn environment variable when serving the API, you can track your API visitor's by IP on Piwik