### PR TITLE
Serve extensions in the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 
-## 19.0.0 [#583](https://github.com/openfisca/openfisca-core/pull/583)
+# 19.0.0 [#583](https://github.com/openfisca/openfisca-core/pull/583)
 
-- Rename serving option `--country_package` to `--country-package`
-- Introduce `openfisca serve` command to serve the new API
-  - Read more in the [doc](https://openfisca.readthedocs.io/en/latest/openfisca_serve.html)
-- Handle reforms and extensions in the new API
+#### Breaking changes
+
+- Change the way the API is started
+  * The previous command `COUNTRY_PACKAGE=openfisca_country gunicorn ...` does not work anymore 
+  * The new command to serve the API is `openfisca serve`.
+    * Read more in the [doc](https://openfisca.readthedocs.io/en/latest/openfisca_serve.html)
+    * This command allows to serve reforms and extensions in the new API
+
+- In `openfisca-run-test` and `openfisca-serve`, rename option `--country_package` to `--country-package`
 
 ## 18.1.0 [#578](https://github.com/openfisca/openfisca-core/pull/578)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 18.2.0 [#583](https://github.com/openfisca/openfisca-core/pull/583)
+
+- Introduce `openfisca serve` command to serve the new API
+  - Read more in the [doc](https://openfisca.readthedocs.io/en/latest/openfisca_serve.html)
+- Handle reforms and extensions in the new API
+
 ## 18.1.0 [#578](https://github.com/openfisca/openfisca-core/pull/578)
 
 #### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 18.2.0 [#583](https://github.com/openfisca/openfisca-core/pull/583)
+## 19.0.0 [#583](https://github.com/openfisca/openfisca-core/pull/583)
 
+- Rename serving option `--country_package` to `--country-package`
 - Introduce `openfisca serve` command to serve the new API
   - Read more in the [doc](https://openfisca.readthedocs.io/en/latest/openfisca_serve.html)
 - Handle reforms and extensions in the new API

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ test:
 	nosetests
 
 api:
-	COUNTRY_PACKAGE=openfisca_country_template gunicorn "openfisca_web_api_preview.app:create_app()" --bind localhost:5000 --workers 3
+	openfisca-serve -c openfisca_country_template -e openfisca_extension_template

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ test:
 	nosetests
 
 api:
-	openfisca-serve -c openfisca_country_template -e openfisca_extension_template
+	openfisca-serve --country_package openfisca_country_template --extensions openfisca_extension_template

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ test:
 	nosetests
 
 api:
-	openfisca-serve --country_package openfisca_country_template --extensions openfisca_extension_template
+	openfisca serve --country-package openfisca_country_template --extensions openfisca_extension_template

--- a/README.md
+++ b/README.md
@@ -31,12 +31,14 @@ make test
 OpenFisca-Core provides a Web-API. To run it with the mock country package `openfisca_country_template`, run:
 
 ```sh
-COUNTRY_PACKAGE=openfisca_country_template gunicorn "openfisca_web_api_preview.app:create_app()" --bind localhost:5000 --workers 3
+openfisca serve --country_package openfisca_country_template --port 5000
 ```
 
-The `--workers k` (with `k >= 3`) option is necessary to avoid [this issue](http://stackoverflow.com/questions/11150343/slow-requests-on-local-flask-server). Without it, AJAX requests from Chrome sometimes take more than 20s to process.  
+To read more about the `openfisca serve` command, check out its [documentation](https://openfisca.readthedocs.io/en/latest/openfisca_serve.html).
 
-Test it by running:
+By default, the Web API uses 3 workers to avoid [this issue](http://stackoverflow.com/questions/11150343/slow-requests-on-local-flask-server). Without it, AJAX requests from Chrome sometimes take more than 20s to process. You can change the number of workers by specifying a `--workers k` option.
+
+You can test that the API is running by executing the command:
 
 ```sh
 curl http://localhost:5000/parameters
@@ -58,14 +60,14 @@ pip install openfisca_core[tracker]  # Or `pip install --editable ".[tracker]"` 
 
 #### Tracker configuration
 
-The tracker is activated when these two environment variables are set:
+The tracker is activated when these two options are set:
 
-* `TRACKER_URL`: An URL ending with `piwik.php`. It defines the Piwik instance that will receive the tracking information. To use the main OpenFisca Piwik instance, use `https://stats.data.gouv.fr/piwik.php`.
-* `TRACKER_IDSITE`: An integer. It defines the identifier of the tracked site on your Piwik instance. To use the main OpenFisca piwik instance, use `4`.
-* `TRACKER_TOKEN`: A string. It defines the Piwik API Authentification token to differentiate API calls based on the user IP. Otherwise, all API calls will seem to come from your server. The Piwik API Authentification token can be found in your Piwik interface, when you are logged.
+* `--tracker-url`: An URL ending with `piwik.php`. It defines the Piwik instance that will receive the tracking information. To use the main OpenFisca Piwik instance, use `https://stats.data.gouv.fr/piwik.php`.
+* `--tracker-idsite`: An integer. It defines the identifier of the tracked site on your Piwik instance. To use the main OpenFisca piwik instance, use `4`.
+* `--tracker-token`: A string. It defines the Piwik API Authentification token to differentiate API calls based on the user IP. Otherwise, all API calls will seem to come from your server. The Piwik API Authentification token can be found in your Piwik interface, when you are logged.
 
 For instance, to run the Web API with the mock country package `openfisca_country_template` and the tracker activated, run:
 
 ```sh
-COUNTRY_PACKAGE=openfisca_country_template TRACKER_URL="https://stats.data.gouv.fr/piwik.php" TRACKER_IDSITE=4 gunicorn "openfisca_web_api_preview.app:create_app()" --bind localhost:5000 --workers 3
+openfisca serve --country_package openfisca_country_template --port 5000 --tracker-url https://stats.data.gouv.fr/piwik.php --tracker-idsite 4 --tracker-token $TRACKER_TOKEN
 ```

--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ make test
 
 ## Serving the API
 
-OpenFisca-Core provides a Web-API. To run it with the mock country package `openfisca_country_template`, run:
+OpenFisca-Core provides a Web-API. It is served on the `6000` port.  
+To run it with the mock country package `openfisca_country_template` and another port value as `5000`, run:
 
 ```sh
-openfisca serve --country_package openfisca_country_template --port 5000
+openfisca serve --country-package openfisca_country_template --port 5000
 ```
 
 To read more about the `openfisca serve` command, check out its [documentation](https://openfisca.readthedocs.io/en/latest/openfisca_serve.html).
@@ -69,5 +70,5 @@ The tracker is activated when these two options are set:
 For instance, to run the Web API with the mock country package `openfisca_country_template` and the tracker activated, run:
 
 ```sh
-openfisca serve --country_package openfisca_country_template --port 5000 --tracker-url https://stats.data.gouv.fr/piwik.php --tracker-idsite 4 --tracker-token $TRACKER_TOKEN
+openfisca serve --country-package openfisca_country_template --port 5000 --tracker-url https://stats.data.gouv.fr/piwik.php --tracker-idsite 4 --tracker-token $TRACKER_TOKEN
 ```

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -18,6 +18,7 @@ Scripts:
    :maxdepth: 1
 
    openfisca-run-test
+   openfisca_serve
 
 Indices and tables
 ==================

--- a/doc/source/openfisca_serve.rst
+++ b/doc/source/openfisca_serve.rst
@@ -1,0 +1,62 @@
+===============
+openfisca serve
+===============
+
+.. argparse::
+   :module: openfisca_core.scripts.openfisca_command
+   :func: get_parser
+   :prog: openfisca
+   :path: serve
+
+Additional arguments
+--------------------
+
+``openfisca serve`` uses ``gunicorn`` under the hood. In addition to the arguments listed above, you can use any ``gunicorn`` arguments when running ``openfisca serve`` (e.g. ``--reload``, ``--workers``, ``--timeout``).
+
+Examples
+--------
+
+Basic use
+^^^^^^^^^
+
+.. code-block:: shell
+
+  openfisca serve --country_package openfisca_france
+
+
+Serving extensions
+^^^^^^^^^^^^^^^^^^
+
+.. code-block:: shell
+
+  openfisca serve --country_package openfisca_france --extensions openfisca_paris
+
+
+Serving reforms
+^^^^^^^^^^^^^^^
+
+.. code-block:: shell
+
+  openfisca serve --country_package openfisca_france --reforms openfisca_france.reforms.plf2015.plf2015
+
+
+Using a configuration file
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**config.py:**
+
+.. code-block:: py
+
+  port = 4000
+  workers = 4
+  country_package = 'openfisca_france'
+  extensions = ['openfisca_paris']
+
+**Command line:**
+
+.. code-block:: shell
+
+  openfisca serve --configuration-file config.py
+
+
+

--- a/doc/source/openfisca_serve.rst
+++ b/doc/source/openfisca_serve.rst
@@ -21,7 +21,7 @@ Basic use
 
 .. code-block:: shell
 
-  openfisca serve --country_package openfisca_france
+  openfisca serve --country-package openfisca_france
 
 
 Serving extensions
@@ -29,7 +29,7 @@ Serving extensions
 
 .. code-block:: shell
 
-  openfisca serve --country_package openfisca_france --extensions openfisca_paris
+  openfisca serve --country-package openfisca_france --extensions openfisca_paris
 
 
 Serving reforms
@@ -37,7 +37,7 @@ Serving reforms
 
 .. code-block:: shell
 
-  openfisca serve --country_package openfisca_france --reforms openfisca_france.reforms.plf2015.plf2015
+  openfisca serve --country-package openfisca_france --reforms openfisca_france.reforms.plf2015.plf2015
 
 
 Using a configuration file
@@ -49,7 +49,7 @@ Using a configuration file
 
   port = 4000
   workers = 4
-  country_package = 'openfisca_france'
+  country-package = 'openfisca_france'
   extensions = ['openfisca_paris']
 
 **Command line:**

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -22,7 +22,7 @@ try:
     from yaml import CLoader as Loader
 except ImportError:
     log.warning(
-        "libyaml is not installed in your environement. This can make OpenFisca slower to start. Once you have installed libyaml, run 'pip uninstall pyyaml && pip install pyyaml' so that it is used in your Python environement.")
+        "libyaml is not installed in your environement. This can make OpenFisca slower to start. Once you have installed libyaml, run 'pip uninstall pyyaml && pip install pyyaml' so that it is used in your Python environement." + os.linesep)
     from yaml import Loader
 
 

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -16,15 +16,9 @@ def handle_error(error_message):
     sys.exit(1)
 
 
-def add_minimal_tax_benefit_system_arguments(parser):
+def add_tax_benefit_system_arguments(parser):
     parser.add_argument('-c', '--country_package', action = 'store', help = u'country package to use. If not provided, an automatic detection will be attempted by scanning the python packages installed in your environment which name contains the word "openfisca".')
     parser.add_argument('-e', '--extensions', action = 'store', help = u'extensions to load', nargs = '*')
-
-    return parser
-
-
-def add_tax_benefit_system_arguments(parser):
-    parser = add_minimal_tax_benefit_system_arguments(parser)
     parser.add_argument('-r', '--reforms', action = 'store', help = u'reforms to apply to the country package', nargs = '*')
 
     return parser

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -17,7 +17,7 @@ def handle_error(error_message):
 
 
 def add_tax_benefit_system_arguments(parser):
-    parser.add_argument('-c', '--country_package', action = 'store', help = u'country package to use. If not provided, an automatic detection will be attempted by scanning the python packages installed in your environment which name contains the word "openfisca".')
+    parser.add_argument('-c', '--country-package', action = 'store', help = u'country package to use. If not provided, an automatic detection will be attempted by scanning the python packages installed in your environment which name contains the word "openfisca".')
     parser.add_argument('-e', '--extensions', action = 'store', help = u'extensions to load', nargs = '*')
     parser.add_argument('-r', '--reforms', action = 'store', help = u'reforms to apply to the country package', nargs = '*')
 
@@ -73,7 +73,7 @@ def detect_country_package():
                 installed_country_packages.append(module_name)
 
     if len(installed_country_packages) == 0:
-        handle_error(u'No country package has been detected on your environment. If your country package is installed but not detected, please use the --country_package option.')
+        handle_error(u'No country package has been detected on your environment. If your country package is installed but not detected, please use the --country-package option.')
     if len(installed_country_packages) > 1:
-        log.warning(u'Several country packages detected : `{}`. Using `{}` by default. To use another package, please use the --country_package option.'.format(', '.join(installed_country_packages), installed_country_packages[0]))
+        log.warning(u'Several country packages detected : `{}`. Using `{}` by default. To use another package, please use the --country-package option.'.format(', '.join(installed_country_packages), installed_country_packages[0]))
     return installed_country_packages[0]

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -29,6 +29,7 @@ def add_tax_benefit_system_arguments(parser):
 
     return parser
 
+
 def build_tax_benefit_system(country_package_name, extensions, reforms):
     if country_package_name is None:
         country_package_name = detect_country_package()

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -16,9 +16,15 @@ def handle_error(error_message):
     sys.exit(1)
 
 
-def add_tax_benefit_system_arguments(parser):
+def add_minimal_tax_benefit_system_arguments(parser):
     parser.add_argument('-c', '--country_package', action = 'store', help = u'country package to use. If not provided, an automatic detection will be attempted by scanning the python packages installed in your environment which name contains the word "openfisca".')
     parser.add_argument('-e', '--extensions', action = 'store', help = u'extensions to load', nargs = '*')
+
+    return parser
+
+
+def add_tax_benefit_system_arguments(parser):
+    parser = add_minimal_tax_benefit_system_arguments(parser)
     parser.add_argument('-r', '--reforms', action = 'store', help = u'reforms to apply to the country package', nargs = '*')
 
     return parser

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -29,8 +29,7 @@ def add_tax_benefit_system_arguments(parser):
 
     return parser
 
-
-def build_tax_benefit_sytem(country_package_name, extensions, reforms):
+def build_tax_benefit_system(country_package_name, extensions, reforms):
     if country_package_name is None:
         country_package_name = detect_country_package()
     try:
@@ -57,6 +56,10 @@ def build_tax_benefit_sytem(country_package_name, extensions, reforms):
             tax_benefit_system = tax_benefit_system.apply_reform(reform_path)
 
     return tax_benefit_system
+
+
+# For retro-compatibility:
+build_tax_benefit_sytem = build_tax_benefit_system
 
 
 def detect_country_package():

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -4,16 +4,10 @@ import traceback
 import importlib
 import logging
 import pkgutil
-import sys
 from os import linesep
 
 log = logging.getLogger(__name__)
 logging.basicConfig(format='%(levelname)s: %(message)s')
-
-
-def handle_error(error_message):
-    log.error(error_message)
-    sys.exit(1)
 
 
 def add_tax_benefit_system_arguments(parser):
@@ -35,9 +29,9 @@ def build_tax_benefit_system(country_package_name, extensions, reforms):
                                 u'Are you sure it is installed in your environment? If so, look at the stack trace above to determine the origin of this error.',
                                 u'See more at <https://github.com/openfisca/country-template#installing>.'])
 
-        handle_error(message)
+        raise ImportError(message)
     if not hasattr(country_package, 'CountryTaxBenefitSystem'):
-        handle_error(u'`{}` does not seem to be a valid Openfisca country package.'.format(country_package_name))
+        raise ImportError(u'`{}` does not seem to be a valid Openfisca country package.'.format(country_package_name))
 
     country_package = importlib.import_module(country_package_name)
     tax_benefit_system = country_package.CountryTaxBenefitSystem()
@@ -68,12 +62,12 @@ def detect_country_package():
                 message = linesep.join([traceback.format_exc(),
                                         u'Could not import module `{}`.'.format(module_name),
                                         u'Look at the stack trace above to determine the error that stopped installed modules detection.'])
-                handle_error(message)
+                raise ImportError(message)
             if hasattr(module, 'CountryTaxBenefitSystem'):
                 installed_country_packages.append(module_name)
 
     if len(installed_country_packages) == 0:
-        handle_error(u'No country package has been detected on your environment. If your country package is installed but not detected, please use the --country-package option.')
+        raise ImportError(u'No country package has been detected on your environment. If your country package is installed but not detected, please use the --country-package option.')
     if len(installed_country_packages) > 1:
         log.warning(u'Several country packages detected : `{}`. Using `{}` by default. To use another package, please use the --country-package option.'.format(', '.join(installed_country_packages), installed_country_packages[0]))
     return installed_country_packages[0]

--- a/openfisca_core/scripts/openfisca_command.py
+++ b/openfisca_core/scripts/openfisca_command.py
@@ -1,0 +1,23 @@
+import argparse
+import sys
+
+from openfisca_web_api_preview.scripts.serve import define_command_line_options, main as serve
+
+
+"""
+    Define the `openfisca` command line interface.
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    subparsers = parser.add_subparsers(help='Available commands')
+    parser_serve = subparsers.add_parser('serve', help='Run the OpenFisca Web API')
+    parser_serve = define_command_line_options(parser_serve)
+
+    sys.exit(serve(parser))
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/openfisca_core/scripts/openfisca_command.py
+++ b/openfisca_core/scripts/openfisca_command.py
@@ -9,13 +9,18 @@ from openfisca_web_api_preview.scripts.serve import define_command_line_options,
 """
 
 
-def main():
+def get_parser():
     parser = argparse.ArgumentParser()
 
     subparsers = parser.add_subparsers(help='Available commands')
     parser_serve = subparsers.add_parser('serve', help='Run the OpenFisca Web API')
     parser_serve = define_command_line_options(parser_serve)
 
+    return parser
+
+
+def main():
+    parser = get_parser()
     sys.exit(serve(parser))
 
 

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -6,7 +6,7 @@ import sys
 import os
 
 from openfisca_core.tools.test_runner import run_tests
-from openfisca_core.scripts import add_tax_benefit_system_arguments, build_tax_benefit_sytem
+from openfisca_core.scripts import add_tax_benefit_system_arguments, build_tax_benefit_system
 
 
 def build_parser():
@@ -24,7 +24,7 @@ def main():
     args = parser.parse_args()
     logging.basicConfig(level = logging.DEBUG if args.verbose else logging.WARNING, stream = sys.stdout)
 
-    tax_benefit_system = build_tax_benefit_sytem(args.country_package, args.extensions, args.reforms)
+    tax_benefit_system = build_tax_benefit_system(args.country_package, args.extensions, args.reforms)
 
     options = {
         'verbose': args.verbose,

--- a/openfisca_web_api_preview/app.py
+++ b/openfisca_web_api_preview/app.py
@@ -36,9 +36,11 @@ def init_tracker(url, idsite, tracker_token):
 
 
 def create_app(country_package = os.environ.get('COUNTRY_PACKAGE'),
+               extensions = os.environ.get('EXTENSIONS'),
                tracker_url = os.environ.get('TRACKER_URL'),
                tracker_token = os.environ.get('TRACKER_TOKEN'),
                tracker_idsite = os.environ.get('TRACKER_IDSITE')):
+
     if country_package is None:
         raise ValueError(
             u"You must specify a country package to start the API. "
@@ -57,7 +59,7 @@ def create_app(country_package = os.environ.get('COUNTRY_PACKAGE'),
 
     app.url_map.strict_slashes = False  # Accept url like /parameters/
 
-    data = build_data(country_package)
+    data = build_data(country_package, extensions)
 
     @app.route('/parameters')
     def get_parameters():

--- a/openfisca_web_api_preview/app.py
+++ b/openfisca_web_api_preview/app.py
@@ -36,10 +36,11 @@ def init_tracker(url, idsite, tracker_token):
 
 
 def create_app(country_package,
-               extensions,
-               tracker_url,
-               tracker_idsite,
-               tracker_token):
+               extensions = None,
+               tracker_url = None,
+               tracker_idsite = None,
+               tracker_token = None
+               ):
 
     if country_package is None:
         raise ValueError(

--- a/openfisca_web_api_preview/app.py
+++ b/openfisca_web_api_preview/app.py
@@ -36,14 +36,11 @@ def init_tracker(url, idsite, tracker_token):
         log.warn(message)
 
 
-def create_app(country_package,
-               extensions = None,
+def create_app(tax_benefit_system,
                tracker_url = None,
                tracker_idsite = None,
                tracker_token = None
                ):
-
-    # country_package defined here or detected in openfisca_core.scripts.build_tax_benefit_system.
 
     if not tracker_url or not tracker_idsite:
         tracker = None
@@ -56,7 +53,7 @@ def create_app(country_package,
 
     app.url_map.strict_slashes = False  # Accept url like /parameters/
 
-    data = build_data(country_package, extensions)
+    data = build_data(tax_benefit_system)
 
     @app.route('/parameters')
     def get_parameters():

--- a/openfisca_web_api_preview/app.py
+++ b/openfisca_web_api_preview/app.py
@@ -37,9 +37,9 @@ def init_tracker(url, idsite, tracker_token):
 
 def create_app(country_package,
                extensions,
-               tracker_url = os.environ.get('TRACKER_URL'),
-               tracker_token = os.environ.get('TRACKER_TOKEN'),
-               tracker_idsite = os.environ.get('TRACKER_IDSITE')):
+               tracker_url,
+               tracker_idsite,
+               tracker_token):
 
     if country_package is None:
         raise ValueError(

--- a/openfisca_web_api_preview/app.py
+++ b/openfisca_web_api_preview/app.py
@@ -6,9 +6,12 @@ from flask import Flask, jsonify, abort, request, make_response
 from werkzeug.contrib.fixers import ProxyFix
 from flask_cors import CORS
 import dpath
+import importlib
 
 from openfisca_core.simulations import Simulation, SituationParsingError
+from openfisca_core.scripts import detect_country_package
 from openfisca_core.columns import EnumCol
+
 from loader import build_data
 import traceback
 import logging
@@ -42,12 +45,7 @@ def create_app(country_package,
                tracker_token = None
                ):
 
-    if country_package is None:
-        raise ValueError(
-            u"You must specify a country package with `-c` option to start the API. "
-            u"For instance, `-c openfisca_france`"
-            .encode('utf-8')
-            )
+    # country_package defined here or detected in openfisca_core.scripts.build_tax_benefit_system.
 
     if not tracker_url or not tracker_idsite:
         tracker = None

--- a/openfisca_web_api_preview/app.py
+++ b/openfisca_web_api_preview/app.py
@@ -35,16 +35,16 @@ def init_tracker(url, idsite, tracker_token):
         log.warn(message)
 
 
-def create_app(country_package = os.environ.get('COUNTRY_PACKAGE'),
-               extensions = os.environ.get('EXTENSIONS'),
+def create_app(country_package,
+               extensions,
                tracker_url = os.environ.get('TRACKER_URL'),
                tracker_token = os.environ.get('TRACKER_TOKEN'),
                tracker_idsite = os.environ.get('TRACKER_IDSITE')):
 
     if country_package is None:
         raise ValueError(
-            u"You must specify a country package to start the API. "
-            u"For instance, `COUNTRY_PACKAGE=openfisca_france flask run`"
+            u"You must specify a country package with `-c` option to start the API. "
+            u"For instance, `-c openfisca_france`"
             .encode('utf-8')
             )
 

--- a/openfisca_web_api_preview/app.py
+++ b/openfisca_web_api_preview/app.py
@@ -6,10 +6,8 @@ from flask import Flask, jsonify, abort, request, make_response
 from werkzeug.contrib.fixers import ProxyFix
 from flask_cors import CORS
 import dpath
-import importlib
 
 from openfisca_core.simulations import Simulation, SituationParsingError
-from openfisca_core.scripts import detect_country_package
 from openfisca_core.columns import EnumCol
 
 from loader import build_data

--- a/openfisca_web_api_preview/loader/__init__.py
+++ b/openfisca_web_api_preview/loader/__init__.py
@@ -16,13 +16,14 @@ def extract_description(items):
 def build_data(country_package_name, extensions):
     tax_benefit_system = build_tax_benefit_system(country_package_name)
     country_package_metadata = tax_benefit_system.get_package_metadata()
-    parameters = build_parameters(tax_benefit_system)
-    variables = build_variables(tax_benefit_system, country_package_metadata)
-    
+
     if extensions is not None:
         for extension in extensions:
             tax_benefit_system.load_extension(extension)
-    
+
+    parameters = build_parameters(tax_benefit_system)
+    variables = build_variables(tax_benefit_system, country_package_metadata)
+
     openAPI_spec = build_openAPI_specification(tax_benefit_system, country_package_metadata)
     return {
         'tax_benefit_system': tax_benefit_system,

--- a/openfisca_web_api_preview/loader/__init__.py
+++ b/openfisca_web_api_preview/loader/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from tax_benefit_system import build_tax_benefit_system
+# from tax_benefit_system import build_tax_benefit_system
+from openfisca_core.scripts import build_tax_benefit_system
 from parameters import build_parameters
 from variables import build_variables
 from spec import build_openAPI_specification
@@ -14,12 +15,8 @@ def extract_description(items):
 
 
 def build_data(country_package_name, extensions):
-    tax_benefit_system = build_tax_benefit_system(country_package_name)
+    tax_benefit_system = build_tax_benefit_system(country_package_name, extensions, reforms = None)
     country_package_metadata = tax_benefit_system.get_package_metadata()
-
-    if extensions is not None:
-        for extension in extensions:
-            tax_benefit_system.load_extension(extension)
 
     parameters = build_parameters(tax_benefit_system)
     variables = build_variables(tax_benefit_system, country_package_metadata)

--- a/openfisca_web_api_preview/loader/__init__.py
+++ b/openfisca_web_api_preview/loader/__init__.py
@@ -13,11 +13,16 @@ def extract_description(items):
         }
 
 
-def build_data(country_package_name):
+def build_data(country_package_name, extensions):
     tax_benefit_system = build_tax_benefit_system(country_package_name)
     country_package_metadata = tax_benefit_system.get_package_metadata()
     parameters = build_parameters(tax_benefit_system)
     variables = build_variables(tax_benefit_system, country_package_metadata)
+    
+    if extensions is not None:
+        for extension in extensions:
+            tax_benefit_system.load_extension(extension)
+    
     openAPI_spec = build_openAPI_specification(tax_benefit_system, country_package_metadata)
     return {
         'tax_benefit_system': tax_benefit_system,

--- a/openfisca_web_api_preview/loader/__init__.py
+++ b/openfisca_web_api_preview/loader/__init__.py
@@ -17,10 +17,8 @@ def extract_description(items):
 def build_data(country_package_name, extensions):
     tax_benefit_system = build_tax_benefit_system(country_package_name, extensions, reforms = None)
     country_package_metadata = tax_benefit_system.get_package_metadata()
-
     parameters = build_parameters(tax_benefit_system)
     variables = build_variables(tax_benefit_system, country_package_metadata)
-
     openAPI_spec = build_openAPI_specification(tax_benefit_system, country_package_metadata)
     return {
         'tax_benefit_system': tax_benefit_system,

--- a/openfisca_web_api_preview/loader/__init__.py
+++ b/openfisca_web_api_preview/loader/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-# from tax_benefit_system import build_tax_benefit_system
 from openfisca_core.scripts import build_tax_benefit_system
 from parameters import build_parameters
 from variables import build_variables

--- a/openfisca_web_api_preview/loader/__init__.py
+++ b/openfisca_web_api_preview/loader/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from openfisca_core.scripts import build_tax_benefit_system
 from parameters import build_parameters
 from variables import build_variables
 from spec import build_openAPI_specification
@@ -13,8 +12,7 @@ def extract_description(items):
         }
 
 
-def build_data(country_package_name, extensions):
-    tax_benefit_system = build_tax_benefit_system(country_package_name, extensions, reforms = None)
+def build_data(tax_benefit_system):
     country_package_metadata = tax_benefit_system.get_package_metadata()
     parameters = build_parameters(tax_benefit_system)
     variables = build_variables(tax_benefit_system, country_package_metadata)

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import argparse
+from wsgiref.simple_server import make_server
+
+from openfisca_core.scripts import add_tax_benefit_system_arguments, detect_country_package
+
+from ..application import make_app
+
+HOST_NAME = 'localhost'
+BASE_CONF = {
+    'debug': 'true',
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-p', '--port', action = 'store', default = 2000, help = "port to serve on", type = int)
+    parser = add_tax_benefit_system_arguments(parser)
+    args = parser.parse_args()
+
+    conf = BASE_CONF.copy()
+    conf['country_package'] = args.country_package or detect_country_package()
+    if args.extensions:
+        # The api excepts the extensions and reforms to be separated by line breaks in the conf
+        conf['extensions'] = os.linesep.join(args.extensions)
+    if args.reforms:
+        conf['reforms'] = os.linesep.join(args.reforms)
+
+    app = make_app({}, **conf)
+    httpd = make_server(HOST_NAME, args.port, app)
+    print u'Serving on http://{}:{}/'.format(HOST_NAME, args.port)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        return
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 
-import os
 import sys
 import argparse
 from gunicorn.app.base import BaseApplication
 from gunicorn.six import iteritems
 
-from openfisca_core.scripts import add_tax_benefit_system_arguments, detect_country_package
+from openfisca_core.scripts import add_minimal_tax_benefit_system_arguments
 from ..app import create_app
 
 
@@ -14,19 +13,32 @@ DEFAULT_PORT = '5000'
 BASE_CONF = {
     'bind': '%s:%s' % ('127.0.0.1', DEFAULT_PORT),
     'workers': '3',
-}
+    }
+
+BASE_CONF_FILE = "./server_configuration.py"
 
 
 def new_configured_app():
     parser = argparse.ArgumentParser()
+    parser.add_argument('-f', '--configuration_file', action = 'store_true', help = "read this gunicorn configuration file: " + BASE_CONF_FILE)
     parser.add_argument('-p', '--port', action = 'store', default = DEFAULT_PORT, help = "port to serve on", type = int)
-    parser.add_argument('-t', '--tracker_url', action = 'store', help = "tracking service url", type = str)
+    parser = add_minimal_tax_benefit_system_arguments(parser)
+
+    parser.add_argument('-u', '--tracker_url', action = 'store', help = "tracking service url", type = str)
     parser.add_argument('-s', '--tracker_idsite', action = 'store', help = "tracking service id site", type = int)
-    parser = add_tax_benefit_system_arguments(parser)
-    args = parser.parse_args()
+
+    args, unknown_args = parser.parse_known_args()
+
+    if args.configuration_file:
+        print u'Reading configuration file `{}` instead of command line configuration...'.format(BASE_CONF_FILE)
+        # TODO BASE_CONF.update(BASE_CONF_FILE)
+        # print BASE_CONF
+    else:
+        if unknown_args:
+            print u'Ignoring these unknown arguments: {}'.format(unknown_args)
 
     app = create_app(args.country_package, args.extensions, args.tracker_url, args.tracker_idsite)
-    return app
+    return app, unknown_args
 
 
 class StandaloneApplication(BaseApplication):
@@ -47,7 +59,8 @@ class StandaloneApplication(BaseApplication):
 
 
 def main():
-    StandaloneApplication(new_configured_app(), BASE_CONF).run()
+    app, unknown_args = new_configured_app()
+    StandaloneApplication(app, BASE_CONF).run()
 
 
 if __name__ == '__main__':

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -65,12 +65,12 @@ def update(configuration, new_options):
     return configuration
 
 
-class StandaloneApplication(BaseApplication):
+class OpenFiscaWebAPIApplication(BaseApplication):
 
     def __init__(self, app, options = None):
         self.options = options or {}
         self.application = app
-        super(StandaloneApplication, self).__init__()
+        super(OpenFiscaWebAPIApplication, self).__init__()
 
     def load_config(self):
         for key, value in iteritems(self.options):
@@ -94,7 +94,7 @@ def main(parser = None):
     configuration = read_user_configuration(configuration, parser)
     tax_benefit_system = build_tax_benefit_system(configuration.get('country_package'), configuration.get('extensions'), configuration.get('reforms'))
     app = create_app(tax_benefit_system, configuration.get('tracker_url'), configuration.get('tracker_idsite'))
-    StandaloneApplication(app, configuration).run()
+    OpenFiscaWebAPIApplication(app, configuration).run()
 
 
 if __name__ == '__main__':

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -16,7 +16,7 @@ from openfisca_web_api_preview.app import create_app
     Define the `openfisca serve` command line interface.
 """
 
-DEFAULT_PORT = '8000'
+DEFAULT_PORT = '6000'
 HOST = '127.0.0.1'
 DEFAULT_WORKERS_NUMBER = '3'
 

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -57,10 +57,8 @@ def read_user_configuration(default_configuration, command_line_parser):
 
 
 def update(configuration, new_options):
-    for key in new_options:
-        value = new_options[key]
-
-        if not configuration.get(key) or value:
+    for key, value in new_options.iteritems():
+        if value is not None:
             configuration[key] = value
             if key == "port":
                 configuration['bind'] = configuration['bind'][:-4] + str(configuration['port'])
@@ -76,10 +74,7 @@ class StandaloneApplication(BaseApplication):
 
     def load_config(self):
         for key, value in iteritems(self.options):
-            if value is None:
-                log.debug('Undefined value for key `{}`.'.format(key))
-
-            if key in self.cfg.settings and value is not None:
+            if key in self.cfg.settings:
                 self.cfg.set(key.lower(), value)
 
     def load(self):
@@ -97,8 +92,7 @@ def main(parser = None):
         'workers': DEFAULT_WORKERS_NUMBER,
         }
     configuration = read_user_configuration(configuration, parser)
-
-    app = create_app(configuration['country_package'], configuration['extensions'], configuration['tracker_url'], configuration['tracker_idsite'])
+    app = create_app(configuration.get('country_package'), configuration.get('extensions'), configuration.get('tracker_url'), configuration.get('tracker_idsite'))
     StandaloneApplication(app, configuration).run()
 
 

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -32,6 +32,7 @@ def define_command_line_options(parser):
     parser.add_argument('-p', '--port', action = 'store', help = "port to serve on", type = int)
     parser.add_argument('--tracker-url', action = 'store', help = "tracking service url", type = str)
     parser.add_argument('--tracker-idsite', action = 'store', help = "tracking service id site", type = int)
+    parser.add_argument('--tracker-token', action = 'store', help = "tracking service authentication token", type = str)
     parser.add_argument('-f', '--configuration-file', action = 'store', help = "configuration file", type = str)
 
     return parser

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -15,45 +15,60 @@ from imp import load_module
 
 
 DEFAULT_PORT = '5000'
-gunicorn_configuration = {
-    'bind': '127.0.0.1:{}'.format(DEFAULT_PORT),
-    'workers': '3',
-    }
+HOST = '127.0.0.1'
+DEFAULT_WORKERS_NUMBER = '3'
 
 
-def new_configured_app():
+def define_command_line_options():
     parser = argparse.ArgumentParser()
 
     # Define OpenFisca modules configuration
     parser = add_minimal_tax_benefit_system_arguments(parser)
+
     # Define server configuration
     parser.add_argument('-p', '--port', action = 'store', default = DEFAULT_PORT, help = "port to serve on", type = int)
     parser.add_argument('--tracker_url', action = 'store', help = "tracking service url", type = str)
     parser.add_argument('--tracker_idsite', action = 'store', help = "tracking service id site", type = int)
     parser.add_argument('-f', '--configuration_file', action = 'store', help = "gunicorn configuration file", type = str)
 
-    # Read user configuration
-    args, unknown_args = parser.parse_known_args()
+    return parser
+
+
+def read_user_configuration(default_configuration, command_line_parser):
+    configuration = default_configuration
+    args, unknown_args = command_line_parser.parse_known_args()
 
     if args.configuration_file:
+        # Configuration file overloads default configuration
         module_name = os.path.splitext(os.path.basename(args.configuration_file))[0]
         module_directory = os.path.dirname(args.configuration_file)
         module = imp.load_module(module_name, *imp.find_module(module_name, [module_directory]))
 
-        # Make a dict out of the explicit variables in server configuration file:
-        custom_configuration = [item for item in dir(module) if not item.startswith("__")]
+        file_configuration = [item for item in dir(module) if not item.startswith("__")]
+        for key in file_configuration:
+            value = getattr(module, key)
+            if value:
+                configuration[key] = value
+                if key == "port":
+                    configuration['bind'] = configuration['bind'][:-4] + str(configuration['port'])
 
-        # Gunicorn configuration file overloads default configuration
-        for item in custom_configuration:
-            gunicorn_configuration[item] = getattr(module, item)
+    # Command line configuration overloads all configuration
+    command_line_parser = config.Config().parser()
+    configuration = update(configuration, vars(args))
+    configuration = update(configuration, unknown_args)
 
-    if unknown_args:
-        # Command line configuration overloads all gunicorn configuration
-        parser = config.Config().parser()
-        gunicorn_configuration.update(vars(parser.parse_args(unknown_args)))
-    print gunicorn_configuration
-    app = create_app(args.country_package, args.extensions, args.tracker_url, args.tracker_idsite)
-    return app, unknown_args
+    return configuration
+
+
+def update(configuration, new_options):
+    for key in new_options:
+        value = new_options[key]
+
+        if not configuration.get(key) or value:
+            configuration[key] = value
+            if key == "port":
+                configuration['bind'] = configuration['bind'][:-4] + str(configuration['port'])
+    return configuration
 
 
 class StandaloneApplication(BaseApplication):
@@ -66,7 +81,7 @@ class StandaloneApplication(BaseApplication):
     def load_config(self):
         for key, value in iteritems(self.options):
             if value is None:
-                print u'Missing value for key `{}`.'.format(key)
+                print u'Undefined value for key `{}`.'.format(key)
 
             if key in self.cfg.settings and value is not None:
                 self.cfg.set(key.lower(), value)
@@ -76,8 +91,17 @@ class StandaloneApplication(BaseApplication):
 
 
 def main():
-    app, unknown_args = new_configured_app()
-    StandaloneApplication(app, gunicorn_configuration).run()
+    command_line_parser = define_command_line_options()
+
+    configuration = {
+        'port': DEFAULT_PORT,
+        'bind': '{}:{}'.format(HOST, DEFAULT_PORT),
+        'workers': DEFAULT_WORKERS_NUMBER,
+        }
+    configuration = read_user_configuration(configuration, command_line_parser)
+
+    app = create_app(configuration['country_package'], configuration['extensions'], configuration['tracker_url'], configuration['tracker_idsite'])
+    StandaloneApplication(app, configuration).run()
 
 
 if __name__ == '__main__':

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -71,9 +71,8 @@ def update(configuration, new_options):
 
 class OpenFiscaWebAPIApplication(BaseApplication):
 
-    def __init__(self, app, options = None):
-        self.options = options or {}
-        self.application = app
+    def __init__(self, options):
+        self.options = options
         super(OpenFiscaWebAPIApplication, self).__init__()
 
     def load_config(self):
@@ -82,7 +81,16 @@ class OpenFiscaWebAPIApplication(BaseApplication):
                 self.cfg.set(key.lower(), value)
 
     def load(self):
-        return self.application
+        tax_benefit_system = build_tax_benefit_system(
+            self.options.get('country_package'),
+            self.options.get('extensions'),
+            self.options.get('reforms')
+            )
+        return create_app(
+            tax_benefit_system,
+            self.options.get('tracker_url'),
+            self.options.get('tracker_idsite')
+            )
 
 
 def main(parser = None):
@@ -96,9 +104,7 @@ def main(parser = None):
         'workers': DEFAULT_WORKERS_NUMBER,
         }
     configuration = read_user_configuration(configuration, parser)
-    tax_benefit_system = build_tax_benefit_system(configuration.get('country_package'), configuration.get('extensions'), configuration.get('reforms'))
-    app = create_app(tax_benefit_system, configuration.get('tracker_url'), configuration.get('tracker_idsite'))
-    OpenFiscaWebAPIApplication(app, configuration).run()
+    OpenFiscaWebAPIApplication(configuration).run()
 
 
 if __name__ == '__main__':

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -5,6 +5,7 @@ import argparse
 from gunicorn.app.base import BaseApplication
 from gunicorn.six import iteritems
 
+import server_configuration
 from openfisca_core.scripts import add_minimal_tax_benefit_system_arguments
 from ..app import create_app
 
@@ -30,9 +31,12 @@ def new_configured_app():
     args, unknown_args = parser.parse_known_args()
 
     if args.configuration_file:
-        print u'Reading configuration file `{}` instead of command line configuration...'.format(BASE_CONF_FILE)
-        # TODO BASE_CONF.update(BASE_CONF_FILE)
-        # print BASE_CONF
+        # This makes a dict out of the explicit variables in server_configuration
+        custom_configuration = [item for item in dir(server_configuration) if not item.startswith("__")]
+        # replace/create the relevant elements in the BASE_CONF
+        for item in custom_configuration:
+            BASE_CONF[item] = eval('server_configuration.' + item)
+
     else:
         if unknown_args:
             print u'Ignoring these unknown arguments: {}'.format(unknown_args)

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -32,7 +32,7 @@ def define_command_line_options(parser):
     parser = add_minimal_tax_benefit_system_arguments(parser)
 
     # Define server configuration
-    parser.add_argument('-p', '--port', action = 'store', default = DEFAULT_PORT, help = "port to serve on", type = int)
+    parser.add_argument('-p', '--port', action = 'store', help = "port to serve on", type = int)
     parser.add_argument('--tracker_url', action = 'store', help = "tracking service url", type = str)
     parser.add_argument('--tracker_idsite', action = 'store', help = "tracking service id site", type = int)
     parser.add_argument('-f', '--configuration_file', action = 'store', help = "gunicorn configuration file", type = str)

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -6,30 +6,33 @@ import argparse
 from wsgiref.simple_server import make_server
 
 from openfisca_core.scripts import add_tax_benefit_system_arguments, detect_country_package
-
-from ..application import make_app
+from ..app import create_app
+# from _tkinter import create
+# from ..application import make_app
 
 HOST_NAME = 'localhost'
 BASE_CONF = {
     'debug': 'true',
     }
 
+# old:
+# paster serve --reload development-france.ini 
 
+# COUNTRY_PACKAGE=openfisca_country_template 
+# gunicorn "openfisca_web_api_preview.app:create_app()" 
+# --bind localhost:5000 --workers 3
+# TRACKER_URL
+# TRACKER_IDSITE
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-p', '--port', action = 'store', default = 2000, help = "port to serve on", type = int)
+    parser.add_argument('-p', '--port', action = 'store', default = 5000, help = "port to serve on", type = int)
     parser = add_tax_benefit_system_arguments(parser)
     args = parser.parse_args()
 
-    conf = BASE_CONF.copy()
-    conf['country_package'] = args.country_package or detect_country_package()
-    if args.extensions:
-        # The api excepts the extensions and reforms to be separated by line breaks in the conf
-        conf['extensions'] = os.linesep.join(args.extensions)
-    if args.reforms:
-        conf['reforms'] = os.linesep.join(args.reforms)
+    tracker_url = os.environ.get('TRACKER_URL')
+    tracker_idsite = os.environ.get('TRACKER_IDSITE')
 
-    app = make_app({}, **conf)
+    app = create_app(args.country_package, args.extensions, tracker_url, tracker_idsite)
     httpd = make_server(HOST_NAME, args.port, app)
     print u'Serving on http://{}:{}/'.format(HOST_NAME, args.port)
     try:

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -52,6 +52,10 @@ def read_user_configuration(default_configuration, command_line_parser):
     gunicorn_parser = config.Config().parser()
     configuration = update(configuration, vars(args))
     configuration = update(configuration, vars(gunicorn_parser.parse_args(unknown_args)))
+    if configuration['args']:
+        command_line_parser.print_help()
+        print('Unexpected positional argument {}'.format(configuration['args']))
+        sys.exit(1)
 
     return configuration
 

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -11,32 +11,32 @@ from ..app import create_app
 
 
 DEFAULT_PORT = '5000'
-BASE_CONF = {
-    'bind': '%s:%s' % ('127.0.0.1', DEFAULT_PORT),
+DEFAULT_CONFIGURATION = {
+    'bind': '127.0.0.1:{}'.format(DEFAULT_PORT),
     'workers': '3',
     }
 
-BASE_CONF_FILE = "./server_configuration.py"
+DEFAULT_CONFIGURATION_FILE = "./server_configuration.py"
 
 
 def new_configured_app():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-f', '--configuration_file', action = 'store_true', help = "read this gunicorn configuration file: " + BASE_CONF_FILE)
+    parser.add_argument('-f', '--configuration_file', action = 'store_true', help = "read this gunicorn configuration file: " + DEFAULT_CONFIGURATION_FILE)
     parser.add_argument('-p', '--port', action = 'store', default = DEFAULT_PORT, help = "port to serve on", type = int)
     parser = add_minimal_tax_benefit_system_arguments(parser)
 
-    parser.add_argument('-u', '--tracker_url', action = 'store', help = "tracking service url", type = str)
-    parser.add_argument('-s', '--tracker_idsite', action = 'store', help = "tracking service id site", type = int)
+    parser.add_argument('--tracker_url', action = 'store', help = "tracking service url", type = str)
+    parser.add_argument('--tracker_idsite', action = 'store', help = "tracking service id site", type = int)
 
     args, unknown_args = parser.parse_known_args()
 
     if args.configuration_file:
         # This makes a dict out of the explicit variables in server_configuration
         custom_configuration = [item for item in dir(server_configuration) if not item.startswith("__")]
-        # replace/create the relevant elements in the BASE_CONF
+        # replace/create the relevant elements in the DEFAULT_CONFIGURATION
         for item in custom_configuration:
-            BASE_CONF[item] = eval('server_configuration.' + item)
-
+            DEFAULT_CONFIGURATION[item] = eval('server_configuration.' + item)
+        print DEFAULT_CONFIGURATION
     else:
         if unknown_args:
             print u'Ignoring these unknown arguments: {}'.format(unknown_args)
@@ -47,16 +47,18 @@ def new_configured_app():
 
 class StandaloneApplication(BaseApplication):
 
-    def __init__(self, app, options=None):
+    def __init__(self, app, options = None):
         self.options = options or {}
         self.application = app
         super(StandaloneApplication, self).__init__()
 
     def load_config(self):
-        config = dict([(key, value) for key, value in iteritems(self.options)
-                       if key in self.cfg.settings and value is not None])
-        for key, value in iteritems(config):
-            self.cfg.set(key.lower(), value)
+        for key, value in iteritems(self.options):
+            if value is None:
+                print u'Missing value for key `{}`.'.format(key)
+
+            if key in self.cfg.settings and value is not None:
+                self.cfg.set(key.lower(), value)
 
     def load(self):
         return self.application
@@ -64,7 +66,7 @@ class StandaloneApplication(BaseApplication):
 
 def main():
     app, unknown_args = new_configured_app()
-    StandaloneApplication(app, BASE_CONF).run()
+    StandaloneApplication(app, DEFAULT_CONFIGURATION).run()
 
 
 if __name__ == '__main__':

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -16,7 +16,7 @@ from openfisca_web_api_preview.app import create_app
     Define the `openfisca serve` command line interface.
 """
 
-DEFAULT_PORT = '5000'
+DEFAULT_PORT = '8000'
 HOST = '127.0.0.1'
 DEFAULT_WORKERS_NUMBER = '3'
 
@@ -55,7 +55,7 @@ def read_user_configuration(default_configuration, command_line_parser):
     configuration = update(configuration, vars(gunicorn_parser.parse_args(unknown_args)))
     if configuration['args']:
         command_line_parser.print_help()
-        print('Unexpected positional argument {}'.format(configuration['args']))
+        log.error('Unexpected positional argument {}'.format(configuration['args']))
         sys.exit(1)
 
     return configuration

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -59,9 +59,9 @@ def read_user_configuration(default_configuration, command_line_parser):
                     configuration['bind'] = configuration['bind'][:-4] + str(configuration['port'])
 
     # Command line configuration overloads all configuration
-    command_line_parser = config.Config().parser()
+    gunicorn_parser = config.Config().parser()
     configuration = update(configuration, vars(args))
-    configuration = update(configuration, unknown_args)
+    configuration = update(configuration, vars(gunicorn_parser.parse_args(unknown_args)))
 
     return configuration
 

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -11,7 +11,7 @@ from gunicorn.six import iteritems
 from gunicorn import config
 
 from openfisca_core.scripts import add_minimal_tax_benefit_system_arguments
-from ..app import create_app
+from openfisca_web_api_preview.app import create_app
 from imp import load_module
 
 
@@ -96,15 +96,17 @@ class StandaloneApplication(BaseApplication):
         return self.application
 
 
-def main(parser):
-    command_line_parser = define_command_line_options(parser)
+def main(parser = None):
+    if not parser:
+        parser = argparse.ArgumentParser()
+        parser = define_command_line_options(parser)
 
     configuration = {
         'port': DEFAULT_PORT,
         'bind': '{}:{}'.format(HOST, DEFAULT_PORT),
         'workers': DEFAULT_WORKERS_NUMBER,
         }
-    configuration = read_user_configuration(configuration, command_line_parser)
+    configuration = read_user_configuration(configuration, parser)
 
     app = create_app(configuration['country_package'], configuration['extensions'], configuration['tracker_url'], configuration['tracker_idsite'])
     StandaloneApplication(app, configuration).run()

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -30,9 +30,9 @@ def define_command_line_options(parser):
 
     # Define server configuration
     parser.add_argument('-p', '--port', action = 'store', help = "port to serve on", type = int)
-    parser.add_argument('--tracker_url', action = 'store', help = "tracking service url", type = str)
-    parser.add_argument('--tracker_idsite', action = 'store', help = "tracking service id site", type = int)
-    parser.add_argument('-f', '--configuration_file', action = 'store', help = "gunicorn configuration file", type = str)
+    parser.add_argument('--tracker-url', action = 'store', help = "tracking service url", type = str)
+    parser.add_argument('--tracker-idsite', action = 'store', help = "tracking service id site", type = int)
+    parser.add_argument('-f', '--configuration-file', action = 'store', help = "configuration file", type = str)
 
     return parser
 

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -8,7 +8,7 @@ from gunicorn.app.base import BaseApplication
 from gunicorn.six import iteritems
 from gunicorn import config
 
-from openfisca_core.scripts import add_minimal_tax_benefit_system_arguments
+from openfisca_core.scripts import add_tax_benefit_system_arguments, build_tax_benefit_system
 from openfisca_web_api_preview.app import create_app
 
 
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 
 def define_command_line_options(parser):
     # Define OpenFisca modules configuration
-    parser = add_minimal_tax_benefit_system_arguments(parser)
+    parser = add_tax_benefit_system_arguments(parser)
 
     # Define server configuration
     parser.add_argument('-p', '--port', action = 'store', help = "port to serve on", type = int)
@@ -92,7 +92,8 @@ def main(parser = None):
         'workers': DEFAULT_WORKERS_NUMBER,
         }
     configuration = read_user_configuration(configuration, parser)
-    app = create_app(configuration.get('country_package'), configuration.get('extensions'), configuration.get('tracker_url'), configuration.get('tracker_idsite'))
+    tax_benefit_system = build_tax_benefit_system(configuration.get('country_package'), configuration.get('extensions'), configuration.get('reforms'))
+    app = create_app(tax_benefit_system, configuration.get('tracker_url'), configuration.get('tracker_idsite'))
     StandaloneApplication(app, configuration).run()
 
 

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -3,6 +3,7 @@
 import sys
 import imp
 import os.path
+import logging
 import argparse
 
 from gunicorn.app.base import BaseApplication
@@ -14,14 +15,19 @@ from ..app import create_app
 from imp import load_module
 
 
+"""
+    Define the `openfisca serve` command line interface.
+"""
+
 DEFAULT_PORT = '5000'
 HOST = '127.0.0.1'
 DEFAULT_WORKERS_NUMBER = '3'
 
 
-def define_command_line_options():
-    parser = argparse.ArgumentParser()
+log = logging.getLogger(__name__)
 
+
+def define_command_line_options(parser):
     # Define OpenFisca modules configuration
     parser = add_minimal_tax_benefit_system_arguments(parser)
 
@@ -81,7 +87,7 @@ class StandaloneApplication(BaseApplication):
     def load_config(self):
         for key, value in iteritems(self.options):
             if value is None:
-                print u'Undefined value for key `{}`.'.format(key)
+                log.debug('Undefined value for key `{}`.'.format(key))
 
             if key in self.cfg.settings and value is not None:
                 self.cfg.set(key.lower(), value)
@@ -90,8 +96,8 @@ class StandaloneApplication(BaseApplication):
         return self.application
 
 
-def main():
-    command_line_parser = define_command_line_options()
+def main(parser):
+    command_line_parser = define_command_line_options(parser)
 
     configuration = {
         'port': DEFAULT_PORT,

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -4,6 +4,7 @@ import os
 import sys
 import argparse
 from gunicorn.app.base import BaseApplication
+from gunicorn.six import iteritems
 
 from openfisca_core.scripts import add_tax_benefit_system_arguments, detect_country_package
 from ..app import create_app
@@ -13,14 +14,13 @@ DEFAULT_PORT = '5000'
 BASE_CONF = {
     'bind': '%s:%s' % ('127.0.0.1', DEFAULT_PORT),
     'workers': '3',
-    'debug': 'true',
 }
 
 
 def new_configured_app():
     parser = argparse.ArgumentParser()
     parser.add_argument('-p', '--port', action = 'store', default = DEFAULT_PORT, help = "port to serve on", type = int)
-    parser.add_argument('-t', '--tracker_url', action = 'store', help = "tracking service url", type = string)
+    parser.add_argument('-t', '--tracker_url', action = 'store', help = "tracking service url", type = str)
     parser.add_argument('-s', '--tracker_idsite', action = 'store', help = "tracking service id site", type = int)
     parser = add_tax_benefit_system_arguments(parser)
     args = parser.parse_args()
@@ -46,5 +46,9 @@ class StandaloneApplication(BaseApplication):
         return self.application
 
 
-if __name__ == '__main__':
+def main():
     StandaloneApplication(new_configured_app(), BASE_CONF).run()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/openfisca_web_api_preview/scripts/server_configuration.py
+++ b/openfisca_web_api_preview/scripts/server_configuration.py
@@ -1,6 +1,0 @@
-# gunicorn server configuration file
-# extends and replaces api default configuration
-
-port = 3000
-bind = "127.0.0.1:" + str(port)
-workers = 3

--- a/openfisca_web_api_preview/scripts/server_configuration.py
+++ b/openfisca_web_api_preview/scripts/server_configuration.py
@@ -2,6 +2,5 @@
 # extends and replaces api default configuration
 
 port = 3000
-bind = "127.0.0.1:" + port
 bind = "127.0.0.1:" + str(port)
 workers = 3

--- a/openfisca_web_api_preview/scripts/server_configuration.py
+++ b/openfisca_web_api_preview/scripts/server_configuration.py
@@ -3,4 +3,5 @@
 
 port = 3000
 bind = "127.0.0.1:" + port
+bind = "127.0.0.1:" + str(port)
 workers = 3

--- a/openfisca_web_api_preview/scripts/server_configuration.py
+++ b/openfisca_web_api_preview/scripts/server_configuration.py
@@ -1,0 +1,6 @@
+# gunicorn server configuration file
+# extends and replaces api default configuration
+
+port = 3000
+bind = "127.0.0.1:" + port
+workers = 3

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         ('share/openfisca/openfisca-core', ['CHANGELOG.md', 'LICENSE.AGPL.txt', 'README.md']),
         ],
     entry_points = {
-        'console_scripts': ['openfisca-run-test=openfisca_core.scripts.run_test:main'],
+        'console_scripts': ['openfisca-run-test=openfisca_core.scripts.run_test:main', 'openfisca-serve=openfisca_web_api_preview.scripts.serve:main'],
         },
     extras_require = {
         'test': [

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         ('share/openfisca/openfisca-core', ['CHANGELOG.md', 'LICENSE.AGPL.txt', 'README.md']),
         ],
     entry_points = {
-        'console_scripts': ['openfisca-run-test=openfisca_core.scripts.run_test:main', 'openfisca-serve=openfisca_web_api_preview.scripts.serve:main'],
+        'console_scripts': ['openfisca=openfisca_core.scripts.openfisca_command:main', 'openfisca-run-test=openfisca_core.scripts.run_test:main'],
         },
     extras_require = {
         'test': [

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     extras_require = {
         'test': [
             'nose',
-            'flake8',
+            'flake8 == 3.4.1',
             'openfisca-country-template == 1.3.1',
             'openfisca-extension-template == 1.1.1',
             ],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '18.1.0',
+    version = '18.2.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/web_api/__init__.py
+++ b/tests/web_api/__init__.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import pkg_resources
 from openfisca_web_api_preview.app import create_app
+from openfisca_core.scripts import build_tax_benefit_system
 
 TEST_COUNTRY_PACKAGE_NAME = 'openfisca_country_template'
 distribution = pkg_resources.get_distribution(TEST_COUNTRY_PACKAGE_NAME)
-subject = create_app(TEST_COUNTRY_PACKAGE_NAME).test_client()
+tax_benefit_system = build_tax_benefit_system(TEST_COUNTRY_PACKAGE_NAME, extensions = None, reforms = None)
+subject = create_app(tax_benefit_system).test_client()

--- a/tests/web_api/test_extensions.py
+++ b/tests/web_api/test_extensions.py
@@ -1,24 +1,27 @@
 # -*- coding: utf-8 -*-
-import pkg_resources
+
+from httplib import OK
+from nose.tools import assert_equal
 from openfisca_web_api_preview.app import create_app
+
 
 TEST_COUNTRY_PACKAGE_NAME = 'openfisca_country_template'
 TEST_EXTENSION_PACKAGE_NAME = 'openfisca_extension_template'
 
-distribution = pkg_resources.get_distribution(TEST_COUNTRY_PACKAGE_NAME)
 extended_subject = create_app(TEST_COUNTRY_PACKAGE_NAME, TEST_EXTENSION_PACKAGE_NAME).test_client()
+assert_equal(extended_subject, )
 
 
 def test_return_code():
-    parameters_response = subject.get('/parameters')
+    parameters_response = extended_subject.get('/parameters')
     assert_equal(parameters_response.status_code, OK)
 
 
 def test_return_code_existing_parameter():
-    extension_parameter_response = subject.get('/parameter/local_town.child_allowance.amount')
+    extension_parameter_response = extended_subject.get('/parameter/local_town.child_allowance.amount')
     assert_equal(extension_parameter_response.status_code, OK)
 
 
 def test_return_code_existing_variable():
-    extension_variable_response = subject.get('/variable/local_town_child_allowance')
+    extension_variable_response = extended_subject.get('/variable/local_town_child_allowance')
     assert_equal(extension_variable_response.status_code, OK)

--- a/tests/web_api/test_extensions.py
+++ b/tests/web_api/test_extensions.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+import pkg_resources
+from openfisca_web_api_preview.app import create_app
+
+TEST_COUNTRY_PACKAGE_NAME = 'openfisca_country_template'
+TEST_EXTENSION_PACKAGE_NAME = 'openfisca_extension_template'
+
+distribution = pkg_resources.get_distribution(TEST_COUNTRY_PACKAGE_NAME)
+extended_subject = create_app(TEST_COUNTRY_PACKAGE_NAME, TEST_EXTENSION_PACKAGE_NAME).test_client()
+
+parameters_response = subject.get('/parameters')
+
+def test_return_code():
+    assert_equal(parameters_response.status_code, OK)

--- a/tests/web_api/test_extensions.py
+++ b/tests/web_api/test_extensions.py
@@ -8,7 +8,17 @@ TEST_EXTENSION_PACKAGE_NAME = 'openfisca_extension_template'
 distribution = pkg_resources.get_distribution(TEST_COUNTRY_PACKAGE_NAME)
 extended_subject = create_app(TEST_COUNTRY_PACKAGE_NAME, TEST_EXTENSION_PACKAGE_NAME).test_client()
 
-parameters_response = subject.get('/parameters')
 
 def test_return_code():
+    parameters_response = subject.get('/parameters')
     assert_equal(parameters_response.status_code, OK)
+
+
+def test_return_code_existing_parameter():
+    extension_parameter_response = subject.get('/parameter/local_town.child_allowance.amount')
+    assert_equal(extension_parameter_response.status_code, OK)
+
+
+def test_return_code_existing_variable():
+    extension_variable_response = subject.get('/variable/local_town_child_allowance')
+    assert_equal(extension_variable_response.status_code, OK)

--- a/tests/web_api/test_extensions.py
+++ b/tests/web_api/test_extensions.py
@@ -2,13 +2,16 @@
 
 from httplib import OK
 from nose.tools import assert_equal
+from openfisca_core.scripts import build_tax_benefit_system
 from openfisca_web_api_preview.app import create_app
 
 
 TEST_COUNTRY_PACKAGE_NAME = 'openfisca_country_template'
-TEST_EXTENSION_PACKAGE_NAME = ['openfisca_extension_template']
+TEST_EXTENSION_PACKAGE_NAMES = ['openfisca_extension_template']
 
-extended_subject = create_app(TEST_COUNTRY_PACKAGE_NAME, TEST_EXTENSION_PACKAGE_NAME).test_client()
+tax_benefit_system = build_tax_benefit_system(TEST_COUNTRY_PACKAGE_NAME, extensions = TEST_EXTENSION_PACKAGE_NAMES, reforms = None)
+
+extended_subject = create_app(tax_benefit_system).test_client()
 
 
 def test_return_code():

--- a/tests/web_api/test_extensions.py
+++ b/tests/web_api/test_extensions.py
@@ -6,10 +6,9 @@ from openfisca_web_api_preview.app import create_app
 
 
 TEST_COUNTRY_PACKAGE_NAME = 'openfisca_country_template'
-TEST_EXTENSION_PACKAGE_NAME = 'openfisca_extension_template'
+TEST_EXTENSION_PACKAGE_NAME = ['openfisca_extension_template']
 
 extended_subject = create_app(TEST_COUNTRY_PACKAGE_NAME, TEST_EXTENSION_PACKAGE_NAME).test_client()
-assert_equal(extended_subject, )
 
 
 def test_return_code():


### PR DESCRIPTION
Connected to #576 

#### New features

- Introduce `openfisca-serve` for new API
  - Allows for serving OpenFisca extensions with `-e` option. Example: openfisca-serve -c openfisca_country_template -e openfisca_extension_template
