### PR TITLE
Add access to documentation of the web API inputs and outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 18.0.1 [#584](https://github.com/openfisca/openfisca-core/pull/584)
+
+- Add a link in `openAPI.yml` to the OpenFisca documentation page explaining the web API inputs and outputs for the /calculate route.
+
 ## 18.0.0 [#582](https://github.com/openfisca/openfisca-core/pull/582)
 
 #### New features

--- a/openfisca_web_api_preview/openAPI.yml
+++ b/openfisca_web_api_preview/openAPI.yml
@@ -38,7 +38,7 @@ paths:
       parameters:
       - in: "body"
         name: "Situation"
-        description: 'Describe the situation (persons and entities). Add the variable you wish to calculate in the proper entity, with null as the value.'
+        description: 'Describe the situation (persons and entities). Add the variable you wish to calculate in the proper entity, with null as the value. Learn more in our official documentation: http://openfisca.org/doc/openfisca-web-api/input-output-data.html'
         required: true
         schema:
           $ref: '#/definitions/SituationInput'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '18.0.0',
+    version = '18.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Connected to openfisca/openfisca-core#577

Technical change : Add a link in the openAPI documentation to the OpenFisca documentation page explaining the web API inputs and outputs for the `calculate`route.