### PR TITLE
Enable fancy indexing on enum variables

### DIFF
--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -10,6 +10,7 @@ import traceback
 
 import yaml
 import numpy as np
+from enum import Enum
 
 from . import taxscales
 from . import periods
@@ -569,7 +570,12 @@ class VectorialParameterNodeAtInstant(object):
         # If the key is a vector, e.g. ['zone_1', 'zone_2', 'zone_1']
         elif isinstance(key, np.ndarray):
             if not np.issubdtype(key.dtype, np.str):
-                key = key.astype('str')  # In case the key is a number vector, stringify it
+                # In case the key is not a string vector, stringify it                       
+                if key.dtype == object and issubclass(type(key[0]), Enum):
+                    enum = type(key[0])
+                    key = np.select([key == item for item in enum], [item.name for item in enum])
+                else:
+                    key = key.astype('str')
             names = list(self.dtype.names)  # Get all the names of the subnodes, e.g. ['zone_1', 'zone_2']
             default = np.full_like(self.vector[key[0]], np.nan)  # In case of unexpected key, we will set the corresponding value to NaN.
             conditions = [key == name for name in names]

--- a/tests/core/parameters_fancy_indexing/test_fancy_indexing.py
+++ b/tests/core/parameters_fancy_indexing/test_fancy_indexing.py
@@ -7,6 +7,7 @@ from nose.tools import raises, assert_in
 
 from openfisca_core.tools import assert_near
 from openfisca_core.parameters import ParameterNode, Parameter, ParameterNotFound
+from openfisca_core.model_api import *  # noqa
 
 LOCAL_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -144,3 +145,13 @@ def test_with_bareme():
         assert_in("'bareme.75016' is a 'MarginalRateTaxScale'", e.message)
         assert_in("has not been implemented", e.message)
         raise
+
+
+def test_with_enum():
+
+    class TypesZone(Enum):
+        z1 = "Zone 1"
+        z2 = "Zone 2"
+
+    zone = np.asarray([TypesZone.z1, TypesZone.z2, TypesZone.z2, TypesZone.z1])
+    assert_near(P.single.owner[zone], [100, 200, 200, 100])


### PR DESCRIPTION
This is a slight improvement of #589 to be able to use the newly introduced enums when requesting a parameter dynamically depending on a variable.

See test for example.
