### PR TITLE
Allow string arrays as inputs for Enum variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### 21.0.1 [#600](https://github.com/openfisca/openfisca-core/pull/600)
+
+- Allow string arrays as inputs for Enum variables
+
+For instance, following the example from 21.0.0, the following now works:
+
+```py
+holder = household.get_holder('housing_occupancy_status')
+holder.set_input(period, np.asarray(['owner']))
+```
+
 # 21.0.0 [#589](https://github.com/openfisca/openfisca-core/pull/589)
 
 #### Breaking changes
@@ -33,7 +44,7 @@ simulation = tax_benefit_system.new_scenario().init_single_entity(
 - In a formula, to compare an Enum variable to a fixed value, use `housing_occupancy_status == HousingOccupancyStatus.tenant`
 - To access a parameter that has a value for each Enum item (e.g. a value for `zone_1`, a value for `zone_2` ... ), use fancy indexing
 
-> For example, if there is an enum: 
+> For example, if there is an enum:
 > ```py
 >     class TypesZone(Enum):
 >         z1 = "Zone 1"
@@ -94,7 +105,7 @@ class housing_occupancy_status(Variable):
     * `bool`
     * `str`
     * `date`
-    * `Enum` 
+    * `Enum`
 
 Before:
 

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -6,6 +6,7 @@ import warnings
 import os
 
 import numpy as np
+from enum import Enum
 
 from . import periods
 from .commons import empty_clone
@@ -273,6 +274,10 @@ class Holder(object):
                 self.variable.definition_period,
                 error_message
                 )
+
+        if self.variable.value_type == Enum and array.dtype.kind in {'U', 'S'}:  # String array
+            enum = self.variable.possible_values
+            array = np.select([array == item.name for item in enum], [item for item in enum])
 
         self.formula.set_input(period, array)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '21.0.0',
+    version = '21.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+from nose.tools import assert_equal
+
+from openfisca_country_template.situation_examples import couple
+from openfisca_core.simulations import Simulation
+from openfisca_core.periods import period as make_period
+from test_countries import tax_benefit_system
+
+
+def test_set_input_enum():
+    simulation = Simulation(tax_benefit_system = tax_benefit_system, simulation_json = couple)
+    status_occupancy = np.asarray(['owner'])
+    period = make_period('2017-12')
+    HousingOccupancyStatus = tax_benefit_system.get_variable('housing_occupancy_status').possible_values
+    simulation.household.get_holder('housing_occupancy_status').set_input(period, status_occupancy)
+    result = simulation.calculate('housing_occupancy_status', period)
+    assert_equal(result, HousingOccupancyStatus.owner)


### PR DESCRIPTION
- Allow string arrays as inputs for Enum variables

For instance, following the example from 21.0.0, the following now works:

```py
holder = household.get_holder('housing_occupancy_status')
holder.set_input(period, np.asarray(['owner']))
```