### PR TITLE
Handle memory overflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 21.2.0 [#601](https://github.com/openfisca/openfisca-core/pull/601)
+
+#### New features
+
+- Improve [`holder.get_memory_usage`]((http://openfisca.readthedocs.io/en/latest/holder.html#openfisca_core.holders.Holder.get_memory_usage)):
+  - Add `nb_requests` and `nb_requests_by_array` fields in the memory usage stats for traced simulations.
+
+- Enable intermediate data storage on disk to avoid memory overflow
+  - Introduce `memory_config` option in `Simulation` constructor
+    - This allows fine tuning of memory management in OpenFisca
+
+For instance:
+
+```
+from openfisca_core.memory_config import MemoryConfig
+config = MemoryConfig(
+    max_memory_occupation = 0.95,  # When 95% of the virtual memory is full, switch to disk storage
+    priority_variables = ['salary', 'age']  # Always store these variables in memory
+    variables_to_drop = ['age_elder_for_family_benefit']  # Do not store the value of these variables
+    )
+```
+
 ## 21.1.0 [#598](https://github.com/openfisca/openfisca-core/pull/598)
 
 #### New features

--- a/openfisca_core/base_functions.py
+++ b/openfisca_core/base_functions.py
@@ -2,18 +2,19 @@
 
 import warnings
 
-import numpy as np
-
 from . import periods
 
-# TODO: Adapt base_functions to cache disk
 
 def permanent_default_value(formula, simulation, period, *extra_params):
-    if formula.find_function(period) is not None:
-        return formula.exec_function(simulation, period, *extra_params)
-    holder = formula.holder
-    array = holder.default_array()
-    return array
+    warnings.warn(
+        u"permanent_default_value is deprecated"
+        u"permanent_default_value has the same effect "
+        u"than requested_period_default_value, the default base_function for float and int variables. "
+        u"There is thus no need to specifiy it. ",
+        Warning
+        )
+
+    return requested_period_default_value(formula, simulation, period, *extra_params)
 
 
 def requested_period_added_value(formula, simulation, period, *extra_params):
@@ -36,39 +37,35 @@ def requested_period_default_value(formula, simulation, period, *extra_params):
 
 
 def requested_period_last_value(formula, simulation, period, *extra_params, **kwargs):
-    # This formula is used for variables that are constants between events and period size independent.
-    # It returns the latest known value for the requested period.
+    """
+        This formula is used for variables that are constants between events and period size independent.
+        If the variable has no formula, it will return the latest known value of the variable
+    """
 
-    def compare_start_instant(x, y):
-        a = x[0]  # x = (period, array)
-        b = y[0]
-
-        return periods.compare_period_start(a, b)
+    function = formula.find_function(period)
+    if function is not None:
+        return formula.exec_function(simulation, period, *extra_params)
 
     accept_future_value = kwargs.pop('accept_future_value', False)
     holder = formula.holder
-    function = formula.find_function(period)
-    # TODO We should take the cache disk into account
-    if holder._array_by_period:
-        known_values = sorted(holder._array_by_period.iteritems(), cmp = compare_start_instant, reverse = True)
-        for last_period, last_result in known_values:
-            if last_period.start <= period.start and (function is None or last_period.stop >= period.stop):
-                if isinstance(last_result, np.ndarray) and not extra_params:
-                    return last_result
-                elif last_result.get(extra_params):
-                        return last_result.get(extra_params)
-        if accept_future_value:
-            next_period, next_array = known_values[-1]
-            return last_result
-    if function is not None:
-        return formula.exec_function(simulation, period, *extra_params)
-    array = holder.default_array()
-    return array
+    known_periods = holder.get_known_periods()
+    if not known_periods:
+        return holder.default_array()
+    known_periods = sorted(known_periods, cmp = periods.compare_period_start, reverse = True)
+    for last_period in known_periods:
+        if last_period.start <= period.start:
+            return holder.get_array(last_period, extra_params)
+    if accept_future_value:
+        next_period = known_periods[-1]
+        return holder.get_array(next_period, extra_params)
+    return holder.default_array()
 
 
 def requested_period_last_or_next_value(formula, simulation, period, *extra_params):
-    # This formula is used for variables that are constants between events and period size independent.
-    # It returns the latest known value for the requested period, or the next value if there is no past value.
+    """
+        This formula is used for variables that are constants between events and period size independent.
+        If the variable has no formula, it will return the latest known value of the variable, or the next value if there is no past value.
+    """
     return requested_period_last_value(formula, simulation, period, *extra_params, accept_future_value = True)
 
 

--- a/openfisca_core/base_functions.py
+++ b/openfisca_core/base_functions.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from . import periods
 
+# TODO: Adapt base_functions to cache disk
 
 def permanent_default_value(formula, simulation, period, *extra_params):
     if formula.find_function(period) is not None:
@@ -47,7 +48,8 @@ def requested_period_last_value(formula, simulation, period, *extra_params, **kw
     accept_future_value = kwargs.pop('accept_future_value', False)
     holder = formula.holder
     function = formula.find_function(period)
-    if holder._array_by_period is not None:
+    # TODO We should take the cache disk into account
+    if holder._array_by_period:
         known_values = sorted(holder._array_by_period.iteritems(), cmp = compare_start_instant, reverse = True)
         for last_period, last_result in known_values:
             if last_period.start <= period.start and (function is None or last_period.stop >= period.stop):

--- a/openfisca_core/data_storage.py
+++ b/openfisca_core/data_storage.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+
+import shutil
+import os
+
+import numpy as np
+
+import periods
+from periods import ETERNITY
+
+
+class InMemoryStorage(object):
+    """
+    Low-level class responsible for storing and retrieving calculated vectors in memory
+    """
+
+    def __init__(self, is_eternal = False):
+        self._arrays = {}
+        self.is_eternal = is_eternal
+
+    def get(self, period, extra_params = None):
+        if self.is_eternal:
+            period = periods.period(ETERNITY)
+        period = periods.period(period)
+
+        values = self._arrays.get(period)
+        if values is None:
+            return None
+        if extra_params:
+            return values.get(tuple(extra_params))
+        if isinstance(values, dict):
+            return values.values()[0]
+        return values
+
+    def put(self, value, period, extra_params = None):
+        if self.is_eternal:
+            period = periods.period(ETERNITY)
+        period = periods.period(period)
+
+        if extra_params is None:
+            self._arrays[period] = value
+        else:
+            if self._arrays.get(period) is None:
+                self._arrays[period] = {}
+            self._arrays[period][tuple(extra_params)] = value
+
+    def delete(self, period = None):
+        if period is None:
+            self._arrays = {}
+            return
+
+        if self.is_eternal:
+            period = periods.period(ETERNITY)
+        period = periods.period(period)
+
+        self._arrays = {
+            period_item: value
+            for period_item, value in self._arrays.iteritems()
+            if not period.contains(period_item)
+            }
+
+    def get_known_periods(self):
+        return self._arrays.keys()
+
+    def get_memory_usage(self):
+        if not self._arrays:
+            return dict(
+                nb_arrays = 0,
+                total_nb_bytes = 0,
+                cell_size = np.nan,
+                )
+
+        nb_arrays = sum([
+            len(array_or_dict) if isinstance(array_or_dict, dict) else 1
+            for array_or_dict in self._arrays.itervalues()
+            ])
+
+        array = self._arrays.values()[0]
+        if isinstance(array, dict):
+            array = array.values()[0]
+        return dict(
+            nb_arrays = nb_arrays,
+            total_nb_bytes = array.nbytes * nb_arrays,
+            cell_size = array.itemsize,
+            )
+
+
+class OnDiskStorage(object):
+    """
+    Low-level class responsible for storing and retrieving calculated vectors on disk
+    """
+
+    def __init__(self, storage_dir, is_eternal = False):
+        self._files = {}
+        self.is_eternal = is_eternal
+        self.storage_dir = storage_dir
+
+    def get(self, period, extra_params = None):
+        if self.is_eternal:
+            period = periods.period(ETERNITY)
+        period = periods.period(period)
+
+        values = self._files.get(period)
+        if values is None:
+            return None
+        if extra_params:
+            if values.get(tuple(extra_params)) is None:
+                return None
+            return np.load(values.get(tuple(extra_params)))
+        if isinstance(values, dict):
+            return np.load(values.values()[0])
+        return np.load(values)
+
+    def put(self, value, period, extra_params = None):
+        if self.is_eternal:
+            period = periods.period(ETERNITY)
+        period = periods.period(period)
+
+        filename = str(period)
+        if extra_params:
+            filename = '{}_{}'.format(
+                filename, '_'.join([str(param) for param in extra_params]))
+        path = os.path.join(self.storage_dir, filename) + '.npy'
+        np.save(path, value)
+        if extra_params is None:
+            self._files[period] = path
+        else:
+            if self._files.get(period) is None:
+                self._files[period] = {}
+            self._files[period][tuple(extra_params)] = path
+
+    def delete(self, period = None):
+        if period is None:
+            self._files = {}
+            return
+
+        if self.is_eternal:
+            period = periods.period(ETERNITY)
+        period = periods.period(period)
+
+        if period is not None:
+            self._files = {
+                period_item: value
+                for period_item, value in self._files.iteritems()
+                if not period.contains(period_item)
+                }
+
+    def get_known_periods(self):
+        return self._files.keys()
+
+    def __del__(self):
+        shutil.rmtree(self.storage_dir)  # Remove the holder temporary files
+        # If the simulation temporary directory is empty, remove it
+        parent_dir = os.path.abspath(os.path.join(self.storage_dir, os.pardir))
+        if not os.listdir(parent_dir):
+            shutil.rmtree(parent_dir)

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -7,7 +7,6 @@ import os
 
 import numpy as np
 
-from . import periods
 from .commons import empty_clone
 from .periods import MONTH, YEAR, ETERNITY
 from columns import make_column_from_variable
@@ -15,6 +14,7 @@ from indexed_enums import Enum, EnumArray
 import logging
 
 log = logging.getLogger(__name__)
+
 
 class DatedHolder(object):
     """
@@ -81,8 +81,11 @@ class Holder(object):
             self.entity = entity
             self.simulation = entity.simulation
         self.variable = variable
+        if self.variable.definition_period != ETERNITY:
+            self._array_by_period = {}
         self.buffer = {}
         self._data_store_dir = None
+        self.disk_cache = {}
 
     @property
     def array(self):
@@ -228,34 +231,74 @@ class Holder(object):
             If ``period`` is not ``None``, only remove all values for any period included in period (e.g. if period is "2017", values for "2017-01", "2017-07", etc. would be removed)
 
         """
-        if self._array is not None:
-            del self._array
-        if self._array_by_period is not None and period is None:
-            del self._array_by_period
+        if self._array is not None:  # When definition_period is ETERNITY
+            self._array = None
+        if self._array_by_period is not None and period is None:  # When definition_period is not ETERNITY
+            self._array_by_period = {}
+        if period is None:
+            self.disk_cache = {}
+            # TODO: Remove files
+
         if period is not None:
             if not isinstance(period, periods.Period):
                 period = periods.period(period)
-            self._array_by_period = {
+            if self._array_by_period:
+                self._array_by_period = {
+                    period_item: value
+                    for period_item, value in self._array_by_period.iteritems()
+                    if not period.contains(period_item)
+                    }
+            self.disk_cache = {
                 period_item: value
-                for period_item, value in self._array_by_period.iteritems()
+                for period_item, value in self.disk_cache.iteritems()
                 if not period.contains(period_item)
                 }
+            # TODO: Remove files
 
-    def get_array(self, period, extra_params = None):
+    def get_value_from_memory(self, period, extra_params = None):
         if self.variable.definition_period == ETERNITY:
             return self.array
         assert period is not None
         array_by_period = self._array_by_period
-        if array_by_period is not None:
-            values = array_by_period.get(period)
-            if values is not None:
-                if extra_params:
-                    return values.get(tuple(extra_params))
-                else:
-                    if(type(values) == dict):
-                        return values.values()[0]
-                    return values
-        return None
+
+        values = array_by_period.get(period)
+        if values is None:
+            return None
+        if extra_params:
+            return values.get(tuple(extra_params))
+        if type(values) == dict:
+            return values.values()[0]
+        return values
+
+    def get_value_from_disk(self, period, extra_params = None):
+        if self.variable.definition_period == ETERNITY:
+            period = periods.period(ETERNITY)
+            if self.disk_cache.get(period) is not None:
+                return np.load(self.disk_cache.get(period))
+        assert period is not None
+        values = self.disk_cache.get(period)
+        if values is None:
+            return None
+        if extra_params:
+            if values.get(tuple(extra_params)) is None:
+                return None
+            return np.load(values.get(tuple(extra_params)))
+        if type(values) == dict:
+            return np.load(values.values()[0])
+        return np.load(values)
+
+    def get_array(self, period, extra_params = None):
+        """
+        Get the value of the variable for the given period (and possibly a list of extra parameters).
+
+        If the value is not known, return ``None``.
+        """
+        if period and not isinstance(period, periods.Period):
+            period = periods.period(period)
+        value = self.get_value_from_memory(period, extra_params)
+        if value is not None:
+            return value
+        return self.get_value_from_disk(period, extra_params)
 
     def graph(self, edges, get_input_variables_and_parameters, nodes, visited):
         variable = self.variable
@@ -305,7 +348,7 @@ class Holder(object):
                 cell_size = self._array.itemsize,
                 ))
             return usage
-        elif self._array_by_period is not None:
+        elif self._array_by_period:
             nb_arrays = sum([
                 len(array_or_dict) if isinstance(array_or_dict, dict) else 1
                 for array_or_dict in self._array_by_period.itervalues()
@@ -336,7 +379,7 @@ class Holder(object):
                 return [ETERNITY]
             else:
                 return []
-        return self._array_by_period.keys()
+        return self._array_by_period.keys() + self.disk_cache.keys()
 
     @property
     def real_formula(self):
@@ -372,14 +415,6 @@ class Holder(object):
             self._data_store_dir = os.path.join(self.simulation.data_store_dir, self.variable.name)
             os.makedirs(self._data_store_dir)
         return self._data_store_dir
-
-    def put_in_disk_cache(self, value, period, extra_params = None):
-        filename = (ETERNITY if self.variable.definition_period == ETERNITY else str(period))
-        if extra_params:
-            filename = '{}_{}'.format(filename, '_'.join([str(param) for param in extra_params]))
-        path = os.path.join(self.data_store_dir, filename) + '.npy'
-        np.save(path, value)
-        return DatedHolder(self, period, value, extra_params)
 
     def put_in_cache(self, value, period, extra_params = None):
         simulation = self.simulation
@@ -426,13 +461,30 @@ class Holder(object):
 
         return self.put_in_disk_cache(value, period, extra_params)
 
+    def put_in_disk_cache(self, value, period, extra_params = None):
+        if self.variable.definition_period == ETERNITY:
+            filename = ETERNITY
+            period = periods.period(ETERNITY)
+        else:
+            filename = str(period)
+        if extra_params:
+            filename = '{}_{}'.format(filename, '_'.join([str(param) for param in extra_params]))
+        path = os.path.join(self.data_store_dir, filename) + '.npy'
+        np.save(path, value)
+        if extra_params is None:
+            self.disk_cache[period] = path
+        else:
+            if self.disk_cache.get(period) is None:
+                self.disk_cache[period] = {}
+            self.disk_cache[period][tuple(extra_params)] = path
+
+        return DatedHolder(self, period, value, extra_params)
+
     def put_in_memory_cache(self, value, period, extra_params = None):
 
         if self.variable.definition_period == ETERNITY:
             self.array = value
         array_by_period = self._array_by_period
-        if array_by_period is None:
-            self._array_by_period = array_by_period = {}
         if extra_params is None:
             array_by_period[period] = value
         else:
@@ -441,28 +493,12 @@ class Holder(object):
             array_by_period[period][tuple(extra_params)] = value
         return self.get_from_cache(period, extra_params)
 
-    def get_from_memory_cache(self, period, extra_params = None):
-        if self.variable.definition_period == ETERNITY:
-            return self
-
-        value = self.get_array(period, extra_params)
-        return DatedHolder(self, period, value, extra_params)
-
-    def get_from_disk_cache(self, period, extra_params = None):
-        filename = ETERNITY if self.variable.definition_period == ETERNITY else str(period)
-        if extra_params:
-            filename = '{}_{}'.format(filename, '_'.join([str(param) for param in extra_params]))
-        path = os.path.join(self.data_store_dir, filename) + '.npy'
-        value = None
-        if os.path.isfile(path):
-            value = np.load(path)
-        return DatedHolder(self, period, value, extra_params)
-
     def get_from_cache(self, period, extra_params = None):
         if self.variable.is_neutralized:
             return DatedHolder(self, period, value = self.default_array())
 
-        return self.get_from_disk_cache(period, extra_params)
+        value = self.get_array(period, extra_params)
+        return DatedHolder(self, period, value, extra_params)
 
     def get_extra_param_names(self, period):
         function = self.formula.find_function(period)
@@ -488,21 +524,34 @@ class Holder(object):
                 for cell in array.tolist()
                 ]
         value_json = {}
-        if self._array_by_period is not None:
-            for period, array_or_dict in self._array_by_period.iteritems():
-                if type(array_or_dict) == dict:
-                    value_json[str(period)] = values_dict = {}
-                    for extra_params, array in array_or_dict.iteritems():
-                        extra_params_key = extra_params_to_json_key(extra_params, period)
-                        values_dict[str(extra_params_key)] = [
-                            transform_dated_value_to_json(cell, use_label = use_label)
-                            for cell in array.tolist()
-                            ]
-                else:
-                    value_json[str(period)] = [
+        for period, array_or_dict in self._array_by_period.iteritems():
+            if type(array_or_dict) == dict:
+                value_json[str(period)] = values_dict = {}
+                for extra_params, array in array_or_dict.iteritems():
+                    extra_params_key = extra_params_to_json_key(extra_params, period)
+                    values_dict[str(extra_params_key)] = [
                         transform_dated_value_to_json(cell, use_label = use_label)
-                        for cell in array_or_dict.tolist()
+                        for cell in array.tolist()
                         ]
+            else:
+                value_json[str(period)] = [
+                    transform_dated_value_to_json(cell, use_label = use_label)
+                    for cell in array_or_dict.tolist()
+                    ]
+        for period, file_or_dict in self.disk_cache.iteritems():
+            if type(file_or_dict) == dict:
+                value_json[str(period)] = values_dict = {}
+                for extra_params, file in file_or_dict.iteritems():
+                    extra_params_key = extra_params_to_json_key(extra_params, period)
+                    values_dict[str(extra_params_key)] = [
+                        transform_dated_value_to_json(cell, use_label = use_label)
+                        for cell in np.load(file).tolist()
+                        ]
+            else:
+                value_json[str(period)] = [
+                    transform_dated_value_to_json(cell, use_label = use_label)
+                    for cell in np.load(file_or_dict).tolist()
+                    ]
         return value_json
 
     def default_array(self):

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -390,7 +390,13 @@ class Holder(object):
                 self.variable.name in simulation.tax_benefit_system.cache_blacklist):
             return DatedHolder(self, period, value, extra_params)
 
-        if self._on_disk_storable and (psutil.virtual_memory().percent >= self.simulation.memory_config.max_memory_occupation_pc):
+        should_store_on_disk = (
+            self._on_disk_storable and
+            not self._memory_storage.get(period, extra_params) and  # If there is already a value in memory, replace it and don't put a new value in the disk storage
+            psutil.virtual_memory().percent >= self.simulation.memory_config.max_memory_occupation_pc
+            )
+
+        if should_store_on_disk:
             self._disk_storage.put(value, period, extra_params)
         else:
             self._memory_storage.put(value, period, extra_params)

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -375,6 +375,8 @@ class Holder(object):
 
     def put_in_disk_cache(self, value, period, extra_params = None):
         filename = (ETERNITY if self.variable.definition_period == ETERNITY else str(period))
+        if extra_params:
+            filename = '{}_{}'.format(filename, '_'.join([str(param) for param in extra_params]))
         path = os.path.join(self.data_store_dir, filename) + '.npy'
         np.save(path, value)
         return DatedHolder(self, period, value, extra_params)
@@ -448,6 +450,8 @@ class Holder(object):
 
     def get_from_disk_cache(self, period, extra_params = None):
         filename = ETERNITY if self.variable.definition_period == ETERNITY else str(period)
+        if extra_params:
+            filename = '{}_{}'.format(filename, '_'.join([str(param) for param in extra_params]))
         path = os.path.join(self.data_store_dir, filename) + '.npy'
         value = None
         if os.path.isfile(path):

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -3,7 +3,6 @@
 
 from __future__ import division
 import logging
-import shutil
 import os
 import warnings
 
@@ -15,6 +14,7 @@ import periods
 from periods import MONTH, YEAR, ETERNITY
 from columns import make_column_from_variable
 from indexed_enums import Enum, EnumArray
+from data_storage import InMemoryStorage, OnDiskStorage
 
 log = logging.getLogger(__name__)
 
@@ -483,144 +483,3 @@ class PeriodMismatchError(ValueError):
         self.period = period
         self.definition_period = definition_period
         ValueError.__init__(self, message)
-
-
-class OnDiskStorage(object):
-
-    def __init__(self, storage_dir, is_eternal = False):
-        self._files = {}
-        self.is_eternal = is_eternal
-        self.storage_dir = storage_dir
-
-    def get(self, period, extra_params = None):
-        if self.is_eternal:
-            period = periods.period(ETERNITY)
-        period = periods.period(period)
-
-        values = self._files.get(period)
-        if values is None:
-            return None
-        if extra_params:
-            if values.get(tuple(extra_params)) is None:
-                return None
-            return np.load(values.get(tuple(extra_params)))
-        if isinstance(values, dict):
-            return np.load(values.values()[0])
-        return np.load(values)
-
-    def put(self, value, period, extra_params = None):
-        if self.is_eternal:
-            period = periods.period(ETERNITY)
-        period = periods.period(period)
-
-        filename = str(period)
-        if extra_params:
-            filename = '{}_{}'.format(
-                filename, '_'.join([str(param) for param in extra_params]))
-        path = os.path.join(self.storage_dir, filename) + '.npy'
-        np.save(path, value)
-        if extra_params is None:
-            self._files[period] = path
-        else:
-            if self._files.get(period) is None:
-                self._files[period] = {}
-            self._files[period][tuple(extra_params)] = path
-
-    def delete(self, period = None):
-        if period is None:
-            self._files = {}
-            return
-
-        if self.is_eternal:
-            period = periods.period(ETERNITY)
-        period = periods.period(period)
-
-        if period is not None:
-            self._files = {
-                period_item: value
-                for period_item, value in self._files.iteritems()
-                if not period.contains(period_item)
-                }
-
-    def get_known_periods(self):
-        return self._files.keys()
-
-    def __del__(self):
-        shutil.rmtree(self.storage_dir)  # Remove the holder temporary files
-        # If the simulation temporary directory is empty, remove it
-        parent_dir = os.path.abspath(os.path.join(self.storage_dir, os.pardir))
-        if not os.listdir(parent_dir):
-            shutil.rmtree(parent_dir)
-
-
-class InMemoryStorage(object):
-
-    def __init__(self, is_eternal = False):
-        self._arrays = {}
-        self.is_eternal = is_eternal
-
-    def get(self, period, extra_params = None):
-        if self.is_eternal:
-            period = periods.period(ETERNITY)
-        period = periods.period(period)
-
-        values = self._arrays.get(period)
-        if values is None:
-            return None
-        if extra_params:
-            return values.get(tuple(extra_params))
-        if isinstance(values, dict):
-            return values.values()[0]
-        return values
-
-    def put(self, value, period, extra_params = None):
-        if self.is_eternal:
-            period = periods.period(ETERNITY)
-        period = periods.period(period)
-
-        if extra_params is None:
-            self._arrays[period] = value
-        else:
-            if self._arrays.get(period) is None:
-                self._arrays[period] = {}
-            self._arrays[period][tuple(extra_params)] = value
-
-    def delete(self, period = None):
-        if period is None:
-            self._arrays = {}
-            return
-
-        if self.is_eternal:
-            period = periods.period(ETERNITY)
-        period = periods.period(period)
-
-        self._arrays = {
-            period_item: value
-            for period_item, value in self._arrays.iteritems()
-            if not period.contains(period_item)
-            }
-
-    def get_known_periods(self):
-        return self._arrays.keys()
-
-    def get_memory_usage(self):
-        if not self._arrays:
-            return dict(
-                nb_arrays = 0,
-                total_nb_bytes = 0,
-                cell_size = np.nan,
-                )
-
-        nb_arrays = sum([
-            len(array_or_dict) if isinstance(array_or_dict, dict) else 1
-            for array_or_dict in self._arrays.itervalues()
-            ])
-
-        array = self._arrays.values()[0]
-        if isinstance(array, dict):
-            array = array.values()[0]
-        return dict(
-            nb_arrays = nb_arrays,
-            total_nb_bytes = array.nbytes * nb_arrays,
-            cell_size = array.itemsize,
-            )

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -392,7 +392,7 @@ class Holder(object):
 
         should_store_on_disk = (
             self._on_disk_storable and
-            not self._memory_storage.get(period, extra_params) and  # If there is already a value in memory, replace it and don't put a new value in the disk storage
+            self._memory_storage.get(period, extra_params) is None and  # If there is already a value in memory, replace it and don't put a new value in the disk storage
             psutil.virtual_memory().percent >= self.simulation.memory_config.max_memory_occupation_pc
             )
 

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -436,13 +436,14 @@ class Holder(object):
         value_json = {}
         for period, array_or_dict in self._memory_storage._arrays.iteritems():
             if type(array_or_dict) == dict:
-                value_json[str(period)] = values_dict = {}
+                values_dict = {}
                 for extra_params, array in array_or_dict.iteritems():
                     extra_params_key = extra_params_to_json_key(extra_params, period)
                     values_dict[str(extra_params_key)] = [
                         transform_dated_value_to_json(cell, use_label = use_label)
                         for cell in array.tolist()
                         ]
+                value_json[str(period)] = values_dict
             else:
                 value_json[str(period)] = [
                     transform_dated_value_to_json(cell, use_label = use_label)
@@ -451,13 +452,14 @@ class Holder(object):
         if self._disk_storage:
             for period, file_or_dict in self._disk_storage._files.iteritems():
                 if type(file_or_dict) == dict:
-                    value_json[str(period)] = values_dict = {}
+                    values_dict = {}
                     for extra_params, file in file_or_dict.iteritems():
                         extra_params_key = extra_params_to_json_key(extra_params, period)
                         values_dict[str(extra_params_key)] = [
                             transform_dated_value_to_json(cell, use_label = use_label)
                             for cell in np.load(file).tolist()
                             ]
+                    value_json[str(period)] = values_dict
                 else:
                     value_json[str(period)] = [
                         transform_dated_value_to_json(cell, use_label = use_label)

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -295,6 +295,8 @@ class Holder(object):
             >>>    'cell_size': 8,  # Each value takes 8B of memory
             >>>    'dtype': dtype('float64')  # Each value is a float 64
             >>>    'total_nb_bytes': 10400  # The holder uses 10.4kB of virtual memory
+            >>>    'nb_requests': 24  # The variable has been computed 24 times
+            >>>    'nb_requests_by_array': 2  # Each array stored has been on average requested twice
             >>>    }
         """
 
@@ -304,6 +306,13 @@ class Holder(object):
             )
 
         usage.update(self._memory_storage.get_memory_usage())
+
+        if self.simulation.trace:
+            usage_stats = self.simulation.tracer.usage_stats[self.variable.name]
+            usage.update(dict(
+                nb_requests = usage_stats['nb_requests'],
+                nb_requests_by_array = usage_stats['nb_requests'] / float(usage['nb_arrays']) if usage['nb_arrays'] > 0 else np.nan
+                ))
 
         return usage
 

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -2,18 +2,19 @@
 
 
 from __future__ import division
-import warnings
+import logging
+import shutil
 import os
+import warnings
 
 import numpy as np
+import psutil
 
 from commons import empty_clone
 import periods
 from periods import MONTH, YEAR, ETERNITY
 from columns import make_column_from_variable
 from indexed_enums import Enum, EnumArray
-import logging
-import psutil
 
 log = logging.getLogger(__name__)
 
@@ -528,6 +529,12 @@ class OnDiskStorage(object):
     def get_known_periods(self):
         return self._files.keys()
 
+    def __del__(self):
+        shutil.rmtree(self.storage_dir)  # Remove the holder temporary files
+        # If the simulation temporary directory is empty, remove it
+        parent_dir = os.path.abspath(os.path.join(self.storage_dir, os.pardir))
+        if not os.listdir(parent_dir):
+            shutil.rmtree(parent_dir)
 
 
 class InMemoryStorage(object):

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -102,12 +102,12 @@ class Holder(object):
             if self.variable.name in self.simulation.memory_config.variables_to_drop:
                 self._do_not_store = True
 
-    # Sould probably be deprecated
+    # Should probably be deprecated
     @property
     def array(self):
         return self.get_array(self.simulation.period)
 
-    # Sould probably be deprecated
+    # Should probably be deprecated
     @array.setter
     def array(self, array):
         self.put_in_cache(array, self.simulation.period)

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -107,11 +107,10 @@ class Holder(object):
     def array(self):
         return self.get_array(self.simulation.period)
 
+    # Sould probably be deprecated
     @array.setter
     def array(self, array):
-        if self.variable.definition_period != ETERNITY:
-            return self.put_in_cache(array, self.simulation.period)
-        self._array = array
+        self.put_in_cache(array, self.simulation.period)
 
     def calculate(self, period, **parameters):
         dated_holder = self.compute(period = period, **parameters)

--- a/openfisca_core/memory_config.py
+++ b/openfisca_core/memory_config.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class MemoryConfig(object):
+
+    def __init__(self,
+      max_memory_occupation,
+      priority_variables = None,
+      variables_to_drop = None):
+        log.warn("Memory configuration is a feature that is still currently under experimentation. You are very welcome to use it and send us precious feedback, but keep in mind that the way it is used might change without any major version bump.")
+
+        self.max_memory_occupation = float(max_memory_occupation)
+        if self.max_memory_occupation > 1:
+            raise ValueError("max_memory_occupation must be <= 1")
+        self.max_memory_occupation_pc = self.max_memory_occupation * 100
+        self.priority_variables = set(priority_variables) if priority_variables else set()
+        self.variables_to_drop = set(variables_to_drop) if variables_to_drop else set()

--- a/openfisca_core/periods.py
+++ b/openfisca_core/periods.py
@@ -612,6 +612,8 @@ class Period(tuple):
         """
         unit, start_instant, size = self
         year, month, day = start_instant
+        if unit == ETERNITY:
+            return Instant((float("inf"), float("inf"), float("inf")))
         if unit == u'day':
             if size > 1:
                 day += size - 1

--- a/openfisca_core/periods.py
+++ b/openfisca_core/periods.py
@@ -787,7 +787,7 @@ def period(value):
             ])
         raise ValueError(message)
 
-    if value == 'ETERNITY':
+    if value == 'ETERNITY' or value == ETERNITY:
         return Period((u'eternity', instant(datetime.date.min), float("inf")))
 
     # check the type

--- a/openfisca_core/periods.py
+++ b/openfisca_core/periods.py
@@ -764,6 +764,8 @@ def period(value):
     >>> period(u'year:2014-2')
     Period((YEAR, Instant((2014, 2, 1)), 1))
     """
+    if isinstance(value, Period):
+        return value
 
     def parse_simple_period(value):
         """
@@ -795,8 +797,6 @@ def period(value):
     # check the type
     if isinstance(value, int):
         return Period((YEAR, Instant((value, 1, 1)), 1))
-    if isinstance(value, Period):
-        return value
     if not isinstance(value, basestring):
         raise_error(value)
 

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -3,6 +3,7 @@
 
 import warnings
 from os import linesep
+import tempfile
 
 import dpath
 
@@ -58,9 +59,18 @@ class Simulation(object):
         # Note: Since simulations are short-lived and must be fast, don't use weakrefs for cache.
         self._parameters_at_instant_cache = {}
         self.baseline_parameters_at_instant_cache = {}
-
         self.instantiate_entities(simulation_json)
-        self.tmp_dir = None  # To set later in case the memory is saturated
+        self._data_store_dir = None  # To set later in case the memory is saturated
+
+
+    @property
+    def data_store_dir(self):
+        """
+        Temporary folder used to store intermediate calculation data in case the memory is saturated
+        """
+        if self._data_store_dir is None:
+            self._data_store_dir = tempfile.mkdtemp(prefix = "openfisca_")
+        return self._data_store_dir
 
     def instantiate_entities(self, simulation_json):
         if simulation_json:

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -54,11 +54,12 @@ class Simulation(object):
         self.requested_periods_by_variable_name = {}
         self.max_nb_cycles = None
 
-        if debug:
-            self.debug = True
-        if debug or trace:
-            self.trace = True
+        self.debug = debug
+        self.trace = trace or self.debug
+        if self.trace:
             self.tracer = Tracer()
+        else:
+            self.tracer = None
         self.opt_out_cache = opt_out_cache
 
         # Note: Since simulations are short-lived and must be fast, don't use weakrefs for cache.

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -4,12 +4,16 @@
 import warnings
 from os import linesep
 import tempfile
+import logging
 
 import dpath
 
 import periods
 from commons import empty_clone
 from tracers import Tracer
+
+
+log = logging.getLogger(__name__)
 
 
 class Simulation(object):
@@ -28,7 +32,8 @@ class Simulation(object):
             tax_benefit_system = None,
             trace = False,
             opt_out_cache = False,
-            simulation_json = None
+            simulation_json = None,
+            memory_config = None,
             ):
         """
             If a simulation_json is given, initilalises a simulation from a JSON dictionnary.
@@ -59,18 +64,9 @@ class Simulation(object):
         # Note: Since simulations are short-lived and must be fast, don't use weakrefs for cache.
         self._parameters_at_instant_cache = {}
         self.baseline_parameters_at_instant_cache = {}
-        self._data_store_dir = None
-        self.cache_on_disk = False
+        self.memory_config = memory_config
+        self._data_storage_dir = None
         self.instantiate_entities(simulation_json)
-
-    @property
-    def data_store_dir(self):
-        """
-        Temporary folder used to store intermediate calculation data in case the memory is saturated
-        """
-        if self._data_store_dir is None:
-            self._data_store_dir = tempfile.mkdtemp(prefix = "openfisca_")
-        return self._data_store_dir
 
     def instantiate_entities(self, simulation_json):
         if simulation_json:
@@ -103,6 +99,19 @@ class Simulation(object):
                 entities = entity_class(self)
             self.entities[entity_class.key] = entities
             setattr(self, entity_class.key, entities)  # create shortcut simulation.household (for instance)
+
+    @property
+    def data_storage_dir(self):
+        """
+        Temporary folder used to store intermediate calculation data in case the memory is saturated
+        """
+        if self._data_storage_dir is None:
+            self._data_storage_dir = tempfile.mkdtemp(prefix = "openfisca_")
+            log.warn((
+                u"Intermediate results will be stored on disk in {} in case of memory overflow. "
+                u"You should remove this directory once you're done with your simulation."
+                ).format(self._data_storage_dir).encode('utf-8'))
+        return self._data_storage_dir
 
     @property
     def holder_by_name(self):

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -59,9 +59,9 @@ class Simulation(object):
         # Note: Since simulations are short-lived and must be fast, don't use weakrefs for cache.
         self._parameters_at_instant_cache = {}
         self.baseline_parameters_at_instant_cache = {}
+        self._data_store_dir = None
+        self.cache_on_disk = False
         self.instantiate_entities(simulation_json)
-        self._data_store_dir = None  # To set later in case the memory is saturated
-
 
     @property
     def data_store_dir(self):

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -60,6 +60,7 @@ class Simulation(object):
         self.baseline_parameters_at_instant_cache = {}
 
         self.instantiate_entities(simulation_json)
+        self.tmp_dir = None  # To set later in case the memory is saturated
 
     def instantiate_entities(self, simulation_json):
         if simulation_json:

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -236,9 +236,9 @@ class Variable(object):
         if not base_function and self.baseline_variable:
             return self.baseline_variable.formula.base_function.im_func
         if self.definition_period == ETERNITY:
-            if base_function and not base_function == permanent_default_value:
+            if base_function and base_function not in [permanent_default_value, requested_period_default_value]:
                 raise ValueError('Unexpected base_function {}'.format(base_function))
-            return permanent_default_value
+            return requested_period_default_value
 
         if self.is_period_size_independent:
             if base_function is None:

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'dpath == 1.4.0',
         'jsonschema >= 2.6',
         'enum34 >= 1.1.6',
+        'psutil == 5.4.2',
         ],
     message_extractors = {
         'openfisca_core': [

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '21.1.0',
+    version = '21.2.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/core/test_base_functions.py
+++ b/tests/core/test_base_functions.py
@@ -1,0 +1,45 @@
+import numpy as np
+from openfisca_core.tools import assert_near
+
+from test_countries import tax_benefit_system
+from openfisca_country_template.situation_examples import single
+from openfisca_country_template.entities import Person
+from openfisca_core.model_api import *  # noqa
+from openfisca_core.simulations import Simulation
+from openfisca_core.periods import period
+
+from test_holders import force_storage_on_disk
+
+
+class state_variable(Variable):
+    entity = Person
+    definition_period = MONTH
+    base_function = requested_period_last_value
+    value_type = int
+
+
+tax_benefit_system.add_variable(state_variable)
+
+
+def get_simulation(**kwargs):
+    return Simulation(tax_benefit_system = tax_benefit_system, simulation_json = single, **kwargs)
+
+
+def test_memory_cache():
+    simulation = get_simulation()
+    value = np.asarray([1])
+    simulation.person.get_holder('state_variable').put_in_cache(value, period('2017-01'))
+    assert_near(
+        simulation.calculate('state_variable', '2017-02'),
+        value
+        )
+
+
+def test_disk_cache():
+    simulation = get_simulation(memory_config = force_storage_on_disk)
+    value = np.asarray([1])
+    simulation.person.get_holder('state_variable').put_in_cache(value, period('2017-01'))
+    assert_near(
+        simulation.calculate('state_variable', '2017-02'),
+        value
+        )

--- a/tests/core/test_extra_params.py
+++ b/tests/core/test_extra_params.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from nose.tools import assert_equal
 
 from openfisca_core import periods
 from openfisca_core.periods import MONTH
@@ -71,8 +72,10 @@ def test_get_extra_param_names():
 
 
 def test_json_conversion():
-    assert str(formula_3_holder.to_value_json()) == \
+    assert_equal(
+        str(formula_3_holder.to_value_json()),
         "{'2013-01': {'{choice: 1}': [1], '{choice: 0}': [0]}}"
+        )
 
 
 def test_base_functions():

--- a/tests/core/test_extra_params.py
+++ b/tests/core/test_extra_params.py
@@ -54,24 +54,32 @@ tax_benefit_system.add_variables(formula_1, formula_2, formula_3, formula_4)
 
 reference_period = periods.period(u'2013-01')
 
-simulation = tax_benefit_system.new_scenario().init_from_attributes(
-    period = reference_period.first_month,
-    ).new_simulation(debug = True)
-formula_1_result = simulation.calculate('formula_1', period = reference_period)
-formula_2_result = simulation.calculate('formula_2', period = reference_period)
-formula_3_holder = simulation.person.get_holder('formula_3')
+
+def get_simulation():
+    return tax_benefit_system.new_scenario().init_from_attributes(
+        period = reference_period.first_month,
+        ).new_simulation()
 
 
 def test_cache():
+    simulation = get_simulation()
+    formula_1_result = simulation.calculate('formula_1', period = reference_period)
+    formula_2_result = simulation.calculate('formula_2', period = reference_period)
     assert_near(formula_1_result, [0])
     assert_near(formula_2_result, [1])
 
 
 def test_get_extra_param_names():
+    simulation = get_simulation()
+    formula_3_holder = simulation.person.get_holder('formula_3')
     assert formula_3_holder.get_extra_param_names(reference_period) == ('choice',)
 
 
 def test_json_conversion():
+    simulation = get_simulation()
+    simulation.calculate('formula_1', period = reference_period)
+    simulation.calculate('formula_2', period = reference_period)
+    formula_3_holder = simulation.person.get_holder('formula_3')
     assert_equal(
         str(formula_3_holder.to_value_json()),
         "{'2013-01': {'{choice: 1}': [1], '{choice: 0}': [0]}}"
@@ -79,6 +87,7 @@ def test_json_conversion():
 
 
 def test_base_functions():
+    simulation = get_simulation()
     assert simulation.calculate('formula_4', '2013-01', extra_params = [0]) == 0
     assert simulation.calculate('formula_4', '2013-01', extra_params = [1]) == 1
 

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -69,6 +69,7 @@ def test_get_memory_usage():
 
 def test_cache_disk():
     simulation = get_simulation(single)
+    simulation.cache_on_disk = True
     month = make_period('2017-01')
     holder = simulation.person.get_holder('salary')
     data = np.asarray([2000, 3000, 0, 500])
@@ -79,6 +80,7 @@ def test_cache_disk():
 
 def test_cache_disk_with_extra_params():
     simulation = get_simulation()
+    simulation.cache_on_disk = True
     month = period('2017-01')
     extra_param_1 = period('2017-02')
     extra_param_2 = period('2017-03')

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -6,6 +6,7 @@ from nose.tools import assert_equal
 from openfisca_country_template.situation_examples import couple, single
 from openfisca_core.simulations import Simulation
 from openfisca_core.periods import period as make_period
+from openfisca_core.tools import assert_near
 from test_countries import tax_benefit_system
 
 period = make_period('2017-12')
@@ -64,3 +65,13 @@ def test_get_memory_usage():
     assert_equal(memory_usage['nb_cells_by_array'], 1)  # one person
     assert_equal(memory_usage['nb_arrays'], 12)  # 12 months
     assert_equal(memory_usage['total_nb_bytes'], 4 * 12 * 1)
+
+
+def test_cache_disk():
+    simulation = get_simulation(single)
+    month = make_period('2017-01')
+    holder = simulation.person.get_holder('salary')
+    data = np.asarray([2000, 3000, 0, 500])
+    holder.put_in_disk_cache(data, month)
+    stored_data = holder.get_from_disk_cache(month).array
+    assert_near(data, stored_data)

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -7,14 +7,16 @@ from openfisca_country_template.situation_examples import couple, single
 from openfisca_core.simulations import Simulation
 from openfisca_core.periods import period as make_period, ETERNITY
 from openfisca_core.tools import assert_near
+from openfisca_core.memory_config import MemoryConfig
 from test_countries import tax_benefit_system
+
+
+def get_simulation(json, **kwargs):
+    return Simulation(tax_benefit_system = tax_benefit_system, simulation_json = json, **kwargs)
+
 
 period = make_period('2017-12')
 HousingOccupancyStatus = tax_benefit_system.get_variable('housing_occupancy_status').possible_values
-
-
-def get_simulation(json):
-    return Simulation(tax_benefit_system = tax_benefit_system, simulation_json = json)
 
 
 def test_set_input_enum_string():
@@ -65,8 +67,9 @@ def test_delete_arrays():
     assert_equal(simulation.person('salary', '2017-01'), 2500)
     assert_equal(simulation.person('salary', '2018-01'), 5000)
     salary_holder.delete_arrays(period = 2018)
+    salary_holder.set_input(period(2018), np.asarray([15000]))
     assert_equal(simulation.person('salary', '2017-01'), 2500)
-    assert_equal(simulation.person('salary', '2018-01'), 0)
+    assert_equal(simulation.person('salary', '2018-01'), 1250)
 
 
 def test_get_memory_usage():
@@ -83,9 +86,11 @@ def test_get_memory_usage():
     assert_equal(memory_usage['total_nb_bytes'], 4 * 12 * 1)
 
 
+force_storage_on_disk = MemoryConfig(max_memory_occupation = 0)
+
+
 def test_delete_arrays_on_disk():
-    simulation = get_simulation()
-    simulation.cache_on_disk = True
+    simulation = get_simulation(memory_config = force_storage_on_disk)  # Force using disk
     salary_holder = simulation.person.get_holder('salary')
     salary_holder.set_input(period(2017), np.asarray([30000]))
     salary_holder.set_input(period(2018), np.asarray([60000]))
@@ -98,27 +103,25 @@ def test_delete_arrays_on_disk():
 
 
 def test_cache_disk():
-    simulation = get_simulation(single)
-    simulation.cache_on_disk = True
+    simulation = get_simulation(single, memory_config = force_storage_on_disk)  # Force using disk
     month = make_period('2017-01')
     holder = simulation.person.get_holder('salary')
     data = np.asarray([2000, 3000, 0, 500])
-    holder.put_in_disk_cache(data, month)
+    holder.put_in_cache(data, month)
     stored_data = holder.get_array(month)
     assert_near(data, stored_data)
 
 
 def test_cache_disk_with_extra_params():
-    simulation = get_simulation()
-    simulation.cache_on_disk = True
+    simulation = get_simulation(memory_config = force_storage_on_disk)  # Force using disk
     month = period('2017-01')
     extra_param_1 = period('2017-02')
     extra_param_2 = period('2017-03')
     holder = simulation.person.get_holder('salary')
     data_1 = np.asarray([2000, 3000, 0, 500])
     data_2 = np.asarray([1000, 4000, 200, 200])
-    holder.put_in_disk_cache(data_1, month, extra_params = [extra_param_1])
-    holder.put_in_disk_cache(data_2, month, extra_params = [extra_param_2])
+    holder.put_in_cache(data_1, month, extra_params = [extra_param_1])
+    holder.put_in_cache(data_2, month, extra_params = [extra_param_2])
     stored_data_1 = holder.get_array(month, extra_params = [extra_param_1])
     stored_data_2 = holder.get_array(month, extra_params = [extra_param_2])
     assert_near(data_1, stored_data_1)
@@ -126,12 +129,11 @@ def test_cache_disk_with_extra_params():
 
 
 def test_known_periods():
-    simulation = get_simulation()
-    simulation.cache_on_disk = True
+    simulation = get_simulation(memory_config = force_storage_on_disk)  # Force using disk
     month = period('2017-01')
     month_2 = period('2017-02')
     holder = simulation.person.get_holder('salary')
     data = np.asarray([2000, 3000, 0, 500])
-    holder.put_in_disk_cache(data, month)
-    holder.put_in_memory_cache(data, month_2)
+    holder.put_in_cache(data, month)
+    holder._memory_storage.put(data, month_2)
     assert_items_equal(holder.get_known_periods(), [month, month_2])

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -75,3 +75,18 @@ def test_cache_disk():
     holder.put_in_disk_cache(data, month)
     stored_data = holder.get_from_disk_cache(month).array
     assert_near(data, stored_data)
+
+def test_cache_disk_with_extra_params():
+    simulation = get_simulation()
+    month = period('2017-01')
+    extra_param_1 = period('2017-02')
+    extra_param_2 = period('2017-03')
+    holder = simulation.person.get_holder('salary')
+    data_1 = np.asarray([2000, 3000, 0, 500])
+    data_2 = np.asarray([1000, 4000, 200, 200])
+    holder.put_in_disk_cache(data_1, month, extra_params = [extra_param_1])
+    holder.put_in_disk_cache(data_2, month, extra_params = [extra_param_2])
+    stored_data_1 = holder.get_from_disk_cache(month, extra_params = [extra_param_1]).array
+    stored_data_2 = holder.get_from_disk_cache(month, extra_params = [extra_param_2]).array
+    assert_near(data_1, stored_data_1)
+    assert_near(data_2, stored_data_2)

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_items_equal
 
 from openfisca_country_template.situation_examples import couple, single
 from openfisca_core.simulations import Simulation
@@ -93,3 +93,15 @@ def test_cache_disk_with_extra_params():
     stored_data_2 = holder.get_array(month, extra_params = [extra_param_2])
     assert_near(data_1, stored_data_1)
     assert_near(data_2, stored_data_2)
+
+
+def test_known_periods():
+    simulation = get_simulation()
+    simulation.cache_on_disk = True
+    month = period('2017-01')
+    month_2 = period('2017-02')
+    holder = simulation.person.get_holder('salary')
+    data = np.asarray([2000, 3000, 0, 500])
+    holder.put_in_disk_cache(data, month)
+    holder.put_in_memory_cache(data, month_2)
+    assert_items_equal(holder.known_periods(), [month, month_2])

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -73,8 +73,9 @@ def test_cache_disk():
     holder = simulation.person.get_holder('salary')
     data = np.asarray([2000, 3000, 0, 500])
     holder.put_in_disk_cache(data, month)
-    stored_data = holder.get_from_disk_cache(month).array
+    stored_data = holder.get_array(month)
     assert_near(data, stored_data)
+
 
 def test_cache_disk_with_extra_params():
     simulation = get_simulation()
@@ -86,7 +87,7 @@ def test_cache_disk_with_extra_params():
     data_2 = np.asarray([1000, 4000, 200, 200])
     holder.put_in_disk_cache(data_1, month, extra_params = [extra_param_1])
     holder.put_in_disk_cache(data_2, month, extra_params = [extra_param_2])
-    stored_data_1 = holder.get_from_disk_cache(month, extra_params = [extra_param_1]).array
-    stored_data_2 = holder.get_from_disk_cache(month, extra_params = [extra_param_2]).array
+    stored_data_1 = holder.get_array(month, extra_params = [extra_param_1])
+    stored_data_2 = holder.get_array(month, extra_params = [extra_param_2])
     assert_near(data_1, stored_data_1)
     assert_near(data_2, stored_data_2)

--- a/tests/core/test_opt_out_cache.py
+++ b/tests/core/test_opt_out_cache.py
@@ -49,7 +49,6 @@ tax_benefit_system = get_filled_tbs()
 
 tax_benefit_system.cache_blacklist = set(['intermediate'])
 
-
 month = '2016-05'
 scenario = tax_benefit_system.new_scenario().init_from_attributes(
     period = month,
@@ -60,22 +59,22 @@ scenario = tax_benefit_system.new_scenario().init_from_attributes(
 
 
 def test_without_cache_opt_out():
-    simulation = scenario.new_simulation(debug = True)
+    simulation = scenario.new_simulation()
     simulation.calculate('output', period = month)
     intermediate_cache = simulation.persons.get_holder('intermediate')
-    assert(len(intermediate_cache._array_by_period) > 0)
+    assert(intermediate_cache.get_array(month) is not None)
 
 
 def test_with_cache_opt_out():
     simulation = scenario.new_simulation(debug = True, opt_out_cache = True)
     simulation.calculate('output', period = month)
     intermediate_cache = simulation.persons.get_holder('intermediate')
-    assert(intermediate_cache._array_by_period is None)
+    assert(intermediate_cache.get_array(month) is None)
 
 
 tax_benefit_system2 = get_filled_tbs()
 
-month = '2016-09'
+month = '2016-05'
 scenario2 = tax_benefit_system2.new_scenario().init_from_attributes(
     period = month,
     input_variables = {
@@ -85,7 +84,7 @@ scenario2 = tax_benefit_system2.new_scenario().init_from_attributes(
 
 
 def test_with_no_blacklist():
-    simulation = scenario2.new_simulation(debug = True, opt_out_cache = True)
+    simulation = scenario2.new_simulation(opt_out_cache = True)
     simulation.calculate('output', period = month)
     intermediate_cache = simulation.persons.get_holder('intermediate')
-    assert(len(intermediate_cache._array_by_period) > 0)
+    assert(intermediate_cache.get_array(month) is not None)

--- a/tests/core/test_reforms.py
+++ b/tests/core/test_reforms.py
@@ -81,7 +81,7 @@ def test_neutralization_optimization():
 
     # As basic_income is neutralized, it should not be cached
     basic_income_holder = simulation.persons.get_holder('basic_income')
-    assert basic_income_holder._array_by_period is None
+    assert basic_income_holder.get_array('2013-01') is None
 
 
 def test_input_variable_neutralization():


### PR DESCRIPTION
Depends on #598.

_Attention: this PR is opened towards `update-taxipp-v20` to make the diff clearer. Once #598 is merged, the target branch must be changed to master_

#### New features

- Improve [`holder.get_memory_usage`]((http://openfisca.readthedocs.io/en/latest/holder.html#openfisca_core.holders.Holder.get_memory_usage)):
  - Add `nb_requests` and `nb_requests_by_array` fields in the memory usage stats for traced simulations.

- Enable intermediate data storage on disk to avoid memory overflow
  - Introduce `memory_config` option in `Simulation` constructor
    - This allows fine tuning of memory management in OpenFisca

For instance:

```
from openfisca_core.memory_config import MemoryConfig
config = MemoryConfig(
    max_memory_occupation = 0.95,  # When 95% of the virtual memory is full, switch to disk storage
    priority_variables = ['salary', 'age']  # Always store these variables in memory
    variables_to_drop = ['age_elder_for_family_benefit']  # Do not store the value of these variables
    )
```