### PR TITLE
Improve projectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+# 22.0.0 [#602](https://github.com/openfisca/openfisca-core/pull/602)
+
+#### Breaking changes
+
+- Improve entities projection consistency
+
+Before, there were inconsistencies in the behaviors of projectors:
+
+_For instance, for a simulation that contains 4 persons in 1 household:_
+
+```py
+person.household('rent', '2018-02')  # The rent paid by the household of the person.
+>>> [800, 800, 800, 800]  # Has the dimension of persons (4)
+
+salaries = person.household.members('salary', '2018-02')
+sum_salary = person.household.sum(salaries)  # The sum of the salaries of the person's family
+>>> [4000] Has the dimension of household (1)
+```
+
+
+Now, consistency have been enforced for all entities related helpers (`sum`, `min`, `max`, `all`, `any`, `has_role`, etc.)
+
+
+```py
+person.household('rent', '2018-02')  # The rent paid by the household of the person.
+>>> [800, 800, 800, 800]  # Has the dimension of persons (4)
+
+salaries = person.household.members('salary')
+sum_salary = person.household.sum(salaries)  # The sum of the salaries of the person's family
+>>> [4000, 4000, 4000, 4000]  # Has the dimension of persons (4)
+```
+
+This is a breaking change, as all the adaptations (such as [this one](https://github.com/openfisca/openfisca-france/blob/18.11.0/openfisca_france/model/prestations/minima_sociaux/rsa.py#L375-L376)) used to overcome these inconsistensies must be removed.
+
 ## 21.5.0 [#621](https://github.com/openfisca/openfisca-core/pull/621)
 
 - Introduce:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '21.5.0',
+    version = '22.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -6,7 +6,7 @@ from openfisca_core.tools import assert_near
 from openfisca_core.simulations import Simulation
 from openfisca_country_template.entities import Household
 from test_countries import tax_benefit_system
-from openfisca_country_template.situation_examples import single
+from openfisca_country_template.situation_examples import single, couple
 
 TEST_CASE = {
     'persons': [{'id': 'ind0'}, {'id': 'ind1'}, {'id': 'ind2'}, {'id': 'ind3'}, {'id': 'ind4'}, {'id': 'ind5'}],
@@ -336,19 +336,19 @@ def test_min():
 def test_value_nth_person():
     test_case = deepcopy(TEST_CASE_AGES)
     simulation = new_simulation(test_case)
-    person = simulation.person
-    array = person('age', MONTH)
+    household = simulation.household
+    array = household.members('age', MONTH)
 
-    result0 = person.household.value_nth_person(0, array, default=-1)
+    result0 = household.value_nth_person(0, array, default=-1)
     assert_near(result0, [40, 54])
 
-    result1 = person.household.value_nth_person(1, array, default=-1)
+    result1 = household.value_nth_person(1, array, default=-1)
     assert_near(result1, [37, 20])
 
-    result2 = person.household.value_nth_person(2, array, default=-1)
+    result2 = household.value_nth_person(2, array, default=-1)
     assert_near(result2, [7, -1])
 
-    result3 = person.household.value_nth_person(3, array, default=-1)
+    result3 = household.value_nth_person(3, array, default=-1)
     assert_near(result3, [9, -1])
 
 
@@ -396,6 +396,23 @@ def test_value_from_first_person():
     salary_first_person = household.value_from_first_person(salaries)
 
     assert_near(salary_first_person, [1000, 3000])
+
+
+def test_projectors_methods():
+    simulation = Simulation(tax_benefit_system = tax_benefit_system, simulation_json = couple)
+    household = simulation.household
+    person = simulation.person
+
+    projected_vector = household.first_parent.has_role(Household.FIRST_PARENT)
+    assert(len(projected_vector) == 1)  # Must be of a household dimension
+
+    salary_i = person.household.members('salary', '2017-01')
+    assert(len(person.household.sum(salary_i)) == 2)  # Must be of a person dimension
+    assert(len(person.household.max(salary_i)) == 2)  # Must be of a person dimension
+    assert(len(person.household.min(salary_i)) == 2)  # Must be of a person dimension
+    assert(len(person.household.all(salary_i)) == 2)  # Must be of a person dimension
+    assert(len(person.household.any(salary_i)) == 2)  # Must be of a person dimension
+    assert(len(household.first_parent.get_rank(household, salary_i)) == 1)  # Must be of a person dimension
 
 
 def test_sum_following_bug_ipp_1():


### PR DESCRIPTION
#### Breaking changes

- Improve entities projection consistency

Before, there were inconsistencies in the behaviors of projectors:

_For instance, for a simulation that contains 4 persons in 1 household:_

```py
person.household('rent')  # The rent paid by the household of the person.
>>> [800, 800, 800, 800]  # Has the dimension of persons (4)

salaries = person.household.members('salary')
sum_salary = person.houdehold.sum(salaries)  # The sum of the salaries of the person's family
>>> [4000] Has the dimension of household (1)
```


Now, consistency have been enforced for all entities related helpers (`sum`, `min`, `max`, `all`, `any`, `has_role`, etc.)


```py
person.household('rent')  # The rent paid by the household of the person.
>>> [800, 800, 800, 800]  # Has the dimension of persons (4)

salaries = person.household.members('salary')
sum_salary = person.houdehold.sum(salaries)  # The sum of the salaries of the person's family
>>> [4000, 4000, 4000, 4000]  # Has the dimension of persons (4)
```


This is a breaking change, as all the adaptations (such as [this one](https://github.com/openfisca/openfisca-france/blob/18.11.0/openfisca_france/model/prestations/minima_sociaux/rsa.py#L375-L376)) used to overcome these inconsistensies must be removed.

See impact on france: https://github.com/openfisca/openfisca-france/pull/895 