### PR TITLE
Add run test options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 21.3.0
+
+Add `--only-variables` and `--ignore-variables` options to `openfisca-run-test` to filter out tested output variables if needed.
+
 ### 21.2.2 [#612](https://github.com/openfisca/openfisca-core/pull/612)
 
 - When a variable file is loaded twice in the same python interpreter, make sure the second loading doesn't corrupt the first one.

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -15,6 +15,8 @@ def build_parser():
     parser = add_tax_benefit_system_arguments(parser)
     parser.add_argument('-n', '--name_filter', default = None, help = "partial name of tests to execute. Only tests with the given name_filter in their name, file name, or keywords will be run.")
     parser.add_argument('-v', '--verbose', action = 'store_true', default = False, help = "increase output verbosity")
+    parser.add_argument('-o', '--only-variables', nargs = '*', default = None, help = "variables to test. If specified, only test the given variables.")
+    parser.add_argument('-i', '--ignore-variables', nargs = '*', default = None, help = "variables to ignore. If specified, do not test the given variables.")
 
     return parser
 
@@ -29,6 +31,8 @@ def main():
     options = {
         'verbose': args.verbose,
         'name_filter': args.name_filter,
+        'only_variables': args.only_variables,
+        'ignore_variables': args.ignore_variables,
         }
 
     paths = map(os.path.abspath, args.path)

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -128,6 +128,8 @@ def _generate_tests_from_file(tax_benefit_system, path_to_file, options):
     if isinstance(name_filter, str):
         name_filter = name_filter.decode('utf-8')
     verbose = options.get('verbose')
+    only_variables = options.get('only_variables')
+    ignore_variables = options.get('ignore_variables')
 
     tests = _parse_test_file(tax_benefit_system, path_to_file)
 
@@ -147,7 +149,7 @@ def _generate_tests_from_file(tax_benefit_system, path_to_file, options):
 
         def check():
             try:
-                _run_test(period_str, test, verbose, options)
+                _run_test(period_str, test, verbose, only_variables, ignore_variables, options)
             except:
                 log.error(title)
                 raise
@@ -218,7 +220,7 @@ def _parse_test_file(tax_benefit_system, yaml_path):
         yield yaml_path, test.get('name') or filename, unicode(test['scenario'].period), test
 
 
-def _run_test(period_str, test, verbose = False, options = {}):
+def _run_test(period_str, test, verbose = False, only_variables = None, ignore_variables = None, options = {}):
     absolute_error_margin = None
     relative_error_margin = None
     if test.get('absolute_error_margin') is not None:
@@ -233,6 +235,10 @@ def _run_test(period_str, test, verbose = False, options = {}):
     if output_variables is not None:
         try:
             for variable_name, expected_value in output_variables.iteritems():
+                variable_ignored = ignore_variables is not None and variable_name in ignore_variables
+                variable_not_tested = only_variables is not None and variable_name not in only_variables
+                if variable_ignored or variable_not_tested:
+                    continue  # Skip this variable
                 if isinstance(expected_value, dict):
                     for requested_period, expected_value_at_period in expected_value.iteritems():
                         assert_near(

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '21.2.2',
+    version = '21.3.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Thanks for contributing to OpenFisca! Remove this line, as well as any other in the following that don't fit your contribution  :)

#### New features

- Introduce new options `--only` and '--ignore` to openfisca-run-test
  - Allows for filter tthe variables to test in YAML tests