### PR TITLE
Insulate TBS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 21.2.2 [#612](https://github.com/openfisca/openfisca-core/pull/612)
+
+- When a variable file is loaded twice in the same python interpreter, make sure the second loading doesn't corrupt the first one.
+    - This fixes a bug introduced in 21.0.2, which could lead to a corruption of the tax and benefit in rare edge cases
+
 ## 21.2.1 [#613](https://github.com/openfisca/openfisca-core/pull/613)
 
 - Fix two bugs that appeared with 21.2.0:

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -136,10 +136,11 @@ class TaxBenefitSystem(object):
         Adds all OpenFisca variables contained in a given file to the tax and benefit system.
         """
         try:
-            module_name = path.splitext(path.basename(file_path))[0]
+            file_name = path.splitext(path.basename(file_path))[0]
+            module_name = '{}_{}'.format(id(self), file_name)  # If two tax and benefit systems load the same module, the second one should not replace the first one. Hence this unique module name.
             module_directory = path.dirname(file_path)
             try:
-                module = load_module(module_name, *find_module(module_name, [module_directory]))
+                module = load_module(module_name, *find_module(file_name, [module_directory]))
             except NameError as e:
                 logging.error(str(e) + ": if this code used to work, this error might be due to a major change in OpenFisca-Core. Checkout the changelog to learn more: <https://github.com/openfisca/openfisca-core/blob/master/CHANGELOG.md>")
                 raise

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '21.2.1',
+    version = '21.2.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
- When a variable file is loaded twice in the same python interpreter, make sure the second loading doesn't corrupt the first one.
   - This fixes a bug introduced in 21.0.2, which could lead to a corruption of the tax and benefit in rare edge cases
