### PR TITLE
Properly encode the result of formulas returning an enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 21.2.1 [#613](https://github.com/openfisca/openfisca-core/pull/613)
 
-- Fix a bug introduced in `21.0.2`:
-  - The result of a formula returning an Enum value was not properly encoded
+- Fix two bugs that appeared with 21.2.0:
+  - Properly encode the result of a formula returning an Enum value
+  - Enable storing an Enum value on disk
 
 ## 21.2.0 [#601](https://github.com/openfisca/openfisca-core/pull/601)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 21.2.1 [#613](https://github.com/openfisca/openfisca-core/pull/613)
+
+- Fix a bug introduced in `21.0.2`:
+  - The result of a formula returning an Enum value was not properly encoded
+
 ## 21.2.0 [#601](https://github.com/openfisca/openfisca-core/pull/601)
 
 #### New features

--- a/openfisca_core/formulas.py
+++ b/openfisca_core/formulas.py
@@ -17,7 +17,7 @@ from . import holders, periods
 from .parameters import ParameterNotFound
 from .periods import MONTH, YEAR, ETERNITY
 from .commons import empty_clone, stringify_array
-from .indexed_enums import Enum
+from .indexed_enums import Enum, EnumArray
 
 
 log = logging.getLogger(__name__)
@@ -515,11 +515,12 @@ class Formula(object):
                         nan_count).encode('utf-8'))
             except TypeError:
                 pass
+
+        if self.holder.variable.value_type == Enum and not isinstance(array, EnumArray):
+            array = self.holder.variable.possible_values.encode(array)
+
         if array.dtype != variable.dtype:
-            if self.holder.variable.value_type == Enum:
-                self.holder.variable.possible_values.encode(array)
-            else:
-                array = array.astype(variable.dtype)
+            array = array.astype(variable.dtype)
 
         self.clean_cycle_detection_data()
         if max_nb_cycles is not None:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '21.2.0',
+    version = '21.2.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -150,3 +150,11 @@ def test_known_periods():
     holder.put_in_cache(data, month)
     holder._memory_storage.put(data, month_2)
     assert_items_equal(holder.get_known_periods(), [month, month_2])
+
+
+def test_cache_enum_on_disk():
+    simulation = get_simulation(single, memory_config = force_storage_on_disk)  # Force using disk
+    month = make_period('2017-01')
+    simulation.calculate('housing_occupancy_status', month)  # First calculation
+    housing_occupancy_status = simulation.calculate('housing_occupancy_status', month)  # Read from cache
+    assert_equal(housing_occupancy_status, HousingOccupancyStatus.tenant)


### PR DESCRIPTION
- Fix two bugs that appeared with 21.2.0:
 - Properly encode the result of a formula returning an Enum value
 - Enable storing an Enum value on disk