### PR TITLE
Introduce new entities helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 21.5.0 [#621](https://github.com/openfisca/openfisca-core/pull/621)
+
+- Introduce:
+  - [`person.get_rank(entity, criteria, condition)`](https://github.com/openfisca/openfisca-core/blob/21.4.0/openfisca_core/entities.py#L278-L293)
+  - [`entity.value_nth_person(k, array, default)`](https://github.com/openfisca/openfisca-core/blob/21.4.0/openfisca_core/entities.py#L515-L520)
+
 ## 21.4.0 [#603](https://github.com/openfisca/openfisca-core/pull/603)
 
 #### New features

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '21.4.0',
+    version = '21.5.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -333,6 +333,38 @@ def test_min():
     assert_near(age_min_parents, [37, 54])
 
 
+def test_value_nth_person():
+    test_case = deepcopy(TEST_CASE_AGES)
+    simulation = new_simulation(test_case)
+    person = simulation.person
+    array = person('age', MONTH)
+
+    result0 = person.household.value_nth_person(0, array, default=-1)
+    assert_near(result0, [40, 54])
+
+    result1 = person.household.value_nth_person(1, array, default=-1)
+    assert_near(result1, [37, 20])
+
+    result2 = person.household.value_nth_person(2, array, default=-1)
+    assert_near(result2, [7, -1])
+
+    result3 = person.household.value_nth_person(3, array, default=-1)
+    assert_near(result3, [9, -1])
+
+
+def test_rank():
+    test_case = deepcopy(TEST_CASE_AGES)
+    simulation = new_simulation(test_case)
+    person = simulation.person
+
+    age = person('age', MONTH)  # [40, 37, 7, 9, 54, 20]
+    rank = person.get_rank(person.household, age)
+    assert_near(rank, [3, 2, 0, 1, 1, 0])
+
+    rank_in_siblings = person.get_rank(person.household, - age, condition = person.has_role(Household.CHILD))
+    assert_near(rank_in_siblings, [-1, -1, 1, 0, -1, 0])
+
+
 def test_partner():
     test_case = deepcopy(TEST_CASE)
     test_case['persons'][0]['salary'] = 1000


### PR DESCRIPTION
Connected to openfisca/openfisca-core#586

Si https://github.com/openfisca/openfisca-core/pull/602 est mergée avant, un rebase attentif sera nécessaire


- Introduce:
  - [`person.get_rank(entity, criteria, condition)`](https://github.com/openfisca/openfisca-core/blob/migrate-cmu/openfisca_core/entities.py#L279-L294)
  - [`entity.value_kth_person(k, array, default)`](https://github.com/openfisca/openfisca-core/blob/migrate-cmu/openfisca_core/entities.py#L516-L521)