### PR TITLE
Make sure ParameterNode:repr generates a valid YAML representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-### 22.0.3 [#635](https://github.com/openfisca/openfisca-core/pull/635) 
+### 22.0.4 [#624](https://github.com/openfisca/openfisca-core/pull/624)
+
+* Technical improvement:
+* Details:
+  - Make sure ParameterNode:__repr__ generates a valid YAML representation
+
+### 22.0.3 [#635](https://github.com/openfisca/openfisca-core/pull/635)
 
 - Update dependancy on numpy
   * Previously, openfisca-core used features removed on numpy 1.13

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -148,7 +148,7 @@ class Parameter(object):
 
     def __repr__(self):
         return os.linesep.join([
-            '{}: {}'.format(value.instant_str, value.value) for value in self.values_list
+            '{}: {}'.format(value.instant_str, value.value if value.value is not None else 'null') for value in self.values_list
             ])
 
     def __eq__(self, other):
@@ -674,8 +674,9 @@ class Scale(object):
             raise KeyError(key)
 
     def __repr__(self):
-        return os.linesep.join([
-            '-' + indent(repr(bracket))[1:]
+        return os.linesep.join(['brackets:'] +
+            [
+            indent('-' + indent(repr(bracket))[1:])
             for bracket in self.brackets
             ])
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '22.0.3',
+    version = '22.0.4',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/core/test_parameters.py
+++ b/tests/core/test_parameters.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from nose.tools import assert_equal, raises
+import tempfile
 
-from openfisca_core.parameters import ParameterNotFound, ParameterNode, ParameterNodeAtInstant
+from openfisca_core.parameters import ParameterNotFound, ParameterNode, ParameterNodeAtInstant, load_parameter_file
 from test_countries import tax_benefit_system
 
 
@@ -64,3 +65,12 @@ def test_parameter_for_period():
 def test_wrong_value():
     income_tax_rate = tax_benefit_system.parameters.taxes.income_tax_rate
     income_tax_rate("test")
+
+
+def test_parameter_repr():
+    parameters = tax_benefit_system.parameters
+    tf = tempfile.NamedTemporaryFile(delete = False)
+    tf.write(repr(parameters))
+    tf.close()
+    tf_parameters = load_parameter_file(file_path = tf.name)
+    assert_equal(repr(parameters), repr(tf_parameters))


### PR DESCRIPTION
#### Technical changes

- Make sure `ParameterNode:repr` generates a valid YAML representation
