### PR TITLE
Improve parameters performances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 22.0.6 [#642](https://github.com/openfisca/openfisca-core/pull/642)
+
+* Improve parameters performances
+
 ### 22.0.5 [#639](https://github.com/openfisca/openfisca-core/pull/639)
 
 * Update country-template dependency to >= 3.0.0, < 4.0.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '22.0.5',
+    version = '22.0.6',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
On `france`:
-  `nosetests tests/test_basics.py` drops from `35s` to `25s`
-  [This file](https://github.com/openfisca/tutorial/blob/master/python/scripts/generate_situation_examples/try_situation_examples.py) drops from `5.26s` to `3.55s`

Interesting lessons:
- Performances waste does not necessarily happen where you think it does
- Flexibles user-friendly interfaces can ruin performances if called under the hood