### PR TITLE
Make OpenFisca more compatible with Python3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,61 +74,18 @@ jobs:
   dependencies_python3:
     working_directory: ~/openfisca-core
     docker:
-      - image: python:2.7.14
+      - image: python:3.6
 
     steps:
       - restore_cache:
           keys:
             - v1-checkout-{{ .Environment.CIRCLE_SHA1 }}
 
-      - run:
-          name: Create virtualenv
-          command: |
-            mkdir -p /tmp/venv/openfisca-core
-            virtualenv /tmp/venv/openfisca-core
-
       # pip >= 8.0 needed to be compatible with "manylinux" wheels, used by numpy >= 1.11
       - run:
           name: Install dependencies
           command: |
-            . /tmp/venv/openfisca-core/bin/activate
             pip install --upgrade pip twine wheel
-            pip install .[test] --upgrade
-
-      # Uncomment and adapt the next line to use a particular feature branch of OpenFisca-Country-Template to run Circle CI tests
-      # - run:
-      #     name: Install a particular feature branch of OpenFisca-Country-Template
-      #     command: |
-      #       . /tmp/venv/openfisca-core/bin/activate
-      #       pip install --editable git+https://github.com/openfisca/country-template.git@BRANCH_NAME#egg=OpenFisca-Country-Template
-
-      - save_cache:
-          key: v1-dependencies-{{ .Environment.CIRCLE_SHA1 }}
-          paths:
-            - /tmp/venv/openfisca-core
-  dependencies:
-    working_directory: ~/openfisca-core
-    docker:
-      - image: python:2.7.14
-
-    steps:
-      - restore_cache:
-          keys:
-            - v1-checkout-{{ .Environment.CIRCLE_SHA1 }}
-
-      - run:
-          name: Create virtualenv
-          command: |
-            mkdir -p /tmp/venv/openfisca-core
-            virtualenv /tmp/venv/openfisca-core
-
-      # pip >= 8.0 needed to be compatible with "manylinux" wheels, used by numpy >= 1.11
-      - run:
-          name: Install dependencies
-          command: |
-            . /tmp/venv/openfisca-core/bin/activate
-            pip install --upgrade pip twine wheel
-            pip install .[test] --upgrade
 
       # Uncomment and adapt the next line to use a particular feature branch of OpenFisca-Country-Template to run Circle CI tests
       # - run:
@@ -174,13 +131,16 @@ jobs:
       - restore_cache:
           keys:
             - v1-dependencies-{{ .Environment.CIRCLE_SHA1 }}
-
       - run:
           name: Run tests
           command: |
-            . /tmp/venv/openfisca-core/bin/activate
-            nosetests core/base_functions.py
-            . check-version-bump.sh
+            pip install --upgrade pip twine wheel
+            pip install . --upgrade
+            pip install --editable git+https://github.com/etalab/biryani.git@master#egg=Biryani
+            pip install --editable git+https://github.com/openfisca/country-template.git@master#egg=OpenFisca-Country-Template
+            pip install --editable git+https://github.com/openfisca/extension-template.git@master#egg=OpenFisca-Extension-Template
+            pip install --editable .[test] --upgrade
+            nosetests core/test_base_functions.py
 
   deploy:
     working_directory: ~/openfisca-core
@@ -210,23 +170,21 @@ workflows:
   openfisca-core:
     jobs:
       - checkout
-
       - dependencies:
           requires:
             - checkout
-
       - tests:
           requires:
             - dependencies
-      - python3
+      - python3:
+          requires:
+            - tests
       - dependencies_python3:
-        requires:
-            - checkout
-
+          requires:
+            - python3
       - tests_python3:
-        requires:
-          - dependencies_python3
-
+          requires:
+            - dependencies_python3
       - deploy:
           requires:
             - tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,23 @@ jobs:
           paths:
             - .
             - ~/.ssh/known_hosts
+  python3:
+    working_directory: ~/openfisca-core
+    docker:
+      - image: python:3.6
+
+    steps:
+      - checkout
+
+      - run:
+          name: Fetch remote refs
+          command: git fetch
+
+      - save_cache:
+          key: v1-checkout-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - .
+            - ~/.ssh/known_hosts
 
   dependencies:
     working_directory: ~/openfisca-core
@@ -54,7 +71,76 @@ jobs:
           key: v1-dependencies-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - /tmp/venv/openfisca-core
+  dependencies_python3:
+    working_directory: ~/openfisca-core
+    docker:
+      - image: python:2.7.14
 
+    steps:
+      - restore_cache:
+          keys:
+            - v1-checkout-{{ .Environment.CIRCLE_SHA1 }}
+
+      - run:
+          name: Create virtualenv
+          command: |
+            mkdir -p /tmp/venv/openfisca-core
+            virtualenv /tmp/venv/openfisca-core
+
+      # pip >= 8.0 needed to be compatible with "manylinux" wheels, used by numpy >= 1.11
+      - run:
+          name: Install dependencies
+          command: |
+            . /tmp/venv/openfisca-core/bin/activate
+            pip install --upgrade pip twine wheel
+            pip install .[test] --upgrade
+
+      # Uncomment and adapt the next line to use a particular feature branch of OpenFisca-Country-Template to run Circle CI tests
+      # - run:
+      #     name: Install a particular feature branch of OpenFisca-Country-Template
+      #     command: |
+      #       . /tmp/venv/openfisca-core/bin/activate
+      #       pip install --editable git+https://github.com/openfisca/country-template.git@BRANCH_NAME#egg=OpenFisca-Country-Template
+
+      - save_cache:
+          key: v1-dependencies-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - /tmp/venv/openfisca-core
+  dependencies:
+    working_directory: ~/openfisca-core
+    docker:
+      - image: python:2.7.14
+
+    steps:
+      - restore_cache:
+          keys:
+            - v1-checkout-{{ .Environment.CIRCLE_SHA1 }}
+
+      - run:
+          name: Create virtualenv
+          command: |
+            mkdir -p /tmp/venv/openfisca-core
+            virtualenv /tmp/venv/openfisca-core
+
+      # pip >= 8.0 needed to be compatible with "manylinux" wheels, used by numpy >= 1.11
+      - run:
+          name: Install dependencies
+          command: |
+            . /tmp/venv/openfisca-core/bin/activate
+            pip install --upgrade pip twine wheel
+            pip install .[test] --upgrade
+
+      # Uncomment and adapt the next line to use a particular feature branch of OpenFisca-Country-Template to run Circle CI tests
+      # - run:
+      #     name: Install a particular feature branch of OpenFisca-Country-Template
+      #     command: |
+      #       . /tmp/venv/openfisca-core/bin/activate
+      #       pip install --editable git+https://github.com/openfisca/country-template.git@BRANCH_NAME#egg=OpenFisca-Country-Template
+
+      - save_cache:
+          key: v1-dependencies-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - /tmp/venv/openfisca-core
   tests:
     working_directory: ~/openfisca-core
     docker:
@@ -74,6 +160,26 @@ jobs:
           command: |
             . /tmp/venv/openfisca-core/bin/activate
             make test
+            . check-version-bump.sh
+  tests_python3:
+    working_directory: ~/openfisca-core
+    docker:
+      - image: python:3.6
+
+    steps:
+      - restore_cache:
+          keys:
+            - v1-checkout-{{ .Environment.CIRCLE_SHA1 }}
+
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ .Environment.CIRCLE_SHA1 }}
+
+      - run:
+          name: Run tests
+          command: |
+            . /tmp/venv/openfisca-core/bin/activate
+            nosetests core/base_functions.py
             . check-version-bump.sh
 
   deploy:
@@ -112,6 +218,14 @@ workflows:
       - tests:
           requires:
             - dependencies
+      - python3
+      - dependencies_python3:
+        requires:
+            - checkout
+
+      - tests_python3:
+        requires:
+          - dependencies_python3
 
       - deploy:
           requires:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### 23.0.2 [#645](https://github.com/openfisca/openfisca-core/pull/645)
+
+* Technical improvement
+* Details:
+
+Start adapting OpenFisca to Python 3
+- Imports are now all absolute imports
+- `unicode_type` and `basestring_type` are now used for compatible type checking.
+- All calls for sorted() use the key parameter
+- Iteration on dict now uses dict.items()
+
 ### 23.0.1 [656](https://github.com/openfisca/openfisca-core/pull/656)
 
 * Re-accept `int` values for `instant` in `tax_benefit_system.get_parameter_at_instant(instant)`

--- a/openfisca_core/base_functions.py
+++ b/openfisca_core/base_functions.py
@@ -27,7 +27,7 @@ def requested_period_last_value(holder, period, *extra_params, **kwargs):
     known_periods = holder.get_known_periods()
     if not known_periods:
         return holder.default_array()
-    known_periods = sorted(known_periods, cmp = periods.compare_period_start, reverse = True)
+    known_periods = sorted(known_periods, key=lambda period: period.start, reverse = True)
     for last_period in known_periods:
         if last_period.start <= period.start:
             return holder.get_array(last_period, extra_params)

--- a/openfisca_core/base_functions.py
+++ b/openfisca_core/base_functions.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from . import periods
 
 """
     base_function is an optional variable attribute that can optionally be set to one of the functions defined in this module.

--- a/openfisca_core/columns.py
+++ b/openfisca_core/columns.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from openfisca_core import conv, periods
 from openfisca_core.indexed_enums import Enum
-from openfisca_core.commons import unicode_type, basestring_type, unicode_this
+from openfisca_core.commons import unicode_type, basestring_type, to_unicode
 
 """
 Columns are the ancestors of Variables, and are now considered deprecated. Preferably use `Variable` instead.
@@ -180,7 +180,7 @@ class DateCol(Column):
 
     def json_default(self):
         default = np.array(self.default_value, self.dtype)
-        return unicode_this(default)
+        return to_unicode(default)
 
     @property
     def json_to_dated_python(self):
@@ -240,7 +240,7 @@ class FloatCol(Column):
     @property
     def json_to_dated_python(self):
         return conv.pipe(
-            conv.test_isinstance((float, int, str, basestring_type)),
+            conv.test_isinstance((float, int, basestring_type)),
             conv.make_anything_to_float(accept_expression = True),
             )
 
@@ -256,7 +256,7 @@ class IntCol(Column):
     @property
     def json_to_dated_python(self):
         return conv.pipe(
-            conv.test_isinstance((int, str, basestring_type)),
+            conv.test_isinstance((int, basestring_type)),
             conv.make_anything_to_int(accept_expression = True),
             )
 
@@ -329,8 +329,8 @@ class EnumCol(Column):
 
     def json_default(self):
         default = self.default_value
-        if default is not None and not isinstance(default, unicode_type):
-            return unicode(default)
+        if default is not None:
+            to_unicode(default)
         return default
 
     @property

--- a/openfisca_core/columns.py
+++ b/openfisca_core/columns.py
@@ -6,8 +6,9 @@ import re
 
 import numpy as np
 
-from indexed_enums import Enum
-from . import conv, periods
+from openfisca_core import conv, periods
+from openfisca_core.indexed_enums import Enum
+from openfisca_core.commons import unicode_type, basestring_type, unicode_this
 
 """
 Columns are the ancestors of Variables, and are now considered deprecated. Preferably use `Variable` instead.

--- a/openfisca_core/columns.py
+++ b/openfisca_core/columns.py
@@ -180,9 +180,7 @@ class DateCol(Column):
 
     def json_default(self):
         default = np.array(self.default_value, self.dtype)
-        if isinstance(default, unicode_type):
-            return default
-        return unicode(default)
+        return unicode_this(default)
 
     @property
     def json_to_dated_python(self):

--- a/openfisca_core/columns.py
+++ b/openfisca_core/columns.py
@@ -20,7 +20,7 @@ def N_(message):
     return message
 
 
-year_or_month_or_day_re = re.compile(ur'(18|19|20)\d{2}(-(0?[1-9]|1[0-2])(-([0-2]?\d|3[0-1]))?)?$')
+year_or_month_or_day_re = re.compile(r'(18|19|20)\d{2}(-(0?[1-9]|1[0-2])(-([0-2]?\d|3[0-1]))?)?$')
 
 
 # Base Column

--- a/openfisca_core/commons.py
+++ b/openfisca_core/commons.py
@@ -5,23 +5,20 @@ unicode_type = u"".__class__
 basestring_type = (str, unicode_type)
 
 
-def unicode_this(string, encoding=None):
+def to_unicode(string):
     """
     :param string: a string that needs to be unicoded
     :param encoding: a string that represent the encoding type
     :return: a unicode string
     if the string is a python 2 str type, returns a unicode version of the string.
     """
+    if not isinstance(string, basestring_type):
+        string = str(string)
     if isinstance(string, unicode_type):
         return string
-    # These lines only gets triggered if the code is run in python 2
-    else:
-        if not encoding:
-            return unicode(string)
-        elif encoding == 'utf-8':
-            return unicode(string, 'utf-8')
-        else:
-            raise NameError('the encoding type {} is not handled'.format(encoding))
+
+    # Next line only gets triggered if the code is run in python 2
+    return unicode(string, 'utf-8')
 
 
 class Dummy(object):

--- a/openfisca_core/commons.py
+++ b/openfisca_core/commons.py
@@ -1,7 +1,27 @@
 # -*- coding: utf-8 -*-
 
+# The following two variables and the is_unicode function are there to bridge string types across Python 2 & 3
 unicode_type = u"".__class__
 basestring_type = (str, unicode_type)
+
+
+def unicode_this(string, encoding=None):
+    """
+    :param string: a string that needs to be unicoded
+    :param encoding: a string that represent the encoding type
+    :return: a unicode string
+    if the string is a python 2 str type, returns a unicode version of the string.
+    """
+    if isinstance(string, unicode_type):
+        return string
+    # These lines only gets triggered if the code is run in python 2
+    else:
+        if not encoding:
+            return unicode(string)
+        elif encoding == 'utf-8':
+            return unicode(string, 'utf-8')
+        else:
+            raise NameError('the encoding type {} is not handled'.format(encoding))
 
 
 class Dummy(object):

--- a/openfisca_core/commons.py
+++ b/openfisca_core/commons.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+unicode_type = u"".__class__
+basestring_type = (str, unicode_type)
+
 
 class Dummy(object):
     """A class that does nothing

--- a/openfisca_core/data_storage.py
+++ b/openfisca_core/data_storage.py
@@ -5,9 +5,9 @@ import os
 
 import numpy as np
 
-import periods
-from periods import ETERNITY
-from indexed_enums import EnumArray
+from openfisca_core import periods
+from openfisca_core.periods import ETERNITY
+from openfisca_core.indexed_enums import EnumArray
 
 
 class InMemoryStorage(object):

--- a/openfisca_core/decompositions.py
+++ b/openfisca_core/decompositions.py
@@ -7,6 +7,7 @@ from xml.etree import ElementTree
 
 from openfisca_core import conv, decompositionsxml, parameters
 from openfisca_core.columns import make_column_from_variable
+from openfisca_core.commons import basestring_type
 
 
 def calculate(simulations, decomposition_json):
@@ -87,7 +88,7 @@ def make_validate_node_json(tax_benefit_system):
                     ),
                 conv.pipe(
                     conv.condition(
-                        conv.test_isinstance(basestring),
+                        conv.test_isinstance(basestring_type),
                         conv.function(lambda code: dict(code = code)),
                         conv.test_isinstance(dict),
                         ),
@@ -102,7 +103,7 @@ def make_validate_node_json(tax_benefit_system):
                                 conv.empty_to_none,
                                 ),
                             code = conv.pipe(
-                                conv.test_isinstance(basestring),
+                                conv.test_isinstance(basestring_type),
                                 conv.cleanup_line,
                                 ),
                             ),

--- a/openfisca_core/decompositions.py
+++ b/openfisca_core/decompositions.py
@@ -5,8 +5,8 @@ import collections
 import copy
 from xml.etree import ElementTree
 
-from . import conv, decompositionsxml, parameters
-from columns import make_column_from_variable
+from openfisca_core import conv, decompositionsxml, parameters
+from openfisca_core.columns import make_column_from_variable
 
 
 def calculate(simulations, decomposition_json):

--- a/openfisca_core/decompositionsxml.py
+++ b/openfisca_core/decompositionsxml.py
@@ -7,6 +7,7 @@
 import collections
 
 from openfisca_core import conv
+from openfisca_core.commons import unicode_type, basestring_type
 
 
 def N_(message):
@@ -72,12 +73,12 @@ def make_validate_node_xml_json(tax_benefit_system):
             conv.struct(
                 dict(
                     code = conv.pipe(
-                        conv.test_isinstance(basestring),
+                        conv.test_isinstance(basestring_type),
                         conv.cleanup_line,
                         conv.not_none,
                         ),
                     color = conv.pipe(
-                        conv.test_isinstance(basestring),
+                        conv.test_isinstance(basestring_type),
                         conv.function(lambda colors: colors.split(u',')),
                         conv.uniform_sequence(
                             conv.pipe(
@@ -87,10 +88,10 @@ def make_validate_node_xml_json(tax_benefit_system):
                                 ),
                             ),
                         conv.test(lambda colors: len(colors) == 3, error = N_(u'Wrong number of colors in triplet.')),
-                        conv.function(lambda colors: u','.join(unicode(color) for color in colors)),
+                        conv.function(lambda colors: u','.join(color if isinstance(color, unicode_type) else unicode(color) for color in colors)),
                         ),
                     desc = conv.pipe(
-                        conv.test_isinstance(basestring),
+                        conv.test_isinstance(basestring_type),
                         conv.cleanup_line,
                         conv.not_none,
                         ),
@@ -103,20 +104,20 @@ def make_validate_node_xml_json(tax_benefit_system):
                         conv.empty_to_none,
                         ),
                     shortname = conv.pipe(
-                        conv.test_isinstance(basestring),
+                        conv.test_isinstance(basestring_type),
                         conv.cleanup_line,
                         conv.not_none,
                         ),
                     tail = conv.pipe(
-                        conv.test_isinstance(basestring),
+                        conv.test_isinstance(basestring_type),
                         conv.cleanup_text,
                         ),
                     text = conv.pipe(
-                        conv.test_isinstance(basestring),
+                        conv.test_isinstance(basestring_type),
                         conv.cleanup_text,
                         ),
                     typevar = conv.pipe(
-                        conv.test_isinstance(basestring),
+                        conv.test_isinstance(basestring_type),
                         conv.input_to_int,
                         conv.test_equals(2),
                         ),

--- a/openfisca_core/decompositionsxml.py
+++ b/openfisca_core/decompositionsxml.py
@@ -7,7 +7,7 @@
 import collections
 
 from openfisca_core import conv
-from openfisca_core.commons import unicode_type, basestring_type
+from openfisca_core.commons import basestring_type, to_unicode
 
 
 def N_(message):
@@ -88,7 +88,7 @@ def make_validate_node_xml_json(tax_benefit_system):
                                 ),
                             ),
                         conv.test(lambda colors: len(colors) == 3, error = N_(u'Wrong number of colors in triplet.')),
-                        conv.function(lambda colors: u','.join(color if isinstance(color, unicode_type) else unicode(color) for color in colors)),
+                        conv.function(lambda colors: u','.join(to_unicode(color) for color in colors)),
                         ),
                     desc = conv.pipe(
                         conv.test_isinstance(basestring_type),

--- a/openfisca_core/decompositionsxml.py
+++ b/openfisca_core/decompositionsxml.py
@@ -6,7 +6,7 @@
 
 import collections
 
-from . import conv
+from openfisca_core import conv
 
 
 def N_(message):

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -52,7 +52,7 @@ class Entity(object):
         self.count = len(entities_json)
         self.step_size = self.count  # Related to axes.
         self.ids = sorted(entities_json.keys())
-        for entity_id, entity_object in entities_json.iteritems():
+        for entity_id, entity_object in entities_json.items():
             check_type(entity_object, dict, [self.plural, entity_id])
             if not self.is_person:
                 roles_json, variables_json = self.split_variables_and_roles_json(entity_object)
@@ -66,7 +66,7 @@ class Entity(object):
 
     def init_variable_values(self, entity_object, entity_id):
         entity_index = self.ids.index(entity_id)
-        for variable_name, variable_values in entity_object.iteritems():
+        for variable_name, variable_values in entity_object.items():
             path_in_json = [self.plural, entity_id, variable_name]
             try:
                 self.check_variable_defined_for_entity(variable_name)
@@ -80,7 +80,7 @@ class Entity(object):
                     u'Invalid type: must be of type object. Input variables must be set for specific periods. For instance: {"salary": {"2017-01": 2000, "2017-02": 2500}}')
 
             holder = self.get_holder(variable_name)
-            for date, value in variable_values.iteritems():
+            for date, value in variable_values.items():
                 path_in_json.append(date)
                 try:
                     period = make_period(date)
@@ -108,7 +108,7 @@ class Entity(object):
                     holder.buffer[period] = array
 
     def finalize_variables_init(self):
-        for variable_name, holder in self._holders.iteritems():
+        for variable_name, holder in self._holders.items():
             periods = holder.buffer.keys()
             # We need to handle small periods first for set_input to work
             sorted_periods = sorted(periods, key=key_period_size)
@@ -414,7 +414,7 @@ class GroupEntity(Entity):
         self.roles_count = self.members_legacy_role.max() + 1
 
     def init_members(self, roles_json, entity_id):
-        for role_id, role_definition in roles_json.iteritems():
+        for role_id, role_definition in roles_json.items():
             check_type(role_definition, list, [self.plural, entity_id, role_id])
             for index, person_id in enumerate(role_definition):
                 check_type(person_id, basestring_type, [self.plural, entity_id, role_id, str(index)])

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -14,6 +14,7 @@ from openfisca_core.simulations import check_type, SituationParsingError
 from openfisca_core.holders import Holder, PeriodMismatchError
 from openfisca_core.periods import compare_period_size, period as make_period
 from openfisca_core.errors import VariableNotFound
+from openfisca_core.commons import basestring_type
 
 ADD = 'add'
 DIVIDE = 'divide'
@@ -89,7 +90,7 @@ class Entity(object):
                     array = holder.buffer.get(period)
                     if array is None:
                         array = holder.default_array()
-                    if holder.variable.value_type == Enum and isinstance(value, basestring):
+                    if holder.variable.value_type == Enum and isinstance(value, basestring_type):
                         try:
                             value = holder.variable.possible_values[value].index
                         except KeyError:
@@ -416,7 +417,7 @@ class GroupEntity(Entity):
         for role_id, role_definition in roles_json.iteritems():
             check_type(role_definition, list, [self.plural, entity_id, role_id])
             for index, person_id in enumerate(role_definition):
-                check_type(person_id, basestring, [self.plural, entity_id, role_id, str(index)])
+                check_type(person_id, basestring_type, [self.plural, entity_id, role_id, str(index)])
                 if person_id not in self.simulation.persons.ids:
                     raise SituationParsingError([self.plural, entity_id, role_id],
                         u"Unexpected value: {0}. {0} has been declared in {1} {2}, but has not been declared in {3}.".format(

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -8,12 +8,12 @@ from os import linesep
 import numpy as np
 import dpath
 
-from indexed_enums import Enum, EnumArray
-from scenarios import iter_over_entity_members
-from simulations import check_type, SituationParsingError
-from holders import Holder, PeriodMismatchError
-from periods import compare_period_size, period as make_period
-from errors import VariableNotFound
+from openfisca_core.indexed_enums import Enum, EnumArray
+from openfisca_core.scenarios import iter_over_entity_members
+from openfisca_core.simulations import check_type, SituationParsingError
+from openfisca_core.holders import Holder, PeriodMismatchError
+from openfisca_core.periods import compare_period_size, period as make_period
+from openfisca_core.errors import VariableNotFound
 
 ADD = 'add'
 DIVIDE = 'divide'

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -12,7 +12,7 @@ from openfisca_core.indexed_enums import Enum, EnumArray
 from openfisca_core.scenarios import iter_over_entity_members
 from openfisca_core.simulations import check_type, SituationParsingError
 from openfisca_core.holders import Holder, PeriodMismatchError
-from openfisca_core.periods import compare_period_size, period as make_period
+from openfisca_core.periods import key_period_size, period as make_period
 from openfisca_core.errors import VariableNotFound
 from openfisca_core.commons import basestring_type
 
@@ -111,7 +111,7 @@ class Entity(object):
         for variable_name, holder in self._holders.iteritems():
             periods = holder.buffer.keys()
             # We need to handle small periods first for set_input to work
-            sorted_periods = sorted(periods, cmp = compare_period_size)
+            sorted_periods = sorted(periods, key=key_period_size)
             for period in sorted_periods:
                 array = holder.buffer[period]
                 try:

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -9,12 +9,12 @@ import warnings
 import numpy as np
 import psutil
 
-from commons import empty_clone
-import periods
-from periods import MONTH, YEAR, ETERNITY
-from columns import make_column_from_variable
-from indexed_enums import Enum, EnumArray
-from data_storage import InMemoryStorage, OnDiskStorage
+from openfisca_core import periods
+from openfisca_core.commons import empty_clone
+from openfisca_core.periods import MONTH, YEAR, ETERNITY
+from openfisca_core.columns import make_column_from_variable
+from openfisca_core.indexed_enums import Enum, EnumArray
+from openfisca_core.data_storage import InMemoryStorage, OnDiskStorage
 
 log = logging.getLogger(__name__)
 

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -130,8 +130,8 @@ class Holder(object):
             Get the list of periods the variable value is known for.
         """
 
-        return self._memory_storage.get_known_periods() + (
-            self._disk_storage.get_known_periods() if self._disk_storage else [])
+        return list(self._memory_storage.get_known_periods()) + list((
+            self._disk_storage.get_known_periods() if self._disk_storage else []))
 
     def set_input(self, period, array):
         """

--- a/openfisca_core/json_to_test_case.py
+++ b/openfisca_core/json_to_test_case.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from copy import deepcopy
-from columns import make_column_from_variable
 
-from . import conv
+from openfisca_core.columns import make_column_from_variable
+from openfisca_core import conv
+from openfisca_core.commons import unicode_type
 
 
 def check_entity_fields(entity_json, entity_class, valid_roles, tax_benefit_system):

--- a/openfisca_core/json_to_test_case.py
+++ b/openfisca_core/json_to_test_case.py
@@ -10,19 +10,19 @@ from openfisca_core.commons import unicode_type
 def check_entity_fields(entity_json, entity_class, valid_roles, tax_benefit_system):
 
     def check_id(value):
-        if value is None or not isinstance(value, (basestring, int)):
+        if value is None or not isinstance(value, (str, unicode_type, int)):
             raise ValueError(u"Invalid id in entity {}".format(entity_json).encode('utf-8'))
 
     def check_role(value, key):
         role = valid_roles.get(key)
         if role.max == 1:
-            value, error = conv.test_isinstance((basestring, int))(value)
+            value, error = conv.test_isinstance((str, unicode_type, int))(value)
         else:
             value, error = conv.pipe(
                 conv.make_item_to_singleton(),
                 conv.test_isinstance(list),
                 conv.uniform_sequence(
-                    conv.test_isinstance((basestring, int)),
+                    conv.test_isinstance((str, unicode_type, int)),
                     drop_none_items = True,
                     )
                 )(value)

--- a/openfisca_core/json_to_test_case.py
+++ b/openfisca_core/json_to_test_case.py
@@ -4,25 +4,25 @@ from copy import deepcopy
 
 from openfisca_core.columns import make_column_from_variable
 from openfisca_core import conv
-from openfisca_core.commons import unicode_type
+from openfisca_core.commons import basestring_type
 
 
 def check_entity_fields(entity_json, entity_class, valid_roles, tax_benefit_system):
 
     def check_id(value):
-        if value is None or not isinstance(value, (str, unicode_type, int)):
+        if value is None or not isinstance(value, (basestring_type, int)):
             raise ValueError(u"Invalid id in entity {}".format(entity_json).encode('utf-8'))
 
     def check_role(value, key):
         role = valid_roles.get(key)
         if role.max == 1:
-            value, error = conv.test_isinstance((str, unicode_type, int))(value)
+            value, error = conv.test_isinstance((basestring_type, int))(value)
         else:
             value, error = conv.pipe(
                 conv.make_item_to_singleton(),
                 conv.test_isinstance(list),
                 conv.uniform_sequence(
-                    conv.test_isinstance((str, unicode_type, int)),
+                    conv.test_isinstance((basestring_type, int)),
                     drop_none_items = True,
                     )
                 )(value)

--- a/openfisca_core/model_api.py
+++ b/openfisca_core/model_api.py
@@ -11,24 +11,24 @@ from numpy import (   # noqa analysis:ignore
     where,
 )
 
-from .holders import (  # noqa analysis:ignore
+from openfisca_core.holders import (  # noqa analysis:ignore
     set_input_dispatch_by_period,
     set_input_divide_by_period,
     )
-from .indexed_enums import Enum  # noqa analysis:ignore
-from .entities import (ADD, DIVIDE)  # noqa analysis:ignore
-from .simulations import (  # noqa analysis:ignore
+from openfisca_core.indexed_enums import Enum  # noqa analysis:ignore
+from openfisca_core.entities import (ADD, DIVIDE)  # noqa analysis:ignore
+from openfisca_core.simulations import (  # noqa analysis:ignore
     calculate_output_add,
     calculate_output_divide,
     )
-from .base_functions import (   # noqa analysis:ignore
+from openfisca_core.base_functions import (   # noqa analysis:ignore
     missing_value,
     requested_period_default_value,
     requested_period_last_or_next_value,
     requested_period_last_value,
     )
-from .variables import Variable  # noqa analysis:ignore
-from .formula_helpers import apply_thresholds, concat, switch  # noqa analysis:ignore
-from .periods import MONTH, YEAR, ETERNITY, period  # noqa analysis:ignore
-from .reforms import Reform  # noqa analysis:ignore
-from .parameters import load_parameter_file, ParameterNode, Scale, Bracket, Parameter, ValuesHistory  # noqa analysis:ignore
+from openfisca_core.variables import Variable  # noqa analysis:ignore
+from openfisca_core.formula_helpers import apply_thresholds, concat, switch  # noqa analysis:ignore
+from openfisca_core.periods import MONTH, YEAR, ETERNITY, period  # noqa analysis:ignore
+from openfisca_core.reforms import Reform  # noqa analysis:ignore
+from openfisca_core.parameters import load_parameter_file, ParameterNode, Scale, Bracket, Parameter, ValuesHistory  # noqa analysis:ignore

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -10,12 +10,12 @@ import traceback
 
 import yaml
 import numpy as np
-from indexed_enums import Enum, EnumArray
 
-from . import taxscales
-from . import periods
-from periods import INSTANT_PATTERN
-from tools import indent
+from openfisca_core import taxscales
+from openfisca_core import periods
+from openfisca_core.indexed_enums import Enum, EnumArray
+from openfisca_core.periods import INSTANT_PATTERN
+from openfisca_core.tools import indent
 
 log = logging.getLogger(__name__)
 

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -16,6 +16,7 @@ from openfisca_core import periods
 from openfisca_core.indexed_enums import Enum, EnumArray
 from openfisca_core.periods import INSTANT_PATTERN
 from openfisca_core.tools import indent
+from openfisca_core.commons import basestring_type
 
 log = logging.getLogger(__name__)
 
@@ -178,7 +179,7 @@ class Parameter(object):
         if period is not None:
             if start is not None or stop is not None:
                 raise TypeError(u"Wrong input for 'update' method: use either 'update(period, value = value)' or 'update(start = start, stop = stop, value = value)'. You cannot both use 'period' and 'start' or 'stop'.")
-            if isinstance(period, basestring):
+            if isinstance(period, basestring_type):
                 period = periods.period(period)
             start = period.start
             stop = period.stop
@@ -571,7 +572,7 @@ class VectorialParameterNodeAtInstant(object):
 
     def __getitem__(self, key):
         # If the key is a string, just get the subnode
-        if isinstance(key, basestring):
+        if isinstance(key, basestring_type):
             return self.__getattr__(key)
         # If the key is a vector, e.g. ['zone_1', 'zone_2', 'zone_1']
         elif isinstance(key, np.ndarray):

--- a/openfisca_core/periods.py
+++ b/openfisca_core/periods.py
@@ -863,27 +863,31 @@ def period(value):
     return Period((unit, base_period.start, size))
 
 
-def compare_period_size(a, b):
-    unit_a, start_a, size_a = a
-    unit_b, start_b, size_b = b
+def key_period_size(period):
+    """
+    Defines a key in order to sort periods by length. It uses two aspects : first unit then size
 
-    if unit_a != unit_b:
-        unit_weights = {
-            MONTH: 1,
-            YEAR: 2,
-            ETERNITY: 3,
-            }
+    :param period: an OpenFisca period
+    :return: a string
 
-        return cmp(unit_weights[unit_a], unit_weights[unit_b])
+    >>> key_period_size(period('2014'))
+    '2_1'
+    >>> key_period_size(period('2013'))
+    '2_1'
+    >>> key_period_size(period('2014-01'))
+    '1_1'
 
-    return cmp(size_a, size_b)
+    """
 
+    unit_weights = {
+        MONTH: 1,
+        YEAR: 2,
+        ETERNITY: 3,
+        }
 
-def compare_period_start(a, b):
-    unit_a, start_a, size_a = a
-    unit_b, start_b, size_b = b
+    unit, start, size = period
 
-    return cmp(start_a, start_b)
+    return '{}_{}'.format(unit_weights[unit], size)
 
 
 # Level-1 converters

--- a/openfisca_core/periods.py
+++ b/openfisca_core/periods.py
@@ -16,7 +16,7 @@ import datetime
 import re
 from os import linesep
 
-from . import conv
+from openfisca_core import conv
 
 
 MONTH = u'month'

--- a/openfisca_core/periods.py
+++ b/openfisca_core/periods.py
@@ -33,7 +33,7 @@ def N_(message):
 # Note: weak references are not used, because Python 2.7 can't create weak reference to 'datetime.date' objects.
 date_by_instant_cache = {}
 str_by_instant_cache = {}
-year_or_month_or_day_re = re.compile(ur'(18|19|20)\d{2}(-(0?[1-9]|1[0-2])(-([0-2]?\d|3[0-1]))?)?$')
+year_or_month_or_day_re = re.compile(r'(18|19|20)\d{2}(-(0?[1-9]|1[0-2])(-([0-2]?\d|3[0-1]))?)?$')
 
 
 class Instant(tuple):

--- a/openfisca_core/periods.py
+++ b/openfisca_core/periods.py
@@ -17,7 +17,7 @@ import re
 from os import linesep
 
 from openfisca_core import conv
-from openfisca_core.commons import unicode_type, basestring_type
+from openfisca_core.commons import unicode_type, basestring_type, unicode_this
 
 
 MONTH = u'month'
@@ -328,10 +328,7 @@ class Period(tuple):
         if (unit == MONTH and size == 12 or unit == YEAR and size == 1):
             if month == 1:
                 # civil year starting from january
-                if isinstance(year, unicode_type):
-                    return year
-                else:
-                    return unicode(year)
+                return unicode_this(year)
             else:
                 # rolling year
                 return u'{}:{}-{:02d}'.format(YEAR, year, month)

--- a/openfisca_core/periods.py
+++ b/openfisca_core/periods.py
@@ -17,7 +17,7 @@ import re
 from os import linesep
 
 from openfisca_core import conv
-from openfisca_core.commons import unicode_type, basestring_type, unicode_this
+from openfisca_core.commons import unicode_type, basestring_type, to_unicode
 
 
 MONTH = u'month'
@@ -328,7 +328,7 @@ class Period(tuple):
         if (unit == MONTH and size == 12 or unit == YEAR and size == 1):
             if month == 1:
                 # civil year starting from january
-                return unicode_this(year)
+                return to_unicode(year)
             else:
                 # rolling year
                 return u'{}:{}-{:02d}'.format(YEAR, year, month)

--- a/openfisca_core/reforms.py
+++ b/openfisca_core/reforms.py
@@ -2,8 +2,8 @@
 
 import copy
 
-from .parameters import ParameterNode
-from .taxbenefitsystems import TaxBenefitSystem
+from openfisca_core.parameters import ParameterNode
+from openfisca_core.taxbenefitsystems import TaxBenefitSystem
 
 
 class Reform(TaxBenefitSystem):

--- a/openfisca_core/scenarios.py
+++ b/openfisca_core/scenarios.py
@@ -8,8 +8,8 @@ import itertools
 
 import numpy as np
 
-from . import conv, periods, simulations, json_to_test_case, columns
-from .indexed_enums import Enum
+from openfisca_core import conv, periods, simulations, json_to_test_case, columns
+from openfisca_core.indexed_enums import Enum
 
 
 def N_(message):

--- a/openfisca_core/scenarios.py
+++ b/openfisca_core/scenarios.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from openfisca_core import conv, periods, simulations, json_to_test_case, columns
 from openfisca_core.indexed_enums import Enum
+from openfisca_core.commons import basestring_type
 
 
 def N_(message):
@@ -512,7 +513,7 @@ def make_json_or_python_to_axes(tax_benefit_system):
                                     conv.not_none,
                                     ),
                                 name = conv.pipe(
-                                    conv.test_isinstance(basestring),
+                                    conv.test_isinstance(basestring_type),
                                     conv.test_in(column_by_name),
                                     conv.test(lambda column_name: tax_benefit_system.get_variable(column_name).dtype in (
                                         np.float32, np.int16, np.int32),
@@ -547,7 +548,7 @@ def make_json_or_python_to_input_variables(tax_benefit_system, period):
             conv.test_isinstance(dict),
             conv.uniform_mapping(
                 conv.pipe(
-                    conv.test_isinstance(basestring),
+                    conv.test_isinstance(basestring_type),
                     conv.not_none,
                     ),
                 conv.noop,
@@ -601,14 +602,14 @@ def make_json_or_python_to_test(tax_benefit_system):
                     ),
                 axes = make_json_or_python_to_axes(tax_benefit_system),
                 description = conv.pipe(
-                    conv.test_isinstance(basestring),
+                    conv.test_isinstance(basestring_type),
                     conv.cleanup_line,
                     ),
                 input_variables = conv.pipe(
                     conv.test_isinstance(dict),
                     conv.uniform_mapping(
                         conv.pipe(
-                            conv.test_isinstance(basestring),
+                            conv.test_isinstance(basestring_type),
                             conv.not_none,
                             ),
                         conv.noop,
@@ -620,7 +621,7 @@ def make_json_or_python_to_test(tax_benefit_system):
                     conv.test_isinstance(list),
                     conv.uniform_sequence(
                         conv.pipe(
-                            conv.test_isinstance(basestring),
+                            conv.test_isinstance(basestring_type),
                             conv.cleanup_line,
                             ),
                         drop_none_items = True,
@@ -628,7 +629,7 @@ def make_json_or_python_to_test(tax_benefit_system):
                     conv.empty_to_none,
                     ),
                 name = conv.pipe(
-                    conv.test_isinstance(basestring),
+                    conv.test_isinstance(basestring_type),
                     conv.cleanup_line,
                     ),
                 output_variables = conv.test_isinstance(dict),

--- a/openfisca_core/scenarios.py
+++ b/openfisca_core/scenarios.py
@@ -168,7 +168,7 @@ class AbstractScenario(object):
                                 variable_periods.add(simulation_period)
                         variable_default_value = column.default_value
                         # Note: For set_input to work, handle days, before months, before years => use sorted().
-                        for variable_period in sorted(variable_periods, cmp = periods.compare_period_size):
+                        for variable_period in sorted(variable_periods, key=periods.key_period_size):
                             variable_values = [
                                 variable_default_value if dated_cell is None else dated_cell
                                 for dated_cell in (

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -8,10 +8,10 @@ import logging
 import dpath
 import numpy as np
 
-import periods
-from commons import empty_clone, stringify_array
-from tracers import Tracer
-from .indexed_enums import Enum, EnumArray
+from openfisca_core import periods
+from openfisca_core.commons import empty_clone, stringify_array
+from openfisca_core.tracers import Tracer
+from openfisca_core.indexed_enums import Enum, EnumArray
 
 
 log = logging.getLogger(__name__)

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -9,7 +9,7 @@ import dpath
 import numpy as np
 
 from openfisca_core import periods
-from openfisca_core.commons import empty_clone, stringify_array
+from openfisca_core.commons import empty_clone, stringify_array, basestring_type
 from openfisca_core.tracers import Tracer
 from openfisca_core.indexed_enums import Enum, EnumArray
 
@@ -456,16 +456,15 @@ class Simulation(object):
         return new
 
 
-def check_type(input, type, path = []):
+def check_type(input, input_type, path = []):
     json_type_map = {
         dict: "Object",
         list: "Array",
-        basestring: "String"
+        basestring_type: "String",
         }
-
-    if not isinstance(input, type):
+    if not isinstance(input, input_type):
         raise SituationParsingError(path,
-            u"Invalid type: must be of type '{}'.".format(json_type_map[type]))
+            u"Invalid type: must be of type '{}'.".format(json_type_map[input_type]))
 
 
 class SituationParsingError(Exception):

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -18,6 +18,7 @@ from openfisca_core.parameters import ParameterNode
 from openfisca_core.variables import Variable, get_neutralized_variable
 from openfisca_core.scenarios import AbstractScenario
 from openfisca_core.errors import VariableNotFound
+from openfisca_core.commons import unicode_type
 
 
 log = logging.getLogger(__name__)
@@ -97,7 +98,10 @@ class TaxBenefitSystem(object):
         pass
 
     def load_variable(self, variable_class, update = False):
-        name = unicode(variable_class.__name__)
+        name = variable_class.__name__
+        # This block is only for Python 2
+        if not isinstance(name, unicode_type):
+            name = unicode(name)
 
         # Check if a Variable with the same name is already registered.
         baseline_variable = self.get_variable(name)

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -18,7 +18,7 @@ from openfisca_core.parameters import ParameterNode
 from openfisca_core.variables import Variable, get_neutralized_variable
 from openfisca_core.scenarios import AbstractScenario
 from openfisca_core.errors import VariableNotFound
-from openfisca_core.commons import unicode_type
+from openfisca_core.commons import to_unicode
 
 
 log = logging.getLogger(__name__)
@@ -98,10 +98,7 @@ class TaxBenefitSystem(object):
         pass
 
     def load_variable(self, variable_class, update = False):
-        name = variable_class.__name__
-        # This block is only for Python 2
-        if not isinstance(name, unicode_type):
-            name = unicode(name)
+        name = to_unicode(variable_class.__name__)
 
         # Check if a Variable with the same name is already registered.
         baseline_variable = self.get_variable(name)

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -12,12 +12,13 @@ import pkg_resources
 import traceback
 from setuptools import find_packages
 
-import conv
-from parameters import ParameterNode
-from variables import Variable, get_neutralized_variable
-from scenarios import AbstractScenario
-from . import periods
-from errors import VariableNotFound
+from openfisca_core import conv
+from openfisca_core import periods
+from openfisca_core.parameters import ParameterNode
+from openfisca_core.variables import Variable, get_neutralized_variable
+from openfisca_core.scenarios import AbstractScenario
+from openfisca_core.errors import VariableNotFound
+
 
 log = logging.getLogger(__name__)
 

--- a/openfisca_core/taxscales.py
+++ b/openfisca_core/taxscales.py
@@ -12,8 +12,8 @@ import os
 import numpy as np
 from numpy import maximum as max_, minimum as min_
 
-from .commons import empty_clone
-from tools import indent
+from openfisca_core.commons import empty_clone
+from openfisca_core.tools import indent
 
 log = logging.getLogger(__name__)
 

--- a/openfisca_core/tools/__init__.py
+++ b/openfisca_core/tools/__init__.py
@@ -2,6 +2,7 @@
 
 import os
 from ..indexed_enums import Enum, EnumArray
+from openfisca_core.commons import unicode_type
 
 
 def assert_near(value, target_value, absolute_error_margin = None, message = '', relative_error_margin = None):
@@ -25,7 +26,7 @@ def assert_near(value, target_value, absolute_error_margin = None, message = '',
         value = np.array(value)
     if isinstance(target_value, (list, tuple)):
         target_value = np.array(target_value)
-    if isinstance(message, unicode):
+    if isinstance(message, unicode_type):
         message = message.encode('utf-8')
     if isinstance(value, np.ndarray):
         if isinstance(target_value, Enum) or (isinstance(target_value, np.ndarray) and target_value.dtype == object):

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -18,6 +18,7 @@ import yaml
 
 from openfisca_core import conv, periods, scenarios
 from openfisca_core.tools import assert_near
+from openfisca_core.commons import unicode_type
 
 log = logging.getLogger(__name__)
 
@@ -26,10 +27,10 @@ log = logging.getLogger(__name__)
 
 def _config_yaml(yaml):
 
-    class folded_unicode(unicode):
+    class folded_unicode(unicode_type):
         pass
 
-    class literal_unicode(unicode):
+    class literal_unicode(unicode_type):
         pass
 
     def dict_constructor(loader, node):
@@ -53,7 +54,7 @@ def _config_yaml(yaml):
     yaml.add_representer(periods.Instant, lambda dumper, data: dumper.represent_scalar(u'tag:yaml.org,2002:str', str(data)))
     yaml.add_representer(periods.Period, lambda dumper, data: dumper.represent_scalar(u'tag:yaml.org,2002:str', str(data)))
     yaml.add_representer(tuple, lambda dumper, data: dumper.represent_list(data))
-    yaml.add_representer(unicode, lambda dumper, data: dumper.represent_scalar(u'tag:yaml.org,2002:str', data))
+    yaml.add_representer(unicode_type, lambda dumper, data: dumper.represent_scalar(u'tag:yaml.org,2002:str', data))
 
     return yaml
 

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -20,6 +20,7 @@ from openfisca_core.base_functions import (
     requested_period_last_or_next_value,
     requested_period_last_value,
     )
+from openfisca_core.commons import unicode_type, basestring_type
 
 
 VALUE_TYPES = {
@@ -143,7 +144,10 @@ class Variable(object):
     """
 
     def __init__(self, baseline_variable = None):
-        self.name = unicode(self.__class__.__name__)
+        self.name = self.__class__.__name__
+        # This block is only for Python 2
+        if not isinstance(self.name, unicode_type):
+            self.name = unicode(self.name)
         attr = {
             name: value for name, value in self.__class__.__dict__.iteritems()
             if not name.startswith('__')}
@@ -163,11 +167,11 @@ class Variable(object):
             self.default_value = self.set(attr, 'default_value', allowed_type = self.value_type, default = VALUE_TYPES[self.value_type].get('default'))
         self.entity = self.set(attr, 'entity', required = True, setter = self.set_entity)
         self.definition_period = self.set(attr, 'definition_period', required = True, allowed_values = (MONTH, YEAR, ETERNITY))
-        self.label = self.set(attr, 'label', allowed_type = basestring, setter = self.set_label)
-        self.end = self.set(attr, 'end', allowed_type = basestring, setter = self.set_end)
+        self.label = self.set(attr, 'label', allowed_type = basestring_type, setter = self.set_label)
+        self.end = self.set(attr, 'end', allowed_type = basestring_type, setter = self.set_end)
         self.reference = self.set(attr, 'reference', setter = self.set_reference)
-        self.cerfa_field = self.set(attr, 'cerfa_field', allowed_type = (basestring, dict))
-        self.unit = self.set(attr, 'unit', allowed_type = basestring)
+        self.cerfa_field = self.set(attr, 'cerfa_field', allowed_type = (str, unicode_type, dict))
+        self.unit = self.set(attr, 'unit', allowed_type = basestring_type)
         self.set_input = self.set_set_input(attr.pop('set_input', None))
         self.calculate_output = self.set_calculate_output(attr.pop('calculate_output', None))
         self.is_period_size_independent = self.set(attr, 'is_period_size_independent', allowed_type = bool, default = VALUE_TYPES[self.value_type]['is_period_size_independent'])
@@ -220,7 +224,7 @@ class Variable(object):
 
     def set_label(self, label):
         if label:
-            if isinstance(label, unicode):
+            if isinstance(label, unicode_type):
                 return label
             else:
                 return unicode(label, 'utf-8')
@@ -234,8 +238,10 @@ class Variable(object):
 
     def set_reference(self, reference):
         if reference:
-            if isinstance(reference, basestring):
+            if isinstance(reference, unicode_type):
                 reference = [reference]
+            elif isinstance(reference, str):
+                reference = [unicode(reference, 'utf-8')]
             elif isinstance(reference, list):
                 pass
             elif isinstance(reference, tuple):
@@ -244,7 +250,7 @@ class Variable(object):
                 raise TypeError('The reference of the variable {} is a {} instead of a String or a List of Strings.'.format(self.name, type(reference)))
 
             for element in reference:
-                if not isinstance(element, basestring):
+                if not isinstance(element, basestring_type):
                     raise TypeError(
                         'The reference of the variable {} is a {} instead of a String or a List of Strings.'.format(
                             self.name, type(reference)))

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -20,7 +20,7 @@ from openfisca_core.base_functions import (
     requested_period_last_or_next_value,
     requested_period_last_value,
     )
-from openfisca_core.commons import unicode_type, basestring_type
+from openfisca_core.commons import unicode_type, basestring_type, unicode_this
 
 
 VALUE_TYPES = {
@@ -224,10 +224,7 @@ class Variable(object):
 
     def set_label(self, label):
         if label:
-            if isinstance(label, unicode_type):
-                return label
-            else:
-                return unicode(label, 'utf-8')
+            return unicode_this(label, 'utf-8')
 
     def set_end(self, end):
         if end:
@@ -238,10 +235,8 @@ class Variable(object):
 
     def set_reference(self, reference):
         if reference:
-            if isinstance(reference, unicode_type):
-                reference = [reference]
-            elif isinstance(reference, str):
-                reference = [unicode(reference, 'utf-8')]
+            if isinstance(reference, basestring_type):
+                reference = [unicode_this(reference, 'utf-8')]
             elif isinstance(reference, list):
                 pass
             elif isinstance(reference, tuple):

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -2,24 +2,24 @@
 
 
 import datetime
-from datetime import date
 import inspect
 import re
 import textwrap
 
 import numpy as np
 from sortedcontainers.sorteddict import SortedDict
+from datetime import date
 
-from .base_functions import (
+from openfisca_core import entities
+from openfisca_core import periods
+from openfisca_core.indexed_enums import Enum, ENUM_ARRAY_DTYPE
+from openfisca_core.periods import MONTH, YEAR, ETERNITY
+from openfisca_core.base_functions import (
     missing_value,
     requested_period_default_value,
     requested_period_last_or_next_value,
     requested_period_last_value,
     )
-from . import entities
-from .indexed_enums import Enum, ENUM_ARRAY_DTYPE
-from . import periods
-from .periods import MONTH, YEAR, ETERNITY
 
 
 VALUE_TYPES = {

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -149,7 +149,7 @@ class Variable(object):
         if not isinstance(self.name, unicode_type):
             self.name = unicode(self.name)
         attr = {
-            name: value for name, value in self.__class__.__dict__.iteritems()
+            name: value for name, value in self.__class__.__dict__.items()
             if not name.startswith('__')}
         self.baseline_variable = baseline_variable
         self.value_type = self.set(attr, 'value_type', required = True, allowed_values = VALUE_TYPES.keys())
@@ -295,7 +295,7 @@ class Variable(object):
             first_reform_formula_date = formulas.peekitem(0)[0] if formulas else None
             formulas.update({
                 baseline_start_date: baseline_formula
-                for baseline_start_date, baseline_formula in self.baseline_variable.formulas.iteritems()
+                for baseline_start_date, baseline_formula in self.baseline_variable.formulas.items()
                 if first_reform_formula_date is None or baseline_start_date < first_reform_formula_date
                 })
 

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -20,7 +20,7 @@ from openfisca_core.base_functions import (
     requested_period_last_or_next_value,
     requested_period_last_value,
     )
-from openfisca_core.commons import unicode_type, basestring_type, unicode_this
+from openfisca_core.commons import basestring_type, to_unicode
 
 
 VALUE_TYPES = {
@@ -144,10 +144,7 @@ class Variable(object):
     """
 
     def __init__(self, baseline_variable = None):
-        self.name = self.__class__.__name__
-        # This block is only for Python 2
-        if not isinstance(self.name, unicode_type):
-            self.name = unicode(self.name)
+        self.name = to_unicode(self.__class__.__name__)
         attr = {
             name: value for name, value in self.__class__.__dict__.items()
             if not name.startswith('__')}
@@ -170,7 +167,7 @@ class Variable(object):
         self.label = self.set(attr, 'label', allowed_type = basestring_type, setter = self.set_label)
         self.end = self.set(attr, 'end', allowed_type = basestring_type, setter = self.set_end)
         self.reference = self.set(attr, 'reference', setter = self.set_reference)
-        self.cerfa_field = self.set(attr, 'cerfa_field', allowed_type = (str, unicode_type, dict))
+        self.cerfa_field = self.set(attr, 'cerfa_field', allowed_type = (basestring_type, dict))
         self.unit = self.set(attr, 'unit', allowed_type = basestring_type)
         self.set_input = self.set_set_input(attr.pop('set_input', None))
         self.calculate_output = self.set_calculate_output(attr.pop('calculate_output', None))
@@ -224,7 +221,7 @@ class Variable(object):
 
     def set_label(self, label):
         if label:
-            return unicode_this(label, 'utf-8')
+            return to_unicode(label)
 
     def set_end(self, end):
         if end:
@@ -236,7 +233,7 @@ class Variable(object):
     def set_reference(self, reference):
         if reference:
             if isinstance(reference, basestring_type):
-                reference = [unicode_this(reference, 'utf-8')]
+                reference = [to_unicode(reference)]
             elif isinstance(reference, list):
                 pass
             elif isinstance(reference, tuple):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '23.0.1',
+    version = '23.0.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/core/test_base_functions.py
+++ b/tests/core/test_base_functions.py
@@ -1,14 +1,14 @@
 import numpy as np
 from openfisca_core.tools import assert_near
 
-from test_countries import tax_benefit_system
 from openfisca_country_template.situation_examples import single
 from openfisca_country_template.entities import Person
 from openfisca_core.model_api import *  # noqa
 from openfisca_core.simulations import Simulation
 from openfisca_core.periods import period
 
-from test_holders import force_storage_on_disk
+from .test_countries import tax_benefit_system
+from .test_holders import force_storage_on_disk
 
 
 class state_variable(Variable):

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-from nose.tools import assert_equal, assert_items_equal, assert_is_none
+
+from nose.tools import assert_equal, assert_is_none
 
 from openfisca_country_template.situation_examples import couple, single
 from openfisca_core.simulations import Simulation
@@ -157,7 +158,8 @@ def test_known_periods():
     data = np.asarray([2000, 3000, 0, 500])
     holder.put_in_cache(data, month)
     holder._memory_storage.put(data, month_2)
-    assert_items_equal(holder.get_known_periods(), [month, month_2])
+
+    assert_equal(sorted(holder.get_known_periods()), [month, month_2])
 
 
 def test_cache_enum_on_disk():

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -8,7 +8,7 @@ from openfisca_core.simulations import Simulation
 from openfisca_core.periods import period as make_period, ETERNITY
 from openfisca_core.tools import assert_near
 from openfisca_core.memory_config import MemoryConfig
-from test_countries import tax_benefit_system
+from .test_countries import tax_benefit_system
 
 
 def get_simulation(json, **kwargs):


### PR DESCRIPTION
Fixes #631
Fixes #632 

#### Technical changes
Python3 has deprecated a lot of elements present in python2 and in OpenFisca : 

- Regex ur"string" --> Regex r"string"
- No more Implicit imports --> explicit imports
- No more `basestring` or `unicode` types (all strings (`str`) are unicode) --> `text_unicode = u"".__class__` and `text_basestring = (str, text_unicode)` in type checking.
- `cmp` is an attribute of `sort()` --> Change `cmp` to `key` 
- `dict.iteritems()` --> `dict.items()`
- `asser_items_equal' --> equivalent assert equal expressions

To work with Python 3, it needs version 0.10.6dev of `biryani`
nosetests core/test_base_functions.py passes :tada:
