### PR TITLE
Fix some entity operators for multi-entities simulations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 22.0.8 [#646](https://github.com/openfisca/openfisca-core/pull/639)
+
+* Fix `entity.max`, `entity.min`, `entity.all` and `entity.reduce` for multi-entities simulations.
+  - This issue was not affecting simulations with several persons in a _single_ entity
+  - These operators were not working as expected in case the persons of the simulation were not sorted by entity id in the persons vector. For instance:
+    - First household: [Alice, Bob]
+    - Second household: [Cesar]
+    - Persons vector: [Alice, Cesar, Bob]
+
 ### 22.0.7 [#639](https://github.com/openfisca/openfisca-core/pull/639)
 
 * Update CircleCI configuration to its v2

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -482,16 +482,16 @@ class GroupEntity(Entity):
         self.check_role_validity(role)
         position_in_entity = self.members_position
         role_filter = self.members.has_role(role) if role is not None else True
+        filtered_array = np.where(role_filter, array, neutral_element)
 
         result = self.filled_array(neutral_element)  # Neutral value that will be returned if no one with the given role exists.
 
         # We loop over the positions in the entity
         # Looping over the entities is tempting, but potentielly slow if there are a lot of entities
-        nb_positions = np.max(position_in_entity) + 1
-        for p in range(nb_positions):
-            filter = (position_in_entity == p) * role_filter
-            entity_filter = self.any(filter)
-            result[entity_filter] = reducer(result[entity_filter], array[filter])
+        biggest_entity_size = np.max(position_in_entity) + 1
+
+        for p in range(biggest_entity_size):
+            result = reducer(result, self.value_nth_person(p, filtered_array, default = neutral_element))
 
         return result
 

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -173,7 +173,7 @@ class Variable(object):
         value = attributes.pop(attribute_name, None)
         if value is None and self.baseline_variable:
             return getattr(self.baseline_variable, attribute_name)
-        if required and not value:
+        if required and value is None:
             raise ValueError("Missing attribute '{}' in definition of variable '{}'.".format(attribute_name, self.name).encode('utf-8'))
         if allowed_values is not None and value not in allowed_values:
             raise ValueError("Invalid value '{}' for attribute '{}' in variable '{}'. Allowed values are '{}'."

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '22.0.7',
+    version = '22.0.8',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Fix `entity.max`, `entity.min`, `entity.all` and `entity.reduce` for multi-entities simulations.
  - This issue was not affecting simulations with several persons in a _single_ entity
  - These operators were not working as expected in case the persons of the simulation were not sorted by entity id in the persons vector. For instance:
    - First household: [Alice, Bob]
    - Second household: [Cesar]
    - Persons vector: [Alice, Cesar, Bob]