### PR TITLE
Document how to run a specific test with nosetests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,28 @@ pip install --editable ".[test]"
 
 ## Testing
 
+To run the entire test suite:
+
 ```sh
 make test
 ```
 
+To run all the tests defined on a test file:
+
+```sh
+nosetests core/test_parameters.py
+```
+
+To run a single test:
+
+```sh
+nosetests core/test_parameters.py:test_parameter_for_period
+```
+
 ## Serving the API
 
-OpenFisca-Core provides a Web-API. It is served on the `6000` port.  
+OpenFisca-Core provides a Web-API. It is served on the `6000` port.
+
 To run it with the mock country package `openfisca_country_template` and another port value as `5000`, run:
 
 ```sh


### PR DESCRIPTION
Fixes #622 

#### Documentation

In order to run a single test file or a single test definition, `nose`
expects you to pass the path relative to its working directory.

For example if your `setup.cfg` looks like this:

    [nosetests]
    where = tests

Then to run your tests you should do:

    > find . -name test_parameters.py
    ./tests/core/test_parameters.py
    ./tests/web_api/basic_case/test_parameters.py
    
    > nosetests core/test_parameters.py
    Ran 9 tests in 0.007s

    nosetests core/test_parameters.py:test_parameter_for_period
    Ran 1 test in 0.000s

See: https://nose.readthedocs.io/en/latest/usage.html#selecting-testsDocument