### PR TITLE
Avoid collisions between module names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 22.1.0 [#648](https://github.com/openfisca/openfisca-core/pull/648)
+
+* Allow two variable file to have the same name in a tax and benefit system
+  - A [collision](https://github.com/openfisca/openfisca-core/issues/642) between module names made it impossible so far.
+
 ### 22.0.10 [#654](https://github.com/openfisca/openfisca-core/pull/654)
 
 * Fix `dtype` attribute for `EnumArray`s (returned when calculating a variable of `value_type` `Enum`):

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -137,7 +137,7 @@ class TaxBenefitSystem(object):
         """
         try:
             file_name = path.splitext(path.basename(file_path))[0]
-            module_name = '{}_{}_{}'.format(id(self), hash(file_path), file_name)  # If two tax and benefit systems load the same module, the second one should not replace the first one. Hence this unique module name.
+            module_name = '{}_{}_{}'.format(id(self), hash(path.abspath(file_path)), file_name)  # If two tax and benefit systems load the same module, the second one should not replace the first one. Hence this unique module name.
             module_directory = path.dirname(file_path)
             try:
                 module = load_module(module_name, *find_module(file_name, [module_directory]))

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -137,7 +137,12 @@ class TaxBenefitSystem(object):
         """
         try:
             file_name = path.splitext(path.basename(file_path))[0]
-            module_name = '{}_{}_{}'.format(id(self), hash(path.abspath(file_path)), file_name)  # If two tax and benefit systems load the same module, the second one should not replace the first one. Hence this unique module name.
+
+            #  As Python remembers loaded modules by name, in order to prevent collisions, we need to make sure that:
+            #  - Files with the same name, but located in different directories, have a different module names. Hence the file path hash in the module name.
+            #  - The same file, loaded by different tax and benefit systems, has distinct module names. Hence the `id(self)` in the module name.
+            module_name = '{}_{}_{}'.format(id(self), hash(path.abspath(file_path)), file_name)
+
             module_directory = path.dirname(file_path)
             try:
                 module = load_module(module_name, *find_module(file_name, [module_directory]))

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -137,7 +137,7 @@ class TaxBenefitSystem(object):
         """
         try:
             file_name = path.splitext(path.basename(file_path))[0]
-            module_name = '{}_{}'.format(id(self), file_name)  # If two tax and benefit systems load the same module, the second one should not replace the first one. Hence this unique module name.
+            module_name = '{}_{}_{}'.format(id(self), hash(file_path), file_name)  # If two tax and benefit systems load the same module, the second one should not replace the first one. Hence this unique module name.
             module_directory = path.dirname(file_path)
             try:
                 module = load_module(module_name, *find_module(file_name, [module_directory]))
@@ -147,9 +147,7 @@ class TaxBenefitSystem(object):
             potential_variables = [getattr(module, item) for item in dir(module) if not item.startswith('__')]
             for pot_variable in potential_variables:
                 # We only want to get the module classes defined in this module (not imported)
-                if isclass(pot_variable) and \
-                        issubclass(pot_variable, Variable) and \
-                        pot_variable.__module__.endswith(module_name):
+                if isclass(pot_variable) and issubclass(pot_variable, Variable) and pot_variable.__module__ == module_name:
                     self.add_variable(pot_variable)
         except:
             log.error(u'Unable to load OpenFisca variables from file "{}"'.format(file_path))

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '22.0.10',
+    version = '22.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Fixes #642 

* Allow two variable file to have the same name in a tax and benefit system
  - A [collision](https://github.com/openfisca/openfisca-core/issues/642) between module names made it impossible so far.

I'm assuming #646 will be merged first, as more urgent, and I bumped the version number accordingly.