### PR TITLE
Cache known hosts after checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
           key: v1-checkout-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - .
+            - ~/.ssh/known_hosts
 
   dependencies:
     working_directory: ~/openfisca-core


### PR DESCRIPTION
#### Configuration

* Cache known hosts after checkout in CircleCI
* Details:
  - Otherwise it fails to push tags
  - See https://discuss.circleci.com/t/git-clone-fails-in-circle-2-0/15211