### PR TITLE
Fix enum dtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 22.0.10 [#654](https://github.com/openfisca/openfisca-core/pull/654)
+
+* Fix `dtype` attribute for `EnumArray`s (returned when calculating a variable of `value_type` `Enum`):
+  - It was the type `np.int16` and not the dtype instance `np.dtype(np.int16)`
+  - This caused issue when trying to export an `EnumArray` with `pandas`
+
 ### 22.0.9 [#650](https://github.com/openfisca/openfisca-core/pull/5O)
 
 * Fix operators such as `household.first_parent`, `foyer_fiscal.declarant_principal` for multi-entities simulations.

--- a/openfisca_core/indexed_enums.py
+++ b/openfisca_core/indexed_enums.py
@@ -3,6 +3,8 @@
 import numpy as np
 from enum import Enum as BaseEnum
 
+ENUM_ARRAY_DTYPE = np.int16
+
 
 class Enum(BaseEnum):
     """
@@ -43,9 +45,9 @@ class Enum(BaseEnum):
         if type(array) is EnumArray:
             return array
         if array.dtype.kind in {'U', 'S'}:  # String array
-            array = np.select([array == item.name for item in cls], [item.index for item in cls]).astype(EnumArray.dtype)
+            array = np.select([array == item.name for item in cls], [item.index for item in cls]).astype(ENUM_ARRAY_DTYPE)
         elif array.dtype.kind == 'O':  # Enum items arrays
-            array = np.select([array == item for item in cls], [item.index for item in cls]).astype(EnumArray.dtype)
+            array = np.select([array == item for item in cls], [item.index for item in cls]).astype(ENUM_ARRAY_DTYPE)
         return EnumArray(array, cls)
 
 
@@ -55,8 +57,6 @@ class EnumArray(np.ndarray):
 
         EnumArrays are encoded as ``int`` arrays to improve performance
     """
-
-    dtype = np.int16
 
     # Subclassing np.ndarray is a little tricky. To read more about the two following methods, see https://docs.scipy.org/doc/numpy-1.13.0/user/basics.subclassing.html#slightly-more-realistic-example-attribute-added-to-existing-array.
     def __new__(cls, input_array, possible_values = None):

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -19,7 +19,7 @@ from base_functions import (
     requested_period_last_value,
     )
 from datetime import date
-from indexed_enums import Enum, EnumArray
+from indexed_enums import Enum, ENUM_ARRAY_DTYPE
 
 VALUE_TYPES = {
     bool: {
@@ -47,7 +47,7 @@ VALUE_TYPES = {
         'is_period_size_independent': True
         },
     Enum: {
-        'dtype': EnumArray.dtype,
+        'dtype': ENUM_ARRAY_DTYPE,
         'json_type': 'Enumeration',
         'is_period_size_independent': True,
         },

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '22.0.9',
+    version = '22.0.10',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -43,6 +43,14 @@ def test_set_input_enum_item():
     assert_equal(result, HousingOccupancyStatus.free_lodger)
 
 
+def test_enum_dtype():
+    simulation = get_simulation(couple)
+    status_occupancy = np.asarray([2], dtype = np.int16)
+    simulation.household.get_holder('housing_occupancy_status').set_input(period, status_occupancy)
+    result = simulation.calculate('housing_occupancy_status', period)
+    assert result.dtype.kind is not None
+
+
 def test_permanent_variable_empty():
     simulation = get_simulation(single)
     holder = simulation.person.get_holder('birth')


### PR DESCRIPTION
Fixes #652 

* Fix `dtype` attribute for `EnumArray`s (returned when calculating a variable of `value_type` `Enum`):
  - It was the type `np.int16` and not the dtype instance `np.dtype(np.int16)`
  - This caused issue when trying to export an `EnumArray` with `pandas`