### PR TITLE
Fixup py3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 23.1.1 [#661](https://github.com/openfisca/openfisca-core/pull/661)
+
+- Fixup Python 3 compatibility
+
 ### 23.1.0 [#660](https://github.com/openfisca/openfisca-core/pull/660)
 
 Make package compatible with Python 3

--- a/openfisca_core/data_storage.py
+++ b/openfisca_core/data_storage.py
@@ -30,7 +30,7 @@ class InMemoryStorage(object):
         if extra_params:
             return values.get(tuple(extra_params))
         if isinstance(values, dict):
-            return values.values()[0]
+            return next(iter(values.values()))
         return values
 
     def put(self, value, period, extra_params = None):
@@ -76,7 +76,7 @@ class InMemoryStorage(object):
             for array_or_dict in self._arrays.values()
             ])
 
-        array = list(self._arrays.values())[0]
+        array = next(iter(self._arrays.values()))
         if isinstance(array, dict):
             array = array.values()[0]
         return dict(
@@ -117,7 +117,7 @@ class OnDiskStorage(object):
                 return None
             return self._decode_file(values.get(tuple(extra_params)))
         if isinstance(values, dict):
-            return self._decode_file(values.values()[0])
+            return self._decode_file(next(iter(values.values())))
         return self._decode_file(values)
 
     def put(self, value, period, extra_params = None):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '23.1.0',
+    version = '23.1.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Relates to #630

- Fixup Python 3 compatibility
- Automatically Publish Python 3 versions in the CI

Publishing works both for [Python 3](https://circleci.com/gh/openfisca/openfisca-core/1609) and [Python 2](https://circleci.com/gh/openfisca/openfisca-core/1610).
The Python 2 deploy script is in charge of publishing the tag and deploying the API, as this should be done only once.