### PR TITLE
Use PyYaml CLoader and CDumper in test_runner.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 23.1.4 [#679](https://github.com/openfisca/openfisca-core/pull/679)
+
+* Use C binding to load and dump Yaml (`CLoader` and `CDumper`)
+  - For countries with several Yaml tests, they can take some time to run
+  - Using the C bindings provided by `libyaml` adds a little performance boost
+
 ### 23.1.3 [#680](https://github.com/openfisca/openfisca-core/pull/680)
 
 Fix test that was failing due to migration to HTTPS

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '23.1.3',
+    version = '23.1.4',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Fixes openfisca/openfisca-france#1016
Depends on #680 

#### Technical changes

- Use `PyYaml` `CLoader` and `CDumper` in `test_runner.py`

#### What's the problem?

Yaml tests are slow

#### Here's what I did

I changed `test_runner.py` to use `CLoader` and `CDumper`, and tested against `OpenFisca-France`.

##### Before

In https://circleci.com/gh/openfisca/openfisca-france/1829, I launched:

    pip install --editable .[test] --upgrade
    time for i in {1..10}; do openfisca-run-test `circleci tests glob tests/mes-aides.gouv.fr/**/*.{yaml,yml} | circleci tests split`; done

Which gave the results

    90.897
    91.777
    88.891
    86.971
    86.612
    86.930
    87.707
    86.335
    87.587
    87.911
    86.571
    85.943
    86.235
    86.842
    86.098
    89.159
    91.572
    85.955
    85.165
    85.336
    81.625
    79.279
    81.266
    81.764
    83.435
    85.062
    83.390
    83.657
    83.077
    82.781

    N   min     max     sum     mean    stddev
    30  79.279  91.777  2575.83 85.861  3.01213

##### After

In https://circleci.com/gh/openfisca/openfisca-france/1829, I launched:

    pip install --editable .[test] --upgrade
    pip install --editable git+https://github.com/openfisca/openfisca-core.git@use-pyyaml-cloader-cdumper#egg=OpenFisca-Core
    time for i in {1..10}; do openfisca-run-test `circleci tests glob tests/mes-aides.gouv.fr/**/*.{yaml,yml} | circleci tests split`; done

Which gave the results

    82.049
    81.467
    84.607
    82.454
    82.001
    83.453
    85.648
    83.979
    81.517
    84.589
    80.119
    82.177
    80.901
    80.650
    79.982
    79.996
    80.299
    78.679
    79.681
    79.424
    78.959
    77.923
    75.529
    78.706
    75.980
    78.315
    75.510
    75.851
    75.702
    76.604

    N   min   max     sum     mean    stddev
    30  75.51 85.648  2402.75 80.0917 2.88911

##### Results

    |80,0917 - 85,861| = 5,7693
    (5,7693 / 85,861) * 100 = ~6,72%

**~6,72%** time improvement

##### Note

I've also tried

    python openfisca_france/scripts/performance_tests/test_circleci_builds.py 1717 1716

However, there's a ~10/15s penalty per build from not test-related stuff (like having to install OpenFisca-Core from a branch), so at this level of improvement the results of that test seem a bit unreliable.