### PR TITLE
Update psutil version to 5.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 23.1.7 [#686](https://github.com/openfisca/openfisca-core/pull/686)
+
+* Fix installation on Windows with Python 3.7
+  - Require `psutil` version `5.4.6`, as `5.4.2` is incompatible with that environment.
+
 ### 23.1.6 [#688](https://github.com/openfisca/openfisca-core/pull/688)
 
 * In the error message sent to a user trying to set a variable without specifying for which period, add an example for a variable defined for `ETERNITY`.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '23.1.6',
+    version = '23.1.7',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [
@@ -49,7 +49,7 @@ setup(
         'flask-cors == 3.0.2',
         'gunicorn >= 19.7.1',
         'numpy >= 1.11, < 1.15',
-        'psutil == 5.4.2',
+        'psutil == 5.4.6',
         'PyYAML >= 3.10',
         'sortedcontainers == 1.5.9',
         ],


### PR DESCRIPTION
#### Technical changes

- Require `psutil` version 5.4.6
- Installation fails with Python 3.7.0 on Windows

See https://github.com/openfisca/openfisca-senegal/pull/10#discussion_r201389882