### PR TITLE
Allow to set uncached variables when using a memory_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 23.1.5 [#687](https://github.com/openfisca/openfisca-core/pull/687)
+
+* Allow to set uncached variables when using a `memory_config`
+  - Previously, trying to set variables listed in `variables_to_drop` of the `memory_config` had no effect.
+  - Now this variables are still not cached, but they can be set by the user.
+
 ### 23.1.4 [#679](https://github.com/openfisca/openfisca-core/pull/679)
 
 * Use C binding to load and dump Yaml (`CLoader` and `CDumper`)

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -345,7 +345,7 @@ def set_input_dispatch_by_period(holder, period, array):
     while sub_period.start < after_instant:
         existing_array = holder.get_array(sub_period)
         if existing_array is None:
-            holder.put_in_cache(array, sub_period)
+            holder._set(sub_period, array)
         else:
             # The array of the current sub-period is reused for the next ones.
             # TODO: refactor or document this behavior
@@ -392,7 +392,7 @@ def set_input_divide_by_period(holder, period, array):
         sub_period = period.start.period(cached_period_unit)
         while sub_period.start < after_instant:
             if holder.get_array(sub_period) is None:
-                holder.put_in_cache(divided_array, sub_period)
+                holder._set(sub_period, divided_array)
             sub_period = sub_period.offset(1)
     elif not (remaining_array == 0).all():
         raise ValueError(u"Inconsistent input: variable {0} has already been set for all months contained in period {1}, and value {2} provided for {1} doesn't match the total ({3}). This error may also be thrown if you try to call set_input twice for the same variable and period.".format(holder.variable.name, period, array, array - remaining_array).encode('utf-8'))

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '23.1.4',
+    version = '23.1.5',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -168,3 +168,12 @@ def test_cache_enum_on_disk():
     simulation.calculate('housing_occupancy_status', month)  # First calculation
     housing_occupancy_status = simulation.calculate('housing_occupancy_status', month)  # Read from cache
     assert_equal(housing_occupancy_status, HousingOccupancyStatus.tenant)
+
+
+def test_set_not_chaged_variable():
+    dont_cache_variable = MemoryConfig(max_memory_occupation = 1, variables_to_drop = ['salary'])
+    simulation = get_simulation(single, memory_config = dont_cache_variable)
+    holder = simulation.person.get_holder('salary')
+    array = np.asarray([2000])
+    holder.set_input('2015-01', array)
+    assert_equal(simulation.calculate('salary', '2015-01'), array)


### PR DESCRIPTION
Fixes #676 

* Allow to set uncached variables when using a `memory_config`
  - Previously, trying to set variables listed in `variables_to_drop` of the `memory_config` had no effect.
  - Now this variables are still not cached, but they can be set by the user.