### PR TITLE
Improve error message for variables defined for ETERNITY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 23.1.6 [#688](https://github.com/openfisca/openfisca-core/pull/688)
+
+* In the error message sent to a user trying to set a variable without specifying for which period, add an example for a variable defined for `ETERNITY`.
+
 ### 23.1.5 [#687](https://github.com/openfisca/openfisca-core/pull/687)
 
 * Allow to set uncached variables when using a `memory_config`

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -77,7 +77,7 @@ class Entity(object):
 
             if not isinstance(variable_values, dict):
                 raise SituationParsingError(path_in_json,
-                    u'Invalid type: must be of type object. Input variables must be set for specific periods. For instance: {"salary": {"2017-01": 2000, "2017-02": 2500}}')
+                    u"Invalid type: must be of type object. Input variables must be set for specific periods. For instance: {'salary': {'2017-01': 2000, '2017-02': 2500}}, or {'birth_date': {'ETERNITY': '1980-01-01'}}.")
 
             holder = self.get_holder(variable_name)
             for date, value in variable_values.items():

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -338,11 +338,11 @@ class Simulation(object):
         the parameter max_nb_cycles of the calculate method.
         """
         def get_error_message():
-            return u'Circular definition detected on formula {}<{}>. Formulas and periods involved: {}.'.format(
+            return u"Circular definition detected on formula {}@{}. Formulas and periods involved: {}.".format(
                 variable.name,
                 period,
-                u', '.join(sorted(set(
-                    u'{}<{}>'.format(variable_name, period2)
+                u", ".join(sorted(set(
+                    u"{}@{}".format(variable_name, period2)
                     for variable_name, periods in requested_periods_by_variable_name.items()
                     for period2 in periods
                     ))).encode('utf-8'),

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -90,8 +90,15 @@ class Simulation(object):
             if unexpected_entities:
                 unexpected_entity = unexpected_entities[0]
                 raise SituationParsingError([unexpected_entity],
-                    'This entity is not defined in the loaded tax and benefit system. The defined entities are {}.'.format(
-                        ', '.join(allowed_entities))
+                    ''.join([
+                        "Some entities in the situation are not defined in the loaded tax and benefit system.",
+                        "These entities are not found: {0}.",
+                        "The defined entities are: {1}."]
+                        )
+                    .format(
+                    ', '.join(unexpected_entities),
+                    ', '.join(allowed_entities)
+                        )
                     )
             persons_json = simulation_json.get(self.tax_benefit_system.person_entity.plural, None)
 

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -477,6 +477,9 @@ class SituationParsingError(Exception):
         self.code = code
         Exception.__init__(self, str(self.error).encode('utf-8'))
 
+    def __str__(self):
+        return str(self.error)
+
 
 def calculate_output_add(simulation, variable_name, period):
     return simulation.calculate_add(variable_name, period)

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -52,11 +52,11 @@ class Simulation(object):
             ):
 
         """
-            If a ``simulation_json`` is given, initilalises a simulation from a JSON dictionnary.
+            If a ``simulation_json`` is given, initialises a simulation from a JSON dictionary.
 
             Note: This way of initialising a simulation, still under experimentation, aims at replacing the initialisation from `scenario.make_json_or_python_to_attributes`.
 
-            If no ``simulation_json`` is given, initilalises an empty simulation.
+            If no ``simulation_json`` is given, initialises an empty simulation.
         """
         self.tax_benefit_system = tax_benefit_system
         assert tax_benefit_system is not None

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -189,13 +189,13 @@ class Simulation(object):
 
         # Check that the requested period matches definition_period
         if variable.definition_period == periods.YEAR and period.unit == periods.MONTH:
-            raise ValueError(u'Unable to compute variable {0} for period {1} : {0} can only be computed for year-long periods. You can use the DIVIDE option to get an estimate of {0} by dividing the yearly value by 12, or change the requested period to "period.this_year".'.format(
+            raise ValueError(u"Unable to compute variable '{0}' for period {1}: '{0}' can only be computed for year-long periods. You can use the DIVIDE option to get an estimate of {0} by dividing the yearly value by 12, or change the requested period to 'period.this_year'.".format(
                 variable.name,
                 period,
                 ).encode('utf-8'))
 
         if variable.definition_period not in [periods.MONTH, periods.YEAR]:
-            raise ValueError(u'Unable to sum constant variable {} over period {} : only variables defined monthly or yearly can be summed over time.'.format(
+            raise ValueError(u"Unable to sum constant variable '{}' over period {}: only variables defined monthly or yearly can be summed over time.".format(
                 variable.name,
                 period).encode('utf-8'))
 
@@ -212,7 +212,7 @@ class Simulation(object):
 
         # Check that the requested period matches definition_period
         if variable.definition_period != periods.YEAR:
-            raise ValueError(u'Unable to divide the value of {} over time (on period {}) : only variables defined yearly can be divided over time.'.format(
+            raise ValueError(u"Unable to divide the value of '{}' over time on period {}: only variables defined yearly can be divided over time.".format(
                 variable_name,
                 period).encode('utf-8'))
 
@@ -225,7 +225,7 @@ class Simulation(object):
         elif period.unit == periods.YEAR:
             return self.calculate(variable_name, period, **parameters)
 
-        raise ValueError(u'Unable to divide the value of {} to match the period {}.'.format(
+        raise ValueError(u"Unable to divide the value of '{}' to match period {}.".format(
             variable_name,
             period).encode('utf-8'))
 
@@ -277,58 +277,58 @@ class Simulation(object):
             return  # For variables which values are constant in time, all periods are accepted
 
         if variable.definition_period == periods.MONTH and period.unit != periods.MONTH:
-            raise ValueError(u'Unable to compute variable {0} for period {1} : {0} must be computed for a whole month. You can use the ADD option to sum {0} over the requested period, or change the requested period to "period.first_month".'.format(
+            raise ValueError(u"Unable to compute variable '{0}' for period {1}: '{0}' must be computed for a whole month. You can use the ADD option to sum '{0}' over the requested period, or change the requested period to 'period.first_month'.".format(
                 variable.name,
                 period
                 ).encode('utf-8'))
 
         if variable.definition_period == periods.YEAR and period.unit != periods.YEAR:
-            raise ValueError(u'Unable to compute variable {0} for period {1} : {0} must be computed for a whole year. You can use the DIVIDE option to get an estimate of {0} by dividing the yearly value by 12, or change the requested period to "period.this_year".'.format(
+            raise ValueError(u"Unable to compute variable '{0}' for period {1}: '{0}' must be computed for a whole year. You can use the DIVIDE option to get an estimate of {0} by dividing the yearly value by 12, or change the requested period to 'period.this_year'.".format(
                 variable.name,
                 period
                 ).encode('utf-8'))
 
         if period.size != 1:
-            raise ValueError(u'Unable to compute variable {0} for period {1} : {0} must be computed for a whole {2}. You can use the ADD option to sum {0} over the requested period.'.format(
+            raise ValueError(u"Unable to compute variable '{0}' for period {1}: '{0}' must be computed for a whole {2}. You can use the ADD option to sum '{0}' over the requested period.".format(
                 variable.name,
                 period,
                 'month' if variable.definition_period == periods.MONTH else 'year'
                 ).encode('utf-8'))
 
-    def _check_formula_result(self, array, variable, entity, period):
+    def _check_formula_result(self, value, variable, entity, period):
 
-        assert isinstance(array, np.ndarray), (linesep.join([
+        assert isinstance(value, np.ndarray), (linesep.join([
             u"You tried to compute the formula '{0}' for the period '{1}'.".format(variable.name, str(period)).encode('utf-8'),
             u"The formula '{0}@{1}' should return a Numpy array;".format(variable.name, str(period)).encode('utf-8'),
-            u"instead it returned '{0}' of '{1}'.".format(array, type(array)).encode('utf-8'),
+            u"instead it returned '{0}' of {1}.".format(value, type(value)).encode('utf-8'),
             u"Learn more about Numpy arrays and vectorial computing:",
             u"<http://openfisca.org/doc/coding-the-legislation/25_vectorial_computing.html.>"
             ]))
 
-        assert array.size == entity.count, \
+        assert value.size == entity.count, \
             u"Function {}@{}<{}>() --> <{}>{} returns an array of size {}, but size {} is expected for {}".format(
-                variable.name, entity.key, str(period), str(period), stringify_array(array),
-                array.size, entity.count, entity.key).encode('utf-8')
+                variable.name, entity.key, str(period), str(period), stringify_array(value),
+                value.size, entity.count, entity.key).encode('utf-8')
 
         if self.debug:
             try:
                 # cf https://stackoverflow.com/questions/6736590/fast-check-for-nan-in-numpy
-                if np.isnan(np.min(array)):
-                    nan_count = np.count_nonzero(np.isnan(array))
+                if np.isnan(np.min(value)):
+                    nan_count = np.count_nonzero(np.isnan(value))
                     raise NaNCreationError(u"Function {}@{}<{}>() --> <{}>{} returns {} NaN value(s)".format(
-                        variable.name, entity.key, str(period), str(period), stringify_array(array),
+                        variable.name, entity.key, str(period), str(period), stringify_array(value),
                         nan_count).encode('utf-8'))
             except TypeError:
                 pass
 
-    def _cast_formula_result(self, array, variable):
-        if variable.value_type == Enum and not isinstance(array, EnumArray):
-            return variable.possible_values.encode(array)
+    def _cast_formula_result(self, value, variable):
+        if variable.value_type == Enum and not isinstance(value, EnumArray):
+            return variable.possible_values.encode(value)
 
-        if array.dtype != variable.dtype:
-            return array.astype(variable.dtype)
+        if value.dtype != variable.dtype:
+            return value.astype(variable.dtype)
 
-        return array
+        return value
 
     # ----- Handle circular dependencies in a calculation ----- #
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '23.1.5',
+    version = '23.1.6',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/web_api/basic_case/test_calculate.py
+++ b/tests/web_api/basic_case/test_calculate.py
@@ -34,7 +34,7 @@ def test_responses():
         ('{"a" : "x", "b"}', BAD_REQUEST, 'error', 'Invalid JSON'),
         ('["An", "array"]', BAD_REQUEST, 'error', 'Invalid type'),
         ('{"persons": {}}', BAD_REQUEST, 'persons', 'At least one person'),
-        ('{"persons": {"bob": {}}, "unknown_entity": {}}', BAD_REQUEST, 'unknown_entity', 'entity is not defined',),
+        ('{"persons": {"bob": {}}, "unknown_entity": {}}', BAD_REQUEST, 'unknown_entity', 'entities are not found',),
         ('{"persons": {"bob": {}}, "households": {"dupont": {"parents": {}}}}', BAD_REQUEST, 'households/dupont/parents', 'type',),
         ('{"persons": {"bob": {"unknown_variable": {}}}}', NOT_FOUND, 'persons/bob/unknown_variable', 'You tried to calculate or to set',),
         ('{"persons": {"bob": {"housing_allowance": {}}}}', BAD_REQUEST, 'persons/bob/housing_allowance', "You tried to compute the variable 'housing_allowance' for the entity 'persons'",),


### PR DESCRIPTION
Connected to #669 

* In the error message sent to a user trying to set a variable without specifying for which period, add an example for a variable defined for `ETERNITY`.

For instance, if a user sends the following to the API:

```JSON
{
    "persons": {
        "Alicia": {
            "birth": "1990-01-01"
        }
    },
    "households": {
        "_": {
            "parents": ["Alicia"]
        }
    }
}
```

Before they would get:
```JSON
{
  "persons": {
    "Alicia": {
      "birth": "Invalid type: must be of type object. Input variables must be set for specific periods. For instance: {\"salary\": {\"2017-01\": 2000, \"2017-02\": 2500}}"
    }
  }
}
```

After, the would get:
```JSON
{
  "persons": {
    "Alicia": {
      "birth": "Invalid type: must be of type object. Input variables must be set for specific periods. For instance: {'salary': {'2017-01': 2000, '2017-02': 2500}}, or {'birth_date': {'ETERNITY': '1980-01-01'}}."
    }
  }
}
```