### PR TITLE
Introduce TaxBenefitSystem.replace_variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 23.2.0 [#689](https://github.com/openfisca/openfisca-core/pull/689)
+
+* Introduce `TaxBenefitSystem.replace_variable`
+  - Unlike `update_variable`, this method does _not_ keep any of the replaced variable in the new one.
+  - See [reference documentation](http://openfisca.readthedocs.io/en/latest/tax-benefit-system.html#openfisca_core.taxbenefitsystems.TaxBenefitSystem.replace_variable).
+
 ### 23.1.7 [#686](https://github.com/openfisca/openfisca-core/pull/686)
 
 * Fix installation on Windows with Python 3.7

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -115,21 +115,38 @@ class TaxBenefitSystem(object):
         """
         Adds an OpenFisca variable to the tax and benefit system.
 
-        :param variable: The variable to add. Must be a subclass of Variable.
+        :param Variable variable: The variable to add. Must be a subclass of Variable.
 
         :raises: :any:`VariableNameConflict` if a variable with the same name have previously been added to the tax and benefit system.
         """
         return self.load_variable(variable, update = False)
 
-    def update_variable(self, variable):
+    def replace_variable(self, variable):
         """
         Replaces an existing OpenFisca variable in the tax and benefit system by a new one.
 
-        The new variable must have the same name than the old one.
+        The new variable must have the same name than the replaced one.
 
-        If no variable with the given name exists in the tax and benefit system, no error will be raised and the variable will be simply added.
+        If no variable with the given name exists in the tax and benefit system, no error will be raised and the new variable will be simply added.
 
-        :param variable: Variable to add. Must be a subclass of Variable.
+        :param Variable variable: New variable to add. Must be a subclass of Variable.
+        """
+        name = to_unicode(variable.__name__)
+        if self.variables.get(name) is not None:
+            del self.variables[name]
+        self.load_variable(variable, update = False)
+
+    def update_variable(self, variable):
+        """
+        Updates an existing OpenFisca variable in the tax and benefit system.
+
+        All attributes of the updated variable that are not explicitely overridden by the new ``variable`` will stay unchanged.
+
+        The new variable must have the same name than the updated one.
+
+        If no variable with the given name exists in the tax and benefit system, no error will be raised and the new variable will be simply added.
+
+        :param Variable variable: Variable to add. Must be a subclass of Variable.
         """
         return self.load_variable(variable, update = True)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '23.1.7',
+    version = '23.2.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/core/test_reforms.py
+++ b/tests/core/test_reforms.py
@@ -301,7 +301,7 @@ def test_update_variable():
     class disposable_income(Variable):
         definition_period = MONTH
 
-        def formula(household, period):
+        def formula_2018(household, period):
             return household.empty_array() + 10
 
     class test_update_variable(Reform):
@@ -310,22 +310,47 @@ def test_update_variable():
 
     reform = test_update_variable(tax_benefit_system)
 
-    year = 2013
+    year = 2018
     scenario = reform.new_scenario().init_from_attributes(
         period = year,
         )
 
     disposable_income_reform = reform.get_variable('disposable_income')
-    disposable_income_reference = tax_benefit_system.get_variable('disposable_income')
+    disposable_income_baseline = tax_benefit_system.get_variable('disposable_income')
 
     assert disposable_income_reform is not None
-    assert disposable_income_reform.entity.plural == disposable_income_reference.entity.plural
-    assert disposable_income_reform.name == disposable_income_reference.name
-    assert disposable_income_reform.label == disposable_income_reference.label
+    assert disposable_income_reform.entity.plural == disposable_income_baseline.entity.plural
+    assert disposable_income_reform.name == disposable_income_baseline.name
+    assert disposable_income_reform.label == disposable_income_baseline.label
 
     reform_simulation = scenario.new_simulation()
-    disposable_income1 = reform_simulation.calculate('disposable_income', period = '2013-01')
+    disposable_income1 = reform_simulation.calculate('disposable_income', period = '2018-01')
     assert_near(disposable_income1, 10, absolute_error_margin = 0)
+
+    disposable_income2 = reform_simulation.calculate('disposable_income', period = '2017-01')
+    # Before 2018, the former formula is used
+    assert(disposable_income2 > 100)
+
+
+def test_replace_variable():
+
+    class disposable_income(Variable):
+        definition_period = MONTH
+        entity = Person
+        label = "Disposable income"
+        value_type = float
+
+        def formula_2018(household, period):
+            return household.empty_array() + 10
+
+    class test_update_variable(Reform):
+        def apply(self):
+            self.replace_variable(disposable_income)
+
+    reform = test_update_variable(tax_benefit_system)
+
+    disposable_income_reform = reform.get_variable('disposable_income')
+    assert disposable_income_reform.get_formula('2017') is None
 
 
 @raises(Exception)


### PR DESCRIPTION
Fixes #465 

* Introduce `TaxBenefitSystem.replace_variable`
  - Unlike `update_variable`, this method does _not_ keep any of the replaced variable in the new one.
  - See [reference documentation](https://github.com/openfisca/openfisca-core/blob/add-replace-variable/openfisca_core/taxbenefitsystems.py#L125-L133).