### PR TITLE
Track user ip through proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 23.4.1 [#700](https://github.com/openfisca/openfisca-core/pull/700)
 
-* Send the web API user's IP address to the tracker even when it goes through a proxy.
+* Fix API source IP detection through proxies.
 
 ## 23.4.0 [#694](https://github.com/openfisca/openfisca-core/pull/694)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 23.4.1 [#700](https://github.com/openfisca/openfisca-core/pull/700)
+
+* Send the web API user's IP address to the tracker even when it goes through a proxy.
+
 ## 23.4.0 [#694](https://github.com/openfisca/openfisca-core/pull/694)
 
 * Use `/` rather than `.` in the path to access a parameter:

--- a/openfisca_web_api_preview/app.py
+++ b/openfisca_web_api_preview/app.py
@@ -184,7 +184,7 @@ def create_app(tax_benefit_system,
 
             api_version = "{}-{}".format(data['country_package_metadata']['name'],
                                          data['country_package_metadata']['version'])
-            
+
             tracker.track(request.url, source_ip, api_version, request.path)
         return response
 

--- a/openfisca_web_api_preview/app.py
+++ b/openfisca_web_api_preview/app.py
@@ -177,13 +177,13 @@ def create_app(tax_benefit_system,
             api_version = "{}-{}".format(data['country_package_metadata']['name'],
                                          data['country_package_metadata']['version'])
             if request.headers.get('dnt'):
-                user_ip = ""
+                source_ip = ""
             elif request.headers.get('X-Forwarded-For'):
-                user_ip = request.headers['X-Forwarded-For'].split(', ')[0]
+                source_ip = request.headers['X-Forwarded-For'].split(', ')[0]
             else:
-                user_ip = request.remote_addr
+                source_ip = request.remote_addr
 
-            tracker.track(request.url, user_ip, api_version, request.path)
+            tracker.track(request.url, source_ip, api_version, request.path)
         return response
 
     @app.errorhandler(500)

--- a/openfisca_web_api_preview/app.py
+++ b/openfisca_web_api_preview/app.py
@@ -174,8 +174,7 @@ def create_app(tax_benefit_system,
     def track_requests(response):
 
         if tracker:
-            api_version = "{}-{}".format(data['country_package_metadata']['name'],
-                                         data['country_package_metadata']['version'])
+
             if request.headers.get('dnt'):
                 source_ip = ""
             elif request.headers.get('X-Forwarded-For'):
@@ -183,6 +182,9 @@ def create_app(tax_benefit_system,
             else:
                 source_ip = request.remote_addr
 
+            api_version = "{}-{}".format(data['country_package_metadata']['name'],
+                                         data['country_package_metadata']['version'])
+            
             tracker.track(request.url, source_ip, api_version, request.path)
         return response
 

--- a/openfisca_web_api_preview/app.py
+++ b/openfisca_web_api_preview/app.py
@@ -172,12 +172,18 @@ def create_app(tax_benefit_system,
 
     @app.after_request
     def track_requests(response):
+
         if tracker:
+            api_version = "{}-{}".format(data['country_package_metadata']['name'],
+                                         data['country_package_metadata']['version'])
             if request.headers.get('dnt'):
-                tracker.track(request.url)
+                user_ip = ""
+            elif request.headers.get('X-Forwarded-For'):
+                user_ip = request.headers['X-Forwarded-For'].split(', ')[0]
             else:
-                api_version = "{}-{}".format(data['country_package_metadata']['name'], data['country_package_metadata']['version'])
-                tracker.track(request.url, request.remote_addr, api_version, request.path)
+                user_ip = request.remote_addr
+
+            tracker.track(request.url, user_ip, api_version, request.path)
         return response
 
     @app.errorhandler(500)

--- a/openfisca_web_api_preview/app.py
+++ b/openfisca_web_api_preview/app.py
@@ -174,7 +174,6 @@ def create_app(tax_benefit_system,
     def track_requests(response):
 
         if tracker:
-
             if request.headers.get('dnt'):
                 source_ip = ""
             elif request.headers.get('X-Forwarded-For'):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '23.4.0',
+    version = '23.4.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
connected to core #683 

This PR fixes the web API tracking so that the user's IP will be sent to the tracker even when the requests goes through a proxy (nginx)

#### Technical changes

- Adds a condition to send the first IP of the  `'X-Forwarded-For'` variable set by nginx, as the user's IP.
