### PR TITLE
 Backport unicode litterals from Python 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+
+### 23.3.2[#???](https://github.com/openfisca/openfisca-core/pull/???)
+
+Minor Change without any impact for country package developers and users:
+  - Make code more Python3-like by backporting unicode litterals.
+  - With this backport, all strings are by default unicodes.
+  - The `u` prefix for strings should *not* be used anymore.
+  - Each new module must start by `from __future__ import unicode_literals` for the backport to be effective.
+
 ### 23.3.1 [#682](https://github.com/openfisca/openfisca-core/pull/682)
 
 * Send reference of the country-package and its version to the tracker so it will appear in the tracking statistics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-### 23.3.2[#702](https://github.com/openfisca/openfisca-core/pull/702)
+### 23.3.2 [#702](https://github.com/openfisca/openfisca-core/pull/702)
 
 Minor Change without any impact for country package developers and users:
   - Make code more Python3-like by backporting unicode litterals.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-### 23.3.2[#???](https://github.com/openfisca/openfisca-core/pull/???)
+### 23.3.2[#702](https://github.com/openfisca/openfisca-core/pull/702)
 
 Minor Change without any impact for country package developers and users:
   - Make code more Python3-like by backporting unicode litterals.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This package contains the core features of OpenFisca, which are meant to be used
 
 ## Environment
 
-This package requires Python 2.7
+OpenFisca runs on Python 3.6, or more recent versions.
+
+Backward compatibility with Python 2.7 is maintained for now, but will be dropped from January 1st, 2019.
 
 ## Installation
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
+
 extensions = [
     'sphinx.ext.autodoc',
     'sphinxarg.ext',
     'sphinxcontrib.httpdomain',
     ]
 master_doc = 'index'
-project = u'openfisca-core'
-author = u'Openfisca Team'
+project = 'openfisca-core'
+author = 'Openfisca Team'
 html_theme = 'classic'
 html_static_path = ['_static']
 html_context = {

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 
 
 extensions = [

--- a/openfisca_core/__init__.py
+++ b/openfisca_core/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals, print_function, division, absolute_import
 import logging
 
 logging.basicConfig()

--- a/openfisca_core/base_functions.py
+++ b/openfisca_core/base_functions.py
@@ -7,7 +7,7 @@
     If a variable is calculated at a period for which it does not have a formulas, its base_function will be called to try to infere a value based on past or future values of the variable.
 """
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 
 
 def requested_period_default_value(holder, period, *extra_params):

--- a/openfisca_core/base_functions.py
+++ b/openfisca_core/base_functions.py
@@ -7,6 +7,8 @@
     If a variable is calculated at a period for which it does not have a formulas, its base_function will be called to try to infere a value based on past or future values of the variable.
 """
 
+from __future__ import unicode_literals
+
 
 def requested_period_default_value(holder, period, *extra_params):
     """
@@ -46,4 +48,4 @@ def requested_period_last_or_next_value(holder, period, *extra_params):
 
 
 def missing_value(holder, period, *extra_params):
-    raise ValueError(u"Missing value for variable {} at {}".format(holder.variable.name, period))
+    raise ValueError("Missing value for variable {} at {}".format(holder.variable.name, period))

--- a/openfisca_core/columns.py
+++ b/openfisca_core/columns.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from builtins import str
 import collections
 import datetime

--- a/openfisca_core/columns.py
+++ b/openfisca_core/columns.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+from builtins import str
 import collections
 import datetime
 import re
@@ -8,7 +10,7 @@ import numpy as np
 
 from openfisca_core import conv, periods
 from openfisca_core.indexed_enums import Enum
-from openfisca_core.commons import unicode_type, basestring_type, to_unicode
+from openfisca_core.commons import basestring_type, to_unicode
 
 """
 Columns are the ancestors of Variables, and are now considered deprecated. Preferably use `Variable` instead.
@@ -173,8 +175,8 @@ class DateCol(Column):
     @property
     def input_to_dated_python(self):
         return conv.pipe(
-            conv.test(year_or_month_or_day_re.match, error = N_(u'Invalid date')),
-            conv.function(lambda birth: u'-'.join((birth.split(u'-') + [u'01', u'01'])[:3])),
+            conv.test(year_or_month_or_day_re.match, error = N_('Invalid date')),
+            conv.function(lambda birth: '-'.join((birth.split('-') + ['01', '01'])[:3])),
             conv.iso8601_input_to_date,
             )
 
@@ -196,8 +198,8 @@ class DateCol(Column):
                         ),
                     conv.pipe(
                         conv.test_isinstance(basestring_type),
-                        conv.test(year_or_month_or_day_re.match, error = N_(u'Invalid date')),
-                        conv.function(lambda birth: u'-'.join((birth.split(u'-') + [u'01', u'01'])[:3])),
+                        conv.test(year_or_month_or_day_re.match, error = N_('Invalid date')),
+                        conv.function(lambda birth: '-'.join((birth.split('-') + ['01', '01'])[:3])),
                         conv.iso8601_input_to_date,
                         ),
                     ),
@@ -222,7 +224,7 @@ class FixedStrCol(Column):
             conv.condition(
                 conv.test_isinstance((float, int)),
                 # YAML stores strings containing only digits as numbers.
-                conv.function(unicode_type),
+                conv.function(str),
                 ),
             conv.test_isinstance(basestring_type),
             conv.test(lambda value: len(value) <= self.variable.max_length),
@@ -273,7 +275,7 @@ class StrCol(Column):
             conv.condition(
                 conv.test_isinstance((float, int)),
                 # YAML stores strings containing only digits as numbers.
-                conv.function(unicode_type),
+                conv.function(str),
                 ),
             conv.test_isinstance(basestring_type),
             )

--- a/openfisca_core/columns.py
+++ b/openfisca_core/columns.py
@@ -34,6 +34,7 @@ def make_column_from_variable(variable):
         int: IntCol,
         float: FloatCol,
         str: StrCol,
+        bytes: StrCol,
         Enum: EnumCol,
         datetime.date: DateCol,
         }

--- a/openfisca_core/commons.py
+++ b/openfisca_core/commons.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+from builtins import str
+
+
 # The following two variables and the is_unicode function are there to bridge string types across Python 2 & 3
-unicode_type = u"".__class__
-basestring_type = (b"".__class__, unicode_type)
+basestring_type = (bytes, str)
 
 
 def to_unicode(string):
@@ -14,7 +17,7 @@ def to_unicode(string):
     """
     if not isinstance(string, basestring_type):
         string = str(string)
-    if isinstance(string, unicode_type):
+    if isinstance(string, str):
         return string
 
     # Next line only gets triggered if the code is run in python 2
@@ -40,7 +43,7 @@ def stringify_array(array):
     """
         Generate a clean string representation of a NumPY array.
     """
-    return u'[{}]'.format(u', '.join(
+    return '[{}]'.format(', '.join(
         to_unicode(cell)
         for cell in array
-        )) if array is not None else u'None'
+        )) if array is not None else 'None'

--- a/openfisca_core/commons.py
+++ b/openfisca_core/commons.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from builtins import str
 
 

--- a/openfisca_core/commons.py
+++ b/openfisca_core/commons.py
@@ -4,24 +4,21 @@ from __future__ import unicode_literals
 from builtins import str
 
 
-# The following two variables and the is_unicode function are there to bridge string types across Python 2 & 3
+# The following variable and the to_unicode function are there to bridge string types across Python 2 & 3
 basestring_type = (bytes, str)
 
 
 def to_unicode(string):
     """
     :param string: a string that needs to be unicoded
-    :param encoding: a string that represent the encoding type
     :return: a unicode string
     if the string is a python 2 str type, returns a unicode version of the string.
     """
-    if not isinstance(string, basestring_type):
-        string = str(string)
     if isinstance(string, str):
         return string
-
-    # Next line only gets triggered if the code is run in python 2
-    return string.decode('utf-8')
+    if isinstance(string, bytes):
+        return string.decode('utf-8')
+    return str(string)
 
 
 class Dummy(object):

--- a/openfisca_core/conv.py
+++ b/openfisca_core/conv.py
@@ -3,7 +3,7 @@
 
 """Conversion functions"""
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 
 from biryani.baseconv import *  # noqa
 from biryani.datetimeconv import *  # noqa

--- a/openfisca_core/conv.py
+++ b/openfisca_core/conv.py
@@ -3,6 +3,7 @@
 
 """Conversion functions"""
 
+from __future__ import unicode_literals
 
 from biryani.baseconv import *  # noqa
 from biryani.datetimeconv import *  # noqa
@@ -31,16 +32,16 @@ def anything_to_strict_int(value, state = None):
     (42, None)
     >>> anything_to_strict_int('42')
     (42, None)
-    >>> anything_to_strict_int(u'42')
+    >>> anything_to_strict_int('42')
     (42, None)
     >>> anything_to_strict_int(42.0)
     (42, None)
     >>> anything_to_strict_int(42.75)
-    (42.75, u'Value must be an integer')
-    >>> anything_to_strict_int(u'42.75')
-    (u'42.75', u'Value must be an integer')
-    >>> anything_to_strict_int(u'42,75')
-    (u'42,75', u'Value must be an integer')
+    (42.75, 'Value must be an integer')
+    >>> anything_to_strict_int('42.75')
+    ('42.75', 'Value must be an integer')
+    >>> anything_to_strict_int('42,75')
+    ('42,75', 'Value must be an integer')
     >>> anything_to_strict_int(None)
     (None, None)
     """
@@ -54,9 +55,9 @@ def anything_to_strict_int(value, state = None):
         float_value = float(value)
         int_value = int(float_value)
     except ValueError:
-        return value, state._(u'Value must be an integer')
+        return value, state._('Value must be an integer')
     if float_value != int_value:
-        return value, state._(u'Value must be an integer')
+        return value, state._('Value must be an integer')
     return int_value, None
 
 
@@ -94,14 +95,14 @@ input_to_strict_int = pipe(cleanup_line, anything_to_strict_int)
 
     >>> input_to_strict_int('42')
     (42, None)
-    >>> input_to_strict_int(u'   42   ')
+    >>> input_to_strict_int('   42   ')
     (42, None)
-    >>> input_to_strict_int(u'42.0')
+    >>> input_to_strict_int('42.0')
     (42, None)
-    >>> input_to_strict_int(u'42.75')
-    (u'42.75', u'Value must be an integer')
-    >>> input_to_strict_int(u'42,75')
-    (u'42,75', u'Value must be an integer')
+    >>> input_to_strict_int('42.75')
+    ('42.75', 'Value must be an integer')
+    >>> input_to_strict_int('42,75')
+    ('42,75', 'Value must be an integer')
     >>> input_to_strict_int(None)
     (None, None)
     """

--- a/openfisca_core/data_storage.py
+++ b/openfisca_core/data_storage.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import shutil
 import os
 

--- a/openfisca_core/data_storage.py
+++ b/openfisca_core/data_storage.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import shutil
 import os
 

--- a/openfisca_core/decompositions.py
+++ b/openfisca_core/decompositions.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
+from __future__ import unicode_literals
 import collections
 import copy
 from xml.etree import ElementTree

--- a/openfisca_core/decompositions.py
+++ b/openfisca_core/decompositions.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import collections
 import copy
 from xml.etree import ElementTree

--- a/openfisca_core/decompositionsxml.py
+++ b/openfisca_core/decompositionsxml.py
@@ -3,7 +3,7 @@
 
 """Handle decompositions in XML format (and convert then to JSON)."""
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import collections
 
 from openfisca_core import conv

--- a/openfisca_core/decompositionsxml.py
+++ b/openfisca_core/decompositionsxml.py
@@ -3,7 +3,7 @@
 
 """Handle decompositions in XML format (and convert then to JSON)."""
 
-
+from __future__ import unicode_literals
 import collections
 
 from openfisca_core import conv
@@ -18,14 +18,14 @@ def transform_node_xml_json_to_json(node_xml_json, root = True):
     comments = []
     node_json = collections.OrderedDict()
     if root:
-        node_json['@context'] = u'https://openfisca.fr/contexts/decomposition.jsonld'
+        node_json['@context'] = 'https://openfisca.fr/contexts/decomposition.jsonld'
     node_json['@type'] = 'Node'
     children_json = []
     for key, value in node_xml_json.items():
         if key == 'color':
             node_json['color'] = [
                 int(color)
-                for color in value.split(u',')
+                for color in value.split(',')
                 ]
         elif key == 'desc':
             node_json['name'] = value
@@ -43,7 +43,7 @@ def transform_node_xml_json_to_json(node_xml_json, root = True):
     if children_json:
         node_json['children'] = children_json
     if comments:
-        node_json['comment'] = u'\n\n'.join(comments)
+        node_json['comment'] = '\n\n'.join(comments)
     return node_json
 
 
@@ -79,7 +79,7 @@ def make_validate_node_xml_json(tax_benefit_system):
                         ),
                     color = conv.pipe(
                         conv.test_isinstance(basestring_type),
-                        conv.function(lambda colors: colors.split(u',')),
+                        conv.function(lambda colors: colors.split(',')),
                         conv.uniform_sequence(
                             conv.pipe(
                                 conv.input_to_int,
@@ -87,8 +87,8 @@ def make_validate_node_xml_json(tax_benefit_system):
                                 conv.not_none,
                                 ),
                             ),
-                        conv.test(lambda colors: len(colors) == 3, error = N_(u'Wrong number of colors in triplet.')),
-                        conv.function(lambda colors: u','.join(to_unicode(color) for color in colors)),
+                        conv.test(lambda colors: len(colors) == 3, error = N_('Wrong number of colors in triplet.')),
+                        conv.function(lambda colors: ','.join(to_unicode(color) for color in colors)),
                         ),
                     desc = conv.pipe(
                         conv.test_isinstance(basestring_type),
@@ -149,5 +149,5 @@ def xml_decomposition_to_json(xml_element, state = None):
     if json_key != 'NODE':
         if state is None:
             state = conv.default_state
-        return json_element, state._(u'Invalid root element in XML: "{}" instead of "NODE"').format(xml_element.tag)
+        return json_element, state._('Invalid root element in XML: "{}" instead of "NODE"').format(xml_element.tag)
     return json_element, None

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import traceback
 import warnings
 import textwrap

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import traceback
 import warnings
 import textwrap
@@ -77,7 +78,7 @@ class Entity(object):
 
             if not isinstance(variable_values, dict):
                 raise SituationParsingError(path_in_json,
-                    u"Invalid type: must be of type object. Input variables must be set for specific periods. For instance: {'salary': {'2017-01': 2000, '2017-02': 2500}}, or {'birth_date': {'ETERNITY': '1980-01-01'}}.")
+                    "Invalid type: must be of type object. Input variables must be set for specific periods. For instance: {'salary': {'2017-01': 2000, '2017-02': 2500}}, or {'birth_date': {'ETERNITY': '1980-01-01'}}.")
 
             holder = self.get_holder(variable_name)
             for date, value in variable_values.items():
@@ -96,14 +97,14 @@ class Entity(object):
                         except KeyError:
                             possible_values = [item.name for item in holder.variable.possible_values]
                             raise SituationParsingError(path_in_json,
-                                u"'{}' is not a valid value for '{}'. Possible values are ['{}'].".format(
+                                "'{}' is not a valid value for '{}'. Possible values are ['{}'].".format(
                                     value, variable_name, "', '".join(possible_values))
                                 )
                     try:
                         array[entity_index] = value
                     except (ValueError, TypeError) as e:
                         raise SituationParsingError(path_in_json,
-                            u'Invalid type: must be of type {}.'.format(holder.variable.json_type))
+                            'Invalid type: must be of type {}.'.format(holder.variable.json_type))
 
                     holder.buffer[period] = array
 
@@ -121,7 +122,7 @@ class Entity(object):
                     # It is only raised when we consume the buffer. We thus don't know which exact key caused the error.
                     # We do a basic research to find the culprit path
                     culprit_path = next(
-                        dpath.search(self.entities_json, u"*/{}/{}".format(e.variable_name, str(e.period)), yielded = True),
+                        dpath.search(self.entities_json, "*/{}/{}".format(e.variable_name, str(e.period)), yielded = True),
                         None)
                     if culprit_path:
                         path = [self.plural] + culprit_path[0].split('/')
@@ -151,7 +152,7 @@ class Entity(object):
     def __getattr__(self, attribute):
         projector = get_projector_from_shortcut(self, attribute)
         if not projector:
-            raise AttributeError(u"Entity {} has no attribute {}".format(self.key, attribute))
+            raise AttributeError("Entity {} has no attribute {}".format(self.key, attribute))
         return projector
 
     @classmethod
@@ -171,25 +172,25 @@ class Entity(object):
         variable_entity = self.simulation.tax_benefit_system.get_variable(variable_name, check_existence = True).entity
         if not isinstance(self, variable_entity):
             message = linesep.join([
-                u"You tried to compute the variable '{0}' for the entity '{1}';".format(variable_name, self.plural),
-                u"however the variable '{0}' is defined for '{1}'.".format(variable_name, variable_entity.plural),
-                u"Learn more about entities in our documentation:",
-                u"<http://openfisca.org/doc/coding-the-legislation/50_entities.html>."])
+                "You tried to compute the variable '{0}' for the entity '{1}';".format(variable_name, self.plural),
+                "however the variable '{0}' is defined for '{1}'.".format(variable_name, variable_entity.plural),
+                "Learn more about entities in our documentation:",
+                "<http://openfisca.org/doc/coding-the-legislation/50_entities.html>."])
             raise ValueError(message)
 
     def check_array_compatible_with_entity(self, array):
         if not self.count == array.size:
-            raise ValueError(u"Input {} is not a valid value for the entity {}".format(array, self.key))
+            raise ValueError("Input {} is not a valid value for the entity {}".format(array, self.key))
 
     def check_role_validity(self, role):
         if role is not None and not type(role) == Role:
-            raise ValueError(u"{} is not a valid role".format(role))
+            raise ValueError("{} is not a valid role".format(role))
 
     def check_period_validity(self, variable_name, period):
         if period is None:
             stack = traceback.extract_stack()
             filename, line_number, function_name, line_of_code = stack[-3]
-            raise ValueError(u'''
+            raise ValueError('''
 You requested computation of variable "{}", but you did not specify on which period in "{}:{}":
     {}
 When you request the computation of a variable within a formula, you must always specify the period as the second parameter. The convention is to call this parameter "period". For example:
@@ -213,7 +214,7 @@ See more information at <http://openfisca.org/doc/coding-the-legislation/35_peri
         self.check_period_validity(variable_name, period)
 
         if ADD in options and DIVIDE in options:
-            raise ValueError(u'Options ADD and DIVIDE are incompatible (trying to compute variable {})'.format(variable_name).encode('utf-8'))
+            raise ValueError('Options ADD and DIVIDE are incompatible (trying to compute variable {})'.format(variable_name).encode('utf-8'))
         elif ADD in options:
             return self.simulation.calculate_add(variable_name, period, **parameters)
         elif DIVIDE in options:
@@ -300,7 +301,7 @@ class PersonEntity(Entity):
         self.check_role_validity(role)
 
         if not role.subroles or not len(role.subroles) == 2:
-            raise Exception(u'Projection to partner is only implemented for roles having exactly two subroles.')
+            raise Exception('Projection to partner is only implemented for roles having exactly two subroles.')
 
         [subrole_1, subrole_2] = role.subroles
         value_subrole_1 = entity.value_from_person(array, subrole_1)
@@ -406,7 +407,7 @@ class GroupEntity(Entity):
         if self.persons_to_allocate:
             unallocated_person = self.persons_to_allocate.pop()
             raise SituationParsingError([self.plural],
-                u'{0} has been declared in {1}, but is not a member of any {2}. All {1} must be allocated to a {2}.'.format(
+                '{0} has been declared in {1}, but is not a member of any {2}. All {1} must be allocated to a {2}.'.format(
                     unallocated_person, self.simulation.persons.plural, self.key)
                 )
 
@@ -417,12 +418,12 @@ class GroupEntity(Entity):
                 check_type(person_id, basestring_type, [self.plural, entity_id, role_id, str(index)])
                 if person_id not in self.simulation.persons.ids:
                     raise SituationParsingError([self.plural, entity_id, role_id],
-                        u"Unexpected value: {0}. {0} has been declared in {1} {2}, but has not been declared in {3}.".format(
+                        "Unexpected value: {0}. {0} has been declared in {1} {2}, but has not been declared in {3}.".format(
                             person_id, entity_id, role_id, self.simulation.persons.plural)
                         )
                 if person_id not in self.persons_to_allocate:
                     raise SituationParsingError([self.plural, entity_id, role_id],
-                        u"{} has been declared more than once in {}".format(
+                        "{} has been declared more than once in {}".format(
                             person_id, self.plural)
                         )
                 self.persons_to_allocate.discard(person_id)
@@ -465,8 +466,8 @@ class GroupEntity(Entity):
     @property
     def roles_count(self):
         warnings.warn(' '.join([
-            u"entity.roles_count is deprecated.",
-            u"Since OpenFisca Core 23.0, this attribute has strictly no effect, and it is not necessary to set it."
+            "entity.roles_count is deprecated.",
+            "Since OpenFisca Core 23.0, this attribute has strictly no effect, and it is not necessary to set it."
             ]),
             Warning
             )
@@ -477,8 +478,8 @@ class GroupEntity(Entity):
     @roles_count.setter
     def roles_count(self, value):
         warnings.warn(' '.join([
-            u"entity.roles_count is deprecated.",
-            u"Since OpenFisca Core 23.0, this attribute has strictly no effect, and it is not necessary to set it."
+            "entity.roles_count is deprecated.",
+            "Since OpenFisca Core 23.0, this attribute has strictly no effect, and it is not necessary to set it."
             ]),
             Warning
             )
@@ -641,7 +642,7 @@ class GroupEntity(Entity):
         self.check_role_validity(role)
         if role.max != 1:
             raise Exception(
-                u'You can only use value_from_person with a role that is unique in {}. Role {} is not unique.'
+                'You can only use value_from_person with a role that is unique in {}. Role {} is not unique.'
                 .format(self.key, role.key)
                 )
         self.simulation.persons.check_array_compatible_with_entity(array)

--- a/openfisca_core/errors.py
+++ b/openfisca_core/errors.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from os import linesep
 
 

--- a/openfisca_core/errors.py
+++ b/openfisca_core/errors.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from os import linesep
 
 
@@ -21,11 +22,11 @@ class VariableNotFound(Exception):
         else:
             country_package_id = country_package_name
         message = linesep.join([
-            u"You tried to calculate or to set a value for variable '{0}', but it was not found in the loaded tax and benefit system ({1}).".format(variable_name, country_package_id),
-            u"Are you sure you spelled '{0}' correctly?".format(variable_name),
-            u"If this code used to work and suddenly does not, this is most probably linked to an update of the tax and benefit system.",
-            u"Look at its changelog to learn about renames and removals and update your code. If it is an official package,",
-            u"it is probably available on <https://github.com/openfisca/{0}/blob/master/CHANGELOG.md>.".format(country_package_name)
+            "You tried to calculate or to set a value for variable '{0}', but it was not found in the loaded tax and benefit system ({1}).".format(variable_name, country_package_id),
+            "Are you sure you spelled '{0}' correctly?".format(variable_name),
+            "If this code used to work and suddenly does not, this is most probably linked to an update of the tax and benefit system.",
+            "Look at its changelog to learn about renames and removals and update your code. If it is an official package,",
+            "it is probably available on <https://github.com/openfisca/{0}/blob/master/CHANGELOG.md>.".format(country_package_name)
             ])
         self.message = message
         Exception.__init__(self, self.message.encode('utf-8'))

--- a/openfisca_core/formula_helpers.py
+++ b/openfisca_core/formula_helpers.py
@@ -2,6 +2,7 @@
 
 
 """Helpers to write formulas."""
+from __future__ import unicode_literals
 
 
 import numpy as np

--- a/openfisca_core/formula_helpers.py
+++ b/openfisca_core/formula_helpers.py
@@ -2,7 +2,7 @@
 
 
 """Helpers to write formulas."""
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 
 
 import numpy as np

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-from __future__ import division
+from __future__ import unicode_literals, print_function, division, absolute_import
 import logging
 import os
 import sys

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-
+from __future__ import unicode_literals
 from __future__ import division
 import logging
 import os
@@ -156,8 +156,8 @@ class Holder(object):
             array = np.asarray(array)
         if period.unit == ETERNITY and self.variable.definition_period != ETERNITY:
             error_message = os.linesep.join([
-                u'Unable to set a value for variable {0} for ETERNITY.',
-                u'{0} is only defined for {1}s. Please adapt your input.',
+                'Unable to set a value for variable {0} for ETERNITY.',
+                '{0} is only defined for {1}s. Please adapt your input.',
                 ]).format(
                     self.variable.name,
                     self.variable.definition_period
@@ -169,7 +169,7 @@ class Holder(object):
                 error_message
                 )
         if self.variable.is_neutralized:
-            warning_message = u"You cannot set a value for the variable {}, as it has been neutralized. The value you provided ({}) will be ignored.".format(self.variable.name, array)
+            warning_message = "You cannot set a value for the variable {}, as it has been neutralized. The value you provided ({}) will be ignored.".format(self.variable.name, array)
             if sys.version_info < (3, 0):
                 warning_message = warning_message.encode('utf-8')
             return warnings.warn(
@@ -189,7 +189,7 @@ class Holder(object):
                 value = value.astype(self.variable.dtype)
             except ValueError:
                 raise ValueError(
-                    u'Unable to set value "{}" for variable "{}", as the variable dtype "{}" does not match the value dtype "{}".'
+                    'Unable to set value "{}" for variable "{}", as the variable dtype "{}" does not match the value dtype "{}".'
                     .format(value, self.variable.name, self.variable.dtype, value.dtype)
                     .encode('utf-8'))
 
@@ -199,9 +199,9 @@ class Holder(object):
             if ((self.variable.definition_period == MONTH and period.unit != periods.MONTH) or
                (self.variable.definition_period == YEAR and period.unit != periods.YEAR)):
                 error_message = os.linesep.join([
-                    u'Unable to set a value for variable {0} for {1}-long period {2}.',
-                    u'{0} is only defined for {3}s. Please adapt your input.',
-                    u'If you are the maintainer of {0}, you can consider adding it a set_input attribute to enable automatic period casting.'
+                    'Unable to set a value for variable {0} for {1}-long period {2}.',
+                    '{0} is only defined for {3}s. Please adapt your input.',
+                    'If you are the maintainer of {0}, you can consider adding it a set_input attribute to enable automatic period casting.'
                     ]).format(
                         self.variable.name,
                         period.unit,
@@ -395,4 +395,4 @@ def set_input_divide_by_period(holder, period, array):
                 holder._set(sub_period, divided_array)
             sub_period = sub_period.offset(1)
     elif not (remaining_array == 0).all():
-        raise ValueError(u"Inconsistent input: variable {0} has already been set for all months contained in period {1}, and value {2} provided for {1} doesn't match the total ({3}). This error may also be thrown if you try to call set_input twice for the same variable and period.".format(holder.variable.name, period, array, array - remaining_array).encode('utf-8'))
+        raise ValueError("Inconsistent input: variable {0} has already been set for all months contained in period {1}, and value {2} provided for {1} doesn't match the total ({3}). This error may also be thrown if you try to call set_input twice for the same variable and period.".format(holder.variable.name, period, array, array - remaining_array).encode('utf-8'))

--- a/openfisca_core/indexed_enums.py
+++ b/openfisca_core/indexed_enums.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 import numpy as np
 from enum import Enum as BaseEnum
 
@@ -101,7 +103,7 @@ class EnumArray(np.ndarray):
             >>> enum_array[0]
             >>> 2  # Encoded value
             >>> enum_array.decode()[0]
-            >>> <HousingOccupancyStatus.free_lodger: u'Free lodger'>  # Decoded value : enum item
+            >>> <HousingOccupancyStatus.free_lodger: 'Free lodger'>  # Decoded value : enum item
         """
         return np.select([self == item.index for item in self.possible_values], [item for item in self.possible_values])
 

--- a/openfisca_core/indexed_enums.py
+++ b/openfisca_core/indexed_enums.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 
 import numpy as np
 from enum import Enum as BaseEnum

--- a/openfisca_core/json_to_test_case.py
+++ b/openfisca_core/json_to_test_case.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from copy import deepcopy
 
 from openfisca_core.columns import make_column_from_variable
@@ -11,7 +12,7 @@ def check_entity_fields(entity_json, entity_class, valid_roles, tax_benefit_syst
 
     def check_id(value):
         if value is None or not isinstance(value, (basestring_type, int)):
-            raise ValueError(u"Invalid id in entity {}".format(entity_json).encode('utf-8'))
+            raise ValueError("Invalid id in entity {}".format(entity_json).encode('utf-8'))
 
     def check_role(value, key):
         role = valid_roles.get(key)
@@ -28,17 +29,17 @@ def check_entity_fields(entity_json, entity_class, valid_roles, tax_benefit_syst
                 )(value)
 
         if error is not None:
-            raise ValueError(u"Invalid description of {}: {}. Error: {}".format(entity_class.key, entity_json, error).encode('utf-8'))
+            raise ValueError("Invalid description of {}: {}. Error: {}".format(entity_class.key, entity_json, error).encode('utf-8'))
         entity_json[key] = value
 
     def check_variable(value, key):
         variable = tax_benefit_system.variables[key]
         column = make_column_from_variable(variable)
         if column.entity != entity_class:
-            raise ValueError(u"Variable {} is defined for entity {}. It cannot be set for entity {}.".format(key, column.entity.key, entity_class.key).encode('utf-8'))
+            raise ValueError("Variable {} is defined for entity {}. It cannot be set for entity {}.".format(key, column.entity.key, entity_class.key).encode('utf-8'))
         value, error = column.json_to_python(value)
         if error is not None:
-            raise ValueError(u"Invalid value {} for variable {}. Error: {}".format(value, key, error).encode('utf-8'))
+            raise ValueError("Invalid value {} for variable {}. Error: {}".format(value, key, error).encode('utf-8'))
         entity_json[key] = value
 
     for key, value in entity_json.items():
@@ -72,7 +73,7 @@ def check_entities_and_role(test_case, tax_benefit_system, state):
     entity_classes = {entity_class.plural: entity_class for entity_class in tax_benefit_system.entities}
     for entity_type_name, entities in test_case.items():
         if entity_classes.get(entity_type_name) is None:
-            raise ValueError(u"Invalid entity name: {}".format(entity_type_name).encode('utf-8'))
+            raise ValueError("Invalid entity name: {}".format(entity_type_name).encode('utf-8'))
         entities, error = conv.pipe(
             conv.make_item_to_singleton(),
             conv.test_isinstance(list),
@@ -83,7 +84,7 @@ def check_entities_and_role(test_case, tax_benefit_system, state):
             conv.function(set_entities_json_id),
             )(entities)
         if error is not None:
-            raise ValueError(u"Invalid list of {}: {}. Error: {}".format(entity_type_name, entities, error).encode('utf-8'))
+            raise ValueError("Invalid list of {}: {}. Error: {}".format(entity_type_name, entities, error).encode('utf-8'))
         if entities is None:
             entities = test_case[entity_type_name] = []  # YAML test runner may set these values to None
         entity_class = entity_classes[entity_type_name]
@@ -145,14 +146,14 @@ def check_each_person_has_entities(test_case, tax_benefit_system, state):
     error = None
     if groupless_persons_ids:
         individu_index_by_id = {
-            individu[u'id']: individu_index
+            individu['id']: individu_index
             for individu_index, individu in enumerate(test_case[tax_benefit_system.person_entity.plural])
             }
         error = {}
         for person_id in groupless_persons_ids:
             error.setdefault(tax_benefit_system.person_entity.plural, {})[individu_index_by_id[person_id]] = state._(
-                u"Individual is missing from {}").format(
-                    state._(u' & ').join(
+                "Individual is missing from {}").format(
+                    state._(' & ').join(
                         word
                         for word in [
                             entity.plural if person_id in groupless_persons[entity.plural] else None

--- a/openfisca_core/json_to_test_case.py
+++ b/openfisca_core/json_to_test_case.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from copy import deepcopy
 
 from openfisca_core.columns import make_column_from_variable

--- a/openfisca_core/memory_config.py
+++ b/openfisca_core/memory_config.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import logging
 
 log = logging.getLogger(__name__)

--- a/openfisca_core/memory_config.py
+++ b/openfisca_core/memory_config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import logging
 
 log = logging.getLogger(__name__)

--- a/openfisca_core/model_api.py
+++ b/openfisca_core/model_api.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from datetime import date  # noqa analysis:ignore
 
 from numpy import (   # noqa analysis:ignore

--- a/openfisca_core/model_api.py
+++ b/openfisca_core/model_api.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from datetime import date  # noqa analysis:ignore
 
 from numpy import (   # noqa analysis:ignore

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -2,6 +2,7 @@
 
 
 """Handle legislative parameters."""
+from __future__ import unicode_literals
 
 
 import os
@@ -36,7 +37,7 @@ def date_constructor(loader, node):
     return node.value
 
 
-yaml.add_constructor(u'tag:yaml.org,2002:timestamp', date_constructor, Loader = Loader)
+yaml.add_constructor('tag:yaml.org,2002:timestamp', date_constructor, Loader = Loader)
 
 
 class ParameterNotFound(AttributeError):
@@ -52,11 +53,11 @@ class ParameterNotFound(AttributeError):
         self.name = name
         self.instant_str = instant_str
         self.variable_name = variable_name
-        message = u"The parameter '{}'".format(name)
+        message = "The parameter '{}'".format(name)
         if variable_name is not None:
-            message += u" requested by variable '{}'".format(variable_name)
+            message += " requested by variable '{}'".format(variable_name)
         message += (
-            u" was not found in the {} tax and benefit system."
+            " was not found in the {} tax and benefit system."
             ).format(instant_str)
         super(ParameterNotFound, self).__init__(message.encode('utf-8'))
 
@@ -74,7 +75,7 @@ class ParameterParsingError(Exception):
         """
         if file is not None:
             message = os.linesep.join([
-                u"Error parsing parameter file '{}':".format(file),
+                "Error parsing parameter file '{}':".format(file),
                 message
                 ])
         if traceback is not None:
@@ -141,7 +142,7 @@ class Parameter(object):
         for instant_str in instants:
             if not INSTANT_PATTERN.match(instant_str):
                 raise ParameterParsingError(
-                    u"Invalid property '{}' in '{}'. Properties must be valid YYYY-MM-DD instants, such as 2017-01-15."
+                    "Invalid property '{}' in '{}'. Properties must be valid YYYY-MM-DD instants, such as 2017-01-15."
                     .format(instant_str, self.name),
                     file_path)
 
@@ -188,7 +189,7 @@ class Parameter(object):
         """
         if period is not None:
             if start is not None or stop is not None:
-                raise TypeError(u"Wrong input for 'update' method: use either 'update(period, value = value)' or 'update(start = start, stop = stop, value = value)'. You cannot both use 'period' and 'start' or 'stop'.")
+                raise TypeError("Wrong input for 'update' method: use either 'update(period, value = value)' or 'update(start = start, stop = stop, value = value)'. You cannot both use 'period' and 'start' or 'stop'.")
             if isinstance(period, basestring_type):
                 period = periods.period(period)
             start = period.start
@@ -280,12 +281,12 @@ class ParameterAtInstant(object):
             value = data['value']
         except KeyError:
             raise ParameterParsingError(
-                u"Missing 'value' property for {}".format(self.name),
+                "Missing 'value' property for {}".format(self.name),
                 self.file_path
                 )
         if type(value) not in self._allowed_value_data_types:
             raise ParameterParsingError(
-                u"Invalid value in {} : {}".format(self.name, value),
+                "Invalid value in {} : {}".format(self.name, value),
                 self.file_path
                 )
 
@@ -293,7 +294,7 @@ class ParameterAtInstant(object):
         return (self.name == other.name) and (self.instant_str == other.instant_str) and (self.value == other.value)
 
     def __repr__(self):
-        result = u"ParameterAtInstant({})".format({self.instant_str: self.value})
+        result = "ParameterAtInstant({})".format({self.instant_str: self.value})
         # repr output must be encoded in Python 2, but not in Python 3
         if sys.version_info < (3, 0):
             return result.encode('utf-8')
@@ -427,7 +428,7 @@ class ParameterNode(object):
     def __repr__(self):
         result = os.linesep.join(
             [os.linesep.join(
-                [u"{}:", u"{}"]).format(name, indent(repr(value)))
+                ["{}:", "{}"]).format(name, indent(repr(value)))
                 for name, value in sorted(self.children.items())]
             )
         # repr output must be encoded in Python 2, but not in Python 3
@@ -473,7 +474,7 @@ class ParameterNodeAtInstant(object):
     def __repr__(self):
         result = os.linesep.join(
             [os.linesep.join(
-                [u"{}:", u"{}"]).format(name, indent(repr(value)))
+                ["{}:", "{}"]).format(name, indent(repr(value)))
                 for name, value in self._children.items()]
             )
         if sys.version_info < (3, 0):

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -2,7 +2,7 @@
 
 
 """Handle legislative parameters."""
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 
 
 import os

--- a/openfisca_core/periods.py
+++ b/openfisca_core/periods.py
@@ -9,7 +9,7 @@ A period is a triple (unit, start, size), where unit is either "month" or "year"
 Since a period is a triple it can be used as a dictionary key.
 """
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from builtins import str
 
 import calendar

--- a/openfisca_core/periods.py
+++ b/openfisca_core/periods.py
@@ -9,6 +9,8 @@ A period is a triple (unit, start, size), where unit is either "month" or "year"
 Since a period is a triple it can be used as a dictionary key.
 """
 
+from __future__ import unicode_literals
+from builtins import str
 
 import calendar
 import collections
@@ -17,12 +19,12 @@ import re
 from os import linesep
 
 from openfisca_core import conv
-from openfisca_core.commons import unicode_type, basestring_type, to_unicode
+from openfisca_core.commons import basestring_type, to_unicode
 
 
-MONTH = u'month'
-YEAR = u'year'
-ETERNITY = u'eternity'
+MONTH = 'month'
+YEAR = 'year'
+ETERNITY = 'eternity'
 
 INSTANT_PATTERN = re.compile('^\d{4}(?:-\d{1,2}){0,2}$')  # matches '2015', '2015-01', '2015-01'
 
@@ -61,11 +63,11 @@ class Instant(tuple):
         '2014-02-03'
 
         >>> to_unicode(instant(2014))
-        u'2014-01-01'
+        '2014-01-01'
         >>> to_unicode(instant('2014-2'))
-        u'2014-02-01'
+        '2014-02-01'
         >>> to_unicode(instant('2014-2-3'))
-        u'2014-02-03'
+        '2014-02-03'
         """
         instant_str = str_by_instant_cache.get(self)
         if instant_str is None:
@@ -118,14 +120,14 @@ class Instant(tuple):
         """Create a new period starting at instant.
 
         >>> instant(2014).period('month')
-        Period((u'month', Instant((2014, 1, 1)), 1))
+        Period(('month', Instant((2014, 1, 1)), 1))
         >>> instant('2014-2').period('year', 2)
-        Period((u'year', Instant((2014, 2, 1)), 2))
+        Period(('year', Instant((2014, 2, 1)), 2))
         >>> instant('2014-2-3').period('day', size = 2)
-        Period((u'day', Instant((2014, 2, 3)), 2))
+        Period(('day', Instant((2014, 2, 3)), 2))
         """
-        assert unit in (u'day', u'month', u'year'), u'Invalid unit: {} of type {}'.format(unit, type(unit))
-        assert isinstance(size, int) and size >= 1, u'Invalid size: {} of type {}'.format(size, type(size))
+        assert unit in ('day', 'month', 'year'), 'Invalid unit: {} of type {}'.format(unit, type(unit))
+        assert isinstance(size, int) and size >= 1, 'Invalid size: {} of type {}'.format(size, type(size))
         return Period((to_unicode(unit), self, size))
 
     def offset(self, offset, unit):
@@ -210,22 +212,22 @@ class Instant(tuple):
         """
         year, month, day = self
         if offset == 'first-of':
-            if unit == u'month':
+            if unit == 'month':
                 day = 1
             else:
-                assert unit == u'year', u'Invalid unit: {} of type {}'.format(unit, type(unit))
+                assert unit == 'year', 'Invalid unit: {} of type {}'.format(unit, type(unit))
                 month = 1
                 day = 1
         elif offset == 'last-of':
-            if unit == u'month':
+            if unit == 'month':
                 day = calendar.monthrange(year, month)[1]
             else:
-                assert unit == u'year', u'Invalid unit: {} of type {}'.format(unit, type(unit))
+                assert unit == 'year', 'Invalid unit: {} of type {}'.format(unit, type(unit))
                 month = 12
                 day = 31
         else:
-            assert isinstance(offset, int), u'Invalid offset: {} of type {}'.format(offset, type(offset))
-            if unit == u'day':
+            assert isinstance(offset, int), 'Invalid offset: {} of type {}'.format(offset, type(offset))
+            if unit == 'day':
                 day += offset
                 if offset < 0:
                     while day < 1:
@@ -243,7 +245,7 @@ class Instant(tuple):
                             month = 1
                         day -= month_last_day
                         month_last_day = calendar.monthrange(year, month)[1]
-            elif unit == u'month':
+            elif unit == 'month':
                 month += offset
                 if offset < 0:
                     while month < 1:
@@ -257,7 +259,7 @@ class Instant(tuple):
                 if day > month_last_day:
                     day = month_last_day
             else:
-                assert unit == u'year', u'Invalid unit: {} of type {}'.format(unit, type(unit))
+                assert unit == 'year', 'Invalid unit: {} of type {}'.format(unit, type(unit))
                 year += offset
                 # Handle february month of leap year.
                 month_last_day = calendar.monthrange(year, month)[1]
@@ -284,11 +286,11 @@ class Period(tuple):
         """Transform period to to its Python representation as a string.
 
         >>> repr(period('year', 2014))
-        "Period((u'year', Instant((2014, 1, 1)), 1))"
+        "Period(('year', Instant((2014, 1, 1)), 1))"
         >>> repr(period('month', '2014-2'))
-        "Period((u'month', Instant((2014, 2, 1)), 1))"
+        "Period(('month', Instant((2014, 2, 1)), 1))"
         >>> repr(period('day', '2014-2-3'))
-        "Period((u'day', Instant((2014, 2, 3)), 1))"
+        "Period(('day', Instant((2014, 2, 3)), 1))"
         """
         return '{}({})'.format(self.__class__.__name__, super(Period, self).__repr__())
 
@@ -296,26 +298,26 @@ class Period(tuple):
         """Transform period to a string.
 
         >>> to_unicode(period(YEAR, 2014))
-        u'2014'
+        '2014'
 
         >>> to_unicode(period(YEAR, '2014-2'))
-        u'year:2014-02'
+        'year:2014-02'
         >>> to_unicode(period(MONTH, '2014-2'))
-        u'2014-02'
+        '2014-02'
 
         >>> to_unicode(period(YEAR, 2012, size = 2))
-        u'year:2012:2'
+        'year:2012:2'
         >>> to_unicode(period(MONTH, 2012, size = 2))
-        u'month:2012-01:2'
+        'month:2012-01:2'
         >>> to_unicode(period(MONTH, 2012, size = 12))
-        u'2012'
+        '2012'
 
         >>> to_unicode(period(YEAR, '2012-3', size = 2))
-        u'year:2012-03:2'
+        'year:2012-03:2'
         >>> to_unicode(period(MONTH, '2012-3', size = 2))
-        u'month:2012-03:2'
+        'month:2012-03:2'
         >>> to_unicode(period(MONTH, '2012-3', size = 12))
-        u'year:2012-03'
+        'year:2012-03'
         """
 
         unit, start_instant, size = self
@@ -331,20 +333,20 @@ class Period(tuple):
                 return to_unicode(year)
             else:
                 # rolling year
-                return u'{}:{}-{:02d}'.format(YEAR, year, month)
+                return '{}:{}-{:02d}'.format(YEAR, year, month)
         # simple month
         if unit == MONTH and size == 1:
-            return u'{}-{:02d}'.format(year, month)
+            return '{}-{:02d}'.format(year, month)
         # several civil years
         if unit == YEAR and month == 1:
-            return u'{}:{}:{}'.format(unit, year, size)
+            return '{}:{}:{}'.format(unit, year, size)
 
         # complex period
-        return u'{}:{}-{:02d}:{}'.format(unit, year, month, size)
+        return '{}:{}-{:02d}:{}'.format(unit, year, month, size)
 
     @property
     def date(self):
-        assert self.size == 1, u'"date" is undefined for a period of size > 1: {}'.format(self)
+        assert self.size == 1, '"date" is undefined for a period of size > 1: {}'.format(self)
         return self.start.date
 
     @property
@@ -392,20 +394,20 @@ class Period(tuple):
         if intersection_start.day == 1 and intersection_start.month == 1 \
                 and intersection_stop.day == 31 and intersection_stop.month == 12:
             return self.__class__((
-                u'year',
+                'year',
                 intersection_start,
                 intersection_stop.year - intersection_start.year + 1,
                 ))
         if intersection_start.day == 1 and intersection_stop.day == calendar.monthrange(intersection_stop.year,
                 intersection_stop.month)[1]:
             return self.__class__((
-                u'month',
+                'month',
                 intersection_start,
                 ((intersection_stop.year - intersection_start.year) * 12 + intersection_stop.month -
                     intersection_start.month + 1),
                 ))
         return self.__class__((
-            u'day',
+            'day',
             intersection_start,
             (intersection_stop.date - intersection_start.date).days + 1,
             ))
@@ -423,7 +425,7 @@ class Period(tuple):
             >>> [period('2014'), period('2015')]
         """
         if self.unit == MONTH and unit == YEAR:
-            raise ValueError(u'Cannot subdivise months into years')
+            raise ValueError('Cannot subdivise months into years')
         if self.unit == YEAR and unit == YEAR:
             return [self.this_year.offset(i, YEAR) for i in range(self.size)]
 
@@ -433,135 +435,135 @@ class Period(tuple):
         """Increment (or decrement) the given period with offset units.
 
         >>> period('day', 2014).offset(1)
-        Period((u'day', Instant((2014, 1, 2)), 365))
+        Period(('day', Instant((2014, 1, 2)), 365))
         >>> period('day', 2014).offset(1, 'day')
-        Period((u'day', Instant((2014, 1, 2)), 365))
+        Period(('day', Instant((2014, 1, 2)), 365))
         >>> period('day', 2014).offset(1, 'month')
-        Period((u'day', Instant((2014, 2, 1)), 365))
+        Period(('day', Instant((2014, 2, 1)), 365))
         >>> period('day', 2014).offset(1, 'year')
-        Period((u'day', Instant((2015, 1, 1)), 365))
+        Period(('day', Instant((2015, 1, 1)), 365))
 
         >>> period('month', 2014).offset(1)
-        Period((u'month', Instant((2014, 2, 1)), 12))
+        Period(('month', Instant((2014, 2, 1)), 12))
         >>> period('month', 2014).offset(1, 'day')
-        Period((u'month', Instant((2014, 1, 2)), 12))
+        Period(('month', Instant((2014, 1, 2)), 12))
         >>> period('month', 2014).offset(1, 'month')
-        Period((u'month', Instant((2014, 2, 1)), 12))
+        Period(('month', Instant((2014, 2, 1)), 12))
         >>> period('month', 2014).offset(1, 'year')
-        Period((u'month', Instant((2015, 1, 1)), 12))
+        Period(('month', Instant((2015, 1, 1)), 12))
 
         >>> period('year', 2014).offset(1)
-        Period((u'year', Instant((2015, 1, 1)), 1))
+        Period(('year', Instant((2015, 1, 1)), 1))
         >>> period('year', 2014).offset(1, 'day')
-        Period((u'year', Instant((2014, 1, 2)), 1))
+        Period(('year', Instant((2014, 1, 2)), 1))
         >>> period('year', 2014).offset(1, 'month')
-        Period((u'year', Instant((2014, 2, 1)), 1))
+        Period(('year', Instant((2014, 2, 1)), 1))
         >>> period('year', 2014).offset(1, 'year')
-        Period((u'year', Instant((2015, 1, 1)), 1))
+        Period(('year', Instant((2015, 1, 1)), 1))
 
         >>> period('day', '2011-2-28').offset(1)
-        Period((u'day', Instant((2011, 3, 1)), 1))
+        Period(('day', Instant((2011, 3, 1)), 1))
         >>> period('month', '2011-2-28').offset(1)
-        Period((u'month', Instant((2011, 3, 28)), 1))
+        Period(('month', Instant((2011, 3, 28)), 1))
         >>> period('year', '2011-2-28').offset(1)
-        Period((u'year', Instant((2012, 2, 28)), 1))
+        Period(('year', Instant((2012, 2, 28)), 1))
 
         >>> period('day', '2011-3-1').offset(-1)
-        Period((u'day', Instant((2011, 2, 28)), 1))
+        Period(('day', Instant((2011, 2, 28)), 1))
         >>> period('month', '2011-3-1').offset(-1)
-        Period((u'month', Instant((2011, 2, 1)), 1))
+        Period(('month', Instant((2011, 2, 1)), 1))
         >>> period('year', '2011-3-1').offset(-1)
-        Period((u'year', Instant((2010, 3, 1)), 1))
+        Period(('year', Instant((2010, 3, 1)), 1))
 
         >>> period('day', '2014-1-30').offset(3)
-        Period((u'day', Instant((2014, 2, 2)), 1))
+        Period(('day', Instant((2014, 2, 2)), 1))
         >>> period('month', '2014-1-30').offset(3)
-        Period((u'month', Instant((2014, 4, 30)), 1))
+        Period(('month', Instant((2014, 4, 30)), 1))
         >>> period('year', '2014-1-30').offset(3)
-        Period((u'year', Instant((2017, 1, 30)), 1))
+        Period(('year', Instant((2017, 1, 30)), 1))
 
         >>> period('day', 2014).offset(-3)
-        Period((u'day', Instant((2013, 12, 29)), 365))
+        Period(('day', Instant((2013, 12, 29)), 365))
         >>> period('month', 2014).offset(-3)
-        Period((u'month', Instant((2013, 10, 1)), 12))
+        Period(('month', Instant((2013, 10, 1)), 12))
         >>> period('year', 2014).offset(-3)
-        Period((u'year', Instant((2011, 1, 1)), 1))
+        Period(('year', Instant((2011, 1, 1)), 1))
 
         >>> period('day', '2014-2-3').offset('first-of', 'month')
-        Period((u'day', Instant((2014, 2, 1)), 1))
+        Period(('day', Instant((2014, 2, 1)), 1))
         >>> period('day', '2014-2-3').offset('first-of', 'year')
-        Period((u'day', Instant((2014, 1, 1)), 1))
+        Period(('day', Instant((2014, 1, 1)), 1))
 
         >>> period('day', '2014-2-3', 4).offset('first-of', 'month')
-        Period((u'day', Instant((2014, 2, 1)), 4))
+        Period(('day', Instant((2014, 2, 1)), 4))
         >>> period('day', '2014-2-3', 4).offset('first-of', 'year')
-        Period((u'day', Instant((2014, 1, 1)), 4))
+        Period(('day', Instant((2014, 1, 1)), 4))
 
         >>> period('month', '2014-2-3').offset('first-of')
-        Period((u'month', Instant((2014, 2, 1)), 1))
+        Period(('month', Instant((2014, 2, 1)), 1))
         >>> period('month', '2014-2-3').offset('first-of', 'month')
-        Period((u'month', Instant((2014, 2, 1)), 1))
+        Period(('month', Instant((2014, 2, 1)), 1))
         >>> period('month', '2014-2-3').offset('first-of', 'year')
-        Period((u'month', Instant((2014, 1, 1)), 1))
+        Period(('month', Instant((2014, 1, 1)), 1))
 
         >>> period('month', '2014-2-3', 4).offset('first-of')
-        Period((u'month', Instant((2014, 2, 1)), 4))
+        Period(('month', Instant((2014, 2, 1)), 4))
         >>> period('month', '2014-2-3', 4).offset('first-of', 'month')
-        Period((u'month', Instant((2014, 2, 1)), 4))
+        Period(('month', Instant((2014, 2, 1)), 4))
         >>> period('month', '2014-2-3', 4).offset('first-of', 'year')
-        Period((u'month', Instant((2014, 1, 1)), 4))
+        Period(('month', Instant((2014, 1, 1)), 4))
 
         >>> period('year', 2014).offset('first-of')
-        Period((u'year', Instant((2014, 1, 1)), 1))
+        Period(('year', Instant((2014, 1, 1)), 1))
         >>> period('year', 2014).offset('first-of', 'month')
-        Period((u'year', Instant((2014, 1, 1)), 1))
+        Period(('year', Instant((2014, 1, 1)), 1))
         >>> period('year', 2014).offset('first-of', 'year')
-        Period((u'year', Instant((2014, 1, 1)), 1))
+        Period(('year', Instant((2014, 1, 1)), 1))
 
         >>> period('year', '2014-2-3').offset('first-of')
-        Period((u'year', Instant((2014, 1, 1)), 1))
+        Period(('year', Instant((2014, 1, 1)), 1))
         >>> period('year', '2014-2-3').offset('first-of', 'month')
-        Period((u'year', Instant((2014, 2, 1)), 1))
+        Period(('year', Instant((2014, 2, 1)), 1))
         >>> period('year', '2014-2-3').offset('first-of', 'year')
-        Period((u'year', Instant((2014, 1, 1)), 1))
+        Period(('year', Instant((2014, 1, 1)), 1))
 
         >>> period('day', '2014-2-3').offset('last-of', 'month')
-        Period((u'day', Instant((2014, 2, 28)), 1))
+        Period(('day', Instant((2014, 2, 28)), 1))
         >>> period('day', '2014-2-3').offset('last-of', 'year')
-        Period((u'day', Instant((2014, 12, 31)), 1))
+        Period(('day', Instant((2014, 12, 31)), 1))
 
         >>> period('day', '2014-2-3', 4).offset('last-of', 'month')
-        Period((u'day', Instant((2014, 2, 28)), 4))
+        Period(('day', Instant((2014, 2, 28)), 4))
         >>> period('day', '2014-2-3', 4).offset('last-of', 'year')
-        Period((u'day', Instant((2014, 12, 31)), 4))
+        Period(('day', Instant((2014, 12, 31)), 4))
 
         >>> period('month', '2014-2-3').offset('last-of')
-        Period((u'month', Instant((2014, 2, 28)), 1))
+        Period(('month', Instant((2014, 2, 28)), 1))
         >>> period('month', '2014-2-3').offset('last-of', 'month')
-        Period((u'month', Instant((2014, 2, 28)), 1))
+        Period(('month', Instant((2014, 2, 28)), 1))
         >>> period('month', '2014-2-3').offset('last-of', 'year')
-        Period((u'month', Instant((2014, 12, 31)), 1))
+        Period(('month', Instant((2014, 12, 31)), 1))
 
         >>> period('month', '2014-2-3', 4).offset('last-of')
-        Period((u'month', Instant((2014, 2, 28)), 4))
+        Period(('month', Instant((2014, 2, 28)), 4))
         >>> period('month', '2014-2-3', 4).offset('last-of', 'month')
-        Period((u'month', Instant((2014, 2, 28)), 4))
+        Period(('month', Instant((2014, 2, 28)), 4))
         >>> period('month', '2014-2-3', 4).offset('last-of', 'year')
-        Period((u'month', Instant((2014, 12, 31)), 4))
+        Period(('month', Instant((2014, 12, 31)), 4))
 
         >>> period('year', 2014).offset('last-of')
-        Period((u'year', Instant((2014, 12, 31)), 1))
+        Period(('year', Instant((2014, 12, 31)), 1))
         >>> period('year', 2014).offset('last-of', 'month')
-        Period((u'year', Instant((2014, 1, 31)), 1))
+        Period(('year', Instant((2014, 1, 31)), 1))
         >>> period('year', 2014).offset('last-of', 'year')
-        Period((u'year', Instant((2014, 12, 31)), 1))
+        Period(('year', Instant((2014, 12, 31)), 1))
 
         >>> period('year', '2014-2-3').offset('last-of')
-        Period((u'year', Instant((2014, 12, 31)), 1))
+        Period(('year', Instant((2014, 12, 31)), 1))
         >>> period('year', '2014-2-3').offset('last-of', 'month')
-        Period((u'year', Instant((2014, 2, 28)), 1))
+        Period(('year', Instant((2014, 2, 28)), 1))
         >>> period('year', '2014-2-3').offset('last-of', 'year')
-        Period((u'year', Instant((2014, 12, 31)), 1))
+        Period(('year', Instant((2014, 12, 31)), 1))
         """
         return self.__class__((self[0], self[1].offset(offset, self[0] if unit is None else unit), self[2]))
 
@@ -634,7 +636,7 @@ class Period(tuple):
         year, month, day = start_instant
         if unit == ETERNITY:
             return Instant((float("inf"), float("inf"), float("inf")))
-        if unit == u'day':
+        if unit == 'day':
             if size > 1:
                 day += size - 1
                 month_last_day = calendar.monthrange(year, month)[1]
@@ -646,13 +648,13 @@ class Period(tuple):
                     day -= month_last_day
                     month_last_day = calendar.monthrange(year, month)[1]
         else:
-            if unit == u'month':
+            if unit == 'month':
                 month += size
                 while month > 12:
                     year += 1
                     month -= 12
             else:
-                assert unit == u'year', u'Invalid unit: {} of type {}'.format(unit, type(unit))
+                assert unit == 'year', 'Invalid unit: {} of type {}'.format(unit, type(unit))
                 year += size
             day -= 1
             if day < 1:
@@ -672,7 +674,7 @@ class Period(tuple):
         return Instant((year, month, day))
 
     def to_json_dict(self):
-        if not isinstance(self[1], unicode_type):
+        if not isinstance(self[1], str):
             self[1] = to_unicode(self[1])
         return collections.OrderedDict((
             ('unit', self[0]),
@@ -716,15 +718,15 @@ def instant(instant):
 
     >>> instant(2014)
     Instant((2014, 1, 1))
-    >>> instant(u'2014')
+    >>> instant('2014')
     Instant((2014, 1, 1))
-    >>> instant(u'2014-02')
+    >>> instant('2014-02')
     Instant((2014, 2, 1))
-    >>> instant(u'2014-3-2')
+    >>> instant('2014-3-2')
     Instant((2014, 3, 2))
-    >>> instant(instant(u'2014-3-2'))
+    >>> instant(instant('2014-3-2'))
     Instant((2014, 3, 2))
-    >>> instant(period('month', u'2014-3-2'))
+    >>> instant(period('month', '2014-3-2'))
     Instant((2014, 3, 2))
 
     >>> instant(None)
@@ -738,7 +740,7 @@ def instant(instant):
             raise ValueError("'{}' is not a valid instant. Instants are described using the 'YYYY-MM-DD' format, for instance '2015-06-15'.".format(instant).encode('utf-8'))
         instant = Instant(
             int(fragment)
-            for fragment in instant.split(u'-', 2)[:3]
+            for fragment in instant.split('-', 2)[:3]
             )
     elif isinstance(instant, datetime.date):
         instant = Instant((instant.year, instant.month, instant.day))
@@ -771,19 +773,19 @@ def instant_date(instant):
 def period(value):
     """Return a new period, aka a triple (unit, start_instant, size).
 
-    >>> period(u'2014')
+    >>> period('2014')
     Period((YEAR, Instant((2014, 1, 1)), 1))
-    >>> period(u'year:2014')
+    >>> period('year:2014')
     Period((YEAR, Instant((2014, 1, 1)), 1))
 
-    >>> period(u'2014-2')
+    >>> period('2014-2')
     Period((MONTH, Instant((2014, 2, 1)), 1))
-    >>> period(u'2014-02')
+    >>> period('2014-02')
     Period((MONTH, Instant((2014, 2, 1)), 1))
-    >>> period(u'month:2014-2')
+    >>> period('month:2014-2')
     Period((MONTH, Instant((2014, 2, 1)), 1))
 
-    >>> period(u'year:2014-2')
+    >>> period('year:2014-2')
     Period((YEAR, Instant((2014, 2, 1)), 1))
     """
     if isinstance(value, Period):
@@ -807,14 +809,14 @@ def period(value):
 
     def raise_error(value):
         message = linesep.join([
-            u"Expected a period (eg. '2017', '2017-01', ...); got: '{}'.".format(value),
-            u"Learn more about legal period formats in OpenFisca:",
-            u"<http://openfisca.org/doc/periodsinstants.html#api>."
+            "Expected a period (eg. '2017', '2017-01', ...); got: '{}'.".format(value),
+            "Learn more about legal period formats in OpenFisca:",
+            "<http://openfisca.org/doc/periodsinstants.html#api>."
             ]).encode('utf-8')
         raise ValueError(message)
 
     if value == 'ETERNITY' or value == ETERNITY:
-        return Period((u'eternity', instant(datetime.date.min), float("inf")))
+        return Period(('eternity', instant(datetime.date.min), float("inf")))
 
     # check the type
     if isinstance(value, int):
@@ -898,25 +900,25 @@ def input_to_period_tuple(value, state = None):
 
     .. note:: This function doesn't return a period, but a tuple that allows to construct a period.
 
-    >>> input_to_period_tuple(u'2014')
-    ((u'year', 2014), None)
-    >>> input_to_period_tuple(u'2014:2')
-    ((u'year', 2014, 2), None)
-    >>> input_to_period_tuple(u'2014-2')
-    ((u'month', (2014, 2)), None)
-    >>> input_to_period_tuple(u'2014-3:12')
-    ((u'month', (2014, 3), 12), None)
-    >>> input_to_period_tuple(u'2014-2-3')
-    ((u'day', (2014, 2, 3)), None)
-    >>> input_to_period_tuple(u'2014-3-4:2')
-    ((u'day', (2014, 3, 4), 2), None)
+    >>> input_to_period_tuple('2014')
+    (('year', 2014), None)
+    >>> input_to_period_tuple('2014:2')
+    (('year', 2014, 2), None)
+    >>> input_to_period_tuple('2014-2')
+    (('month', (2014, 2)), None)
+    >>> input_to_period_tuple('2014-3:12')
+    (('month', (2014, 3), 12), None)
+    >>> input_to_period_tuple('2014-2-3')
+    (('day', (2014, 2, 3)), None)
+    >>> input_to_period_tuple('2014-3-4:2')
+    (('day', (2014, 3, 4), 2), None)
 
-    >>> input_to_period_tuple(u'year:2014')
-    ((u'year', u'2014'), None)
-    >>> input_to_period_tuple(u'year:2014:2')
-    ((u'year', u'2014', u'2'), None)
-    >>> input_to_period_tuple(u'year:2014-2:2')
-    ((u'year', u'2014-2', u'2'), None)
+    >>> input_to_period_tuple('year:2014')
+    (('year', '2014'), None)
+    >>> input_to_period_tuple('year:2014:2')
+    (('year', '2014', '2'), None)
+    >>> input_to_period_tuple('year:2014-2:2')
+    (('year', '2014-2', '2'), None)
     """
     if value is None:
         return value, None
@@ -926,7 +928,7 @@ def input_to_period_tuple(value, state = None):
         clean_fragment
         for clean_fragment in (
             fragment.strip()
-            for fragment in value.split(u':')
+            for fragment in value.split(':')
             )
         if clean_fragment
         )
@@ -937,7 +939,7 @@ def input_to_period_tuple(value, state = None):
             clean_fragment
             for clean_fragment in (
                 fragment.strip()
-                for fragment in split_value[0].split(u'-')
+                for fragment in split_value[0].split('-')
                 )
             if clean_fragment
             )
@@ -945,7 +947,7 @@ def input_to_period_tuple(value, state = None):
             return conv.pipe(
                 conv.input_to_strict_int,
                 conv.test_greater_or_equal(0),
-                conv.function(lambda year: (u'year', year)),
+                conv.function(lambda year: ('year', year)),
                 )(split_value[0], state = state)
         if len(split_value) == 2:
             return conv.pipe(
@@ -961,7 +963,7 @@ def input_to_period_tuple(value, state = None):
                             ),
                         ),
                     ),
-                conv.function(lambda month_tuple: (u'month', month_tuple)),
+                conv.function(lambda month_tuple: ('month', month_tuple)),
                 )(split_value, state = state)
         if len(split_value) == 3:
             return conv.pipe(
@@ -981,15 +983,15 @@ def input_to_period_tuple(value, state = None):
                             ),
                         ),
                     ),
-                conv.function(lambda day_tuple: (u'day', day_tuple)),
+                conv.function(lambda day_tuple: ('day', day_tuple)),
                 )(split_value, state = state)
-        return split_value, state._(u'Instant string contains too much "-" for a year, a month or a day')
+        return split_value, state._('Instant string contains too much "-" for a year, a month or a day')
     if len(split_value) == 2:
         split_start = tuple(
             clean_fragment
             for clean_fragment in (
                 fragment.strip()
-                for fragment in split_value[0].split(u'-')
+                for fragment in split_value[0].split('-')
                 )
             if clean_fragment
             )
@@ -1001,7 +1003,7 @@ def input_to_period_tuple(value, state = None):
                     conv.test_greater_or_equal(0),
                     )(split_start[0], state = state)
                 if error is None:
-                    return (u'year', start, size), None
+                    return ('year', start, size), None
             elif len(split_start) == 2:
                 start, error = conv.struct(
                     (
@@ -1016,7 +1018,7 @@ def input_to_period_tuple(value, state = None):
                         ),
                     )(split_start, state = state)
                 if error is None:
-                    return (u'month', start, size), None
+                    return ('month', start, size), None
             elif len(split_start) == 3:
                 start, error = conv.struct(
                     (
@@ -1035,7 +1037,7 @@ def input_to_period_tuple(value, state = None):
                         ),
                     )(split_start, state = state)
                 if error is None:
-                    return (u'day', start, size), None
+                    return ('day', start, size), None
     return split_value, None
 
 
@@ -1074,10 +1076,10 @@ def json_or_python_to_instant_tuple(value, state = None):
 
     if isinstance(value, basestring_type):
         if year_or_month_or_day_re.match(value) is None:
-            return value, state._(u'Invalid date string')
+            return value, state._('Invalid date string')
         instant = tuple(
             int(fragment)
-            for fragment in value.split(u'-', 2)
+            for fragment in value.split('-', 2)
             )
     elif isinstance(value, datetime.date):
         instant = (value.year, value.month, value.day)
@@ -1085,13 +1087,13 @@ def json_or_python_to_instant_tuple(value, state = None):
         instant = (value,)
     elif isinstance(value, list):
         if not (1 <= len(value) <= 3):
-            return value, state._(u'Invalid size for date list')
+            return value, state._('Invalid size for date list')
         instant = tuple(value)
     else:
         if not isinstance(value, tuple):
-            return value, state._(u'Invalid type')
+            return value, state._('Invalid type')
         if not (1 <= len(value) <= 3):
-            return value, state._(u'Invalid size for date tuple')
+            return value, state._('Invalid size for date tuple')
         instant = value
 
     return instant, None

--- a/openfisca_core/rates.py
+++ b/openfisca_core/rates.py
@@ -2,6 +2,7 @@
 
 
 from __future__ import division
+from __future__ import unicode_literals
 
 import numpy
 

--- a/openfisca_core/rates.py
+++ b/openfisca_core/rates.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
-
-from __future__ import division
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 
 import numpy
 

--- a/openfisca_core/reforms.py
+++ b/openfisca_core/reforms.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import copy
 
 from openfisca_core.parameters import ParameterNode
@@ -63,7 +64,7 @@ class Reform(TaxBenefitSystem):
         assert key is not None, 'key was not set for reform {} (name: {!r})'.format(self, self.name)
         if self.baseline is not None and hasattr(self.baseline, 'key'):
             baseline_full_key = self.baseline.full_key
-            key = u'.'.join([baseline_full_key, key])
+            key = '.'.join([baseline_full_key, key])
         return key
 
     def modify_parameters(self, modifier_function):

--- a/openfisca_core/reforms.py
+++ b/openfisca_core/reforms.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import copy
 
 from openfisca_core.parameters import ParameterNode

--- a/openfisca_core/scenarios.py
+++ b/openfisca_core/scenarios.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import division
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 
 import collections
 import itertools

--- a/openfisca_core/scenarios.py
+++ b/openfisca_core/scenarios.py
@@ -2,6 +2,7 @@
 
 
 from __future__ import division
+from __future__ import unicode_literals
 
 import collections
 import itertools
@@ -107,12 +108,12 @@ class AbstractScenario(object):
                 count = steps_count * step_size
                 entity.count = count
                 entity.step_size = step_size
-                entity.ids = [entity_instance[u'id'] for entity_instance in test_case[entity.plural]]
+                entity.ids = [entity_instance['id'] for entity_instance in test_case[entity.plural]]
 
             persons_step_size = persons.step_size
 
             person_index_by_id = dict(
-                (person[u'id'], person_index)
+                (person['id'], person_index)
                 for person_index, person in enumerate(test_case[persons.plural])
                 )
 
@@ -295,10 +296,10 @@ class AbstractScenario(object):
             # Third validation and conversion step
             errors = {}
             if data['input_variables'] is not None and data['test_case'] is not None:
-                errors['input_variables'] = state._(u"Items input_variables and test_case can't both exist")
-                errors['test_case'] = state._(u"Items input_variables and test_case can't both exist")
+                errors['input_variables'] = state._("Items input_variables and test_case can't both exist")
+                errors['test_case'] = state._("Items input_variables and test_case can't both exist")
             elif data['axes'] is not None and data["test_case"] is None:
-                errors['axes'] = state._(u"Axes can't be used with input_variables.")
+                errors['axes'] = state._("Axes can't be used with input_variables.")
             if errors:
                 return data, errors
 
@@ -311,29 +312,29 @@ class AbstractScenario(object):
                     for axis_index, axis in enumerate(parallel_axes):
                         if axis['min'] >= axis['max']:
                             errors.setdefault('axes', {}).setdefault(parallel_axes_index, {}).setdefault(
-                                axis_index, {})['max'] = state._(u"Max value must be greater than min value")
+                                axis_index, {})['max'] = state._("Max value must be greater than min value")
                         column = tbs.get_variable(axis['name'])
                         if axis['index'] >= len(data['test_case'][column.entity.plural]):
                             errors.setdefault('axes', {}).setdefault(parallel_axes_index, {}).setdefault(
-                                axis_index, {})['index'] = state._(u"Index must be lower than {}").format(
+                                axis_index, {})['index'] = state._("Index must be lower than {}").format(
                                     len(data['test_case'][column.entity.plural]))
                         if axis_index > 0:
                             if axis['count'] != axis_count:
                                 errors.setdefault('axes', {}).setdefault(parallel_axes_index, {}).setdefault(
-                                    axis_index, {})['count'] = state._(u"Parallel indexes must have the same count")
+                                    axis_index, {})['count'] = state._("Parallel indexes must have the same count")
                             if column.entity.key != axis_entity_key:
                                 errors.setdefault('axes', {}).setdefault(parallel_axes_index, {}).setdefault(
                                     axis_index, {})['period'] = state._(
-                                        u"Parallel indexes must belong to the same entity")
+                                        "Parallel indexes must belong to the same entity")
                             axis_period = axis['period'] or data['period']
                             if axis_period.unit != first_axis_period.unit:
                                 errors.setdefault('axes', {}).setdefault(parallel_axes_index, {}).setdefault(
                                     axis_index, {})['period'] = state._(
-                                        u"Parallel indexes must have the same period unit")
+                                        "Parallel indexes must have the same period unit")
                             elif axis_period.size != first_axis_period.size:
                                 errors.setdefault('axes', {}).setdefault(parallel_axes_index, {}).setdefault(
                                     axis_index, {})['period'] = state._(
-                                        u"Parallel indexes must have the same period size")
+                                        "Parallel indexes must have the same period size")
                 if errors:
                     return data, errors
 
@@ -515,7 +516,7 @@ def make_json_or_python_to_axes(tax_benefit_system):
                                     conv.test_in(column_by_name),
                                     conv.test(lambda column_name: tax_benefit_system.get_variable(column_name).dtype in (
                                         np.float32, np.int16, np.int32),
-                                        error = N_(u'Invalid type for axe: integer or float expected')),
+                                        error = N_('Invalid type for axe: integer or float expected')),
                                     conv.not_none,
                                     ),
                                 period = conv.function(periods.period),
@@ -582,7 +583,7 @@ def make_json_or_python_to_input_variables(tax_benefit_system, period):
                     count_by_entity_key[entity_key] = entity_count = len(variable_array)
                 elif len(variable_array) != entity_count:
                     errors[column.name] = state._(
-                        u"Array has not the same length as other variables of entity {}: {} instead of {}").format(
+                        "Array has not the same length as other variables of entity {}: {} instead of {}").format(
                             column.name, len(variable_array), entity_count)
 
         return input_variables, errors or None
@@ -672,15 +673,15 @@ def make_json_or_python_to_test(tax_benefit_system):
             return value, error
 
         test_case = value.copy()
-        absolute_error_margin = test_case.pop(u'absolute_error_margin')
-        axes = test_case.pop(u'axes')
-        description = test_case.pop(u'description')
-        input_variables = test_case.pop(u'input_variables')
-        keywords = test_case.pop(u'keywords')
-        name = test_case.pop(u'name')
-        output_variables = test_case.pop(u'output_variables')
-        period = test_case.pop(u'period')
-        relative_error_margin = test_case.pop(u'relative_error_margin')
+        absolute_error_margin = test_case.pop('absolute_error_margin')
+        axes = test_case.pop('axes')
+        description = test_case.pop('description')
+        input_variables = test_case.pop('input_variables')
+        keywords = test_case.pop('keywords')
+        name = test_case.pop('name')
+        output_variables = test_case.pop('output_variables')
+        period = test_case.pop('period')
+        relative_error_margin = test_case.pop('relative_error_margin')
 
         if test_case is not None and all(entity_members is None for entity_members in test_case.values()):
             test_case = None

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import traceback
 import importlib
 import logging
@@ -11,9 +12,9 @@ logging.basicConfig(format='%(levelname)s: %(message)s')
 
 
 def add_tax_benefit_system_arguments(parser):
-    parser.add_argument('-c', '--country-package', action = 'store', help = u'country package to use. If not provided, an automatic detection will be attempted by scanning the python packages installed in your environment which name contains the word "openfisca".')
-    parser.add_argument('-e', '--extensions', action = 'store', help = u'extensions to load', nargs = '*')
-    parser.add_argument('-r', '--reforms', action = 'store', help = u'reforms to apply to the country package', nargs = '*')
+    parser.add_argument('-c', '--country-package', action = 'store', help = 'country package to use. If not provided, an automatic detection will be attempted by scanning the python packages installed in your environment which name contains the word "openfisca".')
+    parser.add_argument('-e', '--extensions', action = 'store', help = 'extensions to load', nargs = '*')
+    parser.add_argument('-r', '--reforms', action = 'store', help = 'reforms to apply to the country package', nargs = '*')
 
     return parser
 
@@ -25,13 +26,13 @@ def build_tax_benefit_system(country_package_name, extensions, reforms):
         country_package = importlib.import_module(country_package_name)
     except ImportError:
         message = linesep.join([traceback.format_exc(),
-                                u'Could not import module `{}`.'.format(country_package_name),
-                                u'Are you sure it is installed in your environment? If so, look at the stack trace above to determine the origin of this error.',
-                                u'See more at <https://github.com/openfisca/country-template#installing>.'])
+                                'Could not import module `{}`.'.format(country_package_name),
+                                'Are you sure it is installed in your environment? If so, look at the stack trace above to determine the origin of this error.',
+                                'See more at <https://github.com/openfisca/country-template#installing>.'])
 
         raise ImportError(message)
     if not hasattr(country_package, 'CountryTaxBenefitSystem'):
-        raise ImportError(u'`{}` does not seem to be a valid Openfisca country package.'.format(country_package_name))
+        raise ImportError('`{}` does not seem to be a valid Openfisca country package.'.format(country_package_name))
 
     country_package = importlib.import_module(country_package_name)
     tax_benefit_system = country_package.CountryTaxBenefitSystem()
@@ -60,14 +61,14 @@ def detect_country_package():
                 module = importlib.import_module(module_name)
             except ImportError:
                 message = linesep.join([traceback.format_exc(),
-                                        u'Could not import module `{}`.'.format(module_name),
-                                        u'Look at the stack trace above to determine the error that stopped installed modules detection.'])
+                                        'Could not import module `{}`.'.format(module_name),
+                                        'Look at the stack trace above to determine the error that stopped installed modules detection.'])
                 raise ImportError(message)
             if hasattr(module, 'CountryTaxBenefitSystem'):
                 installed_country_packages.append(module_name)
 
     if len(installed_country_packages) == 0:
-        raise ImportError(u'No country package has been detected on your environment. If your country package is installed but not detected, please use the --country-package option.')
+        raise ImportError('No country package has been detected on your environment. If your country package is installed but not detected, please use the --country-package option.')
     if len(installed_country_packages) > 1:
-        log.warning(u'Several country packages detected : `{}`. Using `{}` by default. To use another package, please use the --country-package option.'.format(', '.join(installed_country_packages), installed_country_packages[0]))
+        log.warning('Several country packages detected : `{}`. Using `{}` by default. To use another package, please use the --country-package option.'.format(', '.join(installed_country_packages), installed_country_packages[0]))
     return installed_country_packages[0]

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import traceback
 import importlib
 import logging

--- a/openfisca_core/scripts/find_placeholders.py
+++ b/openfisca_core/scripts/find_placeholders.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+from __future__ import unicode_literals
 import os
 import fnmatch
 import sys

--- a/openfisca_core/scripts/find_placeholders.py
+++ b/openfisca_core/scripts/find_placeholders.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import os
 import fnmatch
 import sys

--- a/openfisca_core/scripts/json_with_test_case_to_input_variables.py
+++ b/openfisca_core/scripts/json_with_test_case_to_input_variables.py
@@ -3,10 +3,7 @@
 
 
 """Convert a scenario or simulation JSON containing a test case to the same JSON with input variables."""
-from __future__ import print_function
-from __future__ import unicode_literals
-
-
+from __future__ import unicode_literals, print_function, division, absolute_import
 import argparse
 import copy
 import importlib

--- a/openfisca_core/scripts/json_with_test_case_to_input_variables.py
+++ b/openfisca_core/scripts/json_with_test_case_to_input_variables.py
@@ -3,6 +3,8 @@
 
 
 """Convert a scenario or simulation JSON containing a test case to the same JSON with input variables."""
+from __future__ import print_function
+from __future__ import unicode_literals
 
 
 import argparse

--- a/openfisca_core/scripts/measure_numpy_condition_notations.py
+++ b/openfisca_core/scripts/measure_numpy_condition_notations.py
@@ -10,10 +10,7 @@ Measure and compare different vectorial condition notations:
 
 The aim of this script is to compare the time taken by the calculation of the values
 """
-from __future__ import print_function
-from __future__ import unicode_literals
-
-
+from __future__ import unicode_literals, print_function, division, absolute_import
 from contextlib import contextmanager
 import argparse
 import sys

--- a/openfisca_core/scripts/measure_numpy_condition_notations.py
+++ b/openfisca_core/scripts/measure_numpy_condition_notations.py
@@ -10,6 +10,8 @@ Measure and compare different vectorial condition notations:
 
 The aim of this script is to compare the time taken by the calculation of the values
 """
+from __future__ import print_function
+from __future__ import unicode_literals
 
 
 from contextlib import contextmanager
@@ -30,7 +32,7 @@ def measure_time(title):
     t1 = time.time()
     yield
     t2 = time.time()
-    print(u'{}\t: {:.8f} seconds elapsed'.format(title, t2 - t1).encode('utf-8'))
+    print('{}\t: {:.8f} seconds elapsed'.format(title, t2 - t1).encode('utf-8'))
 
 
 def switch_fromiter(conditions, function_by_condition, dtype):

--- a/openfisca_core/scripts/measure_performances.py
+++ b/openfisca_core/scripts/measure_performances.py
@@ -3,6 +3,8 @@
 
 
 """Measure performances of a basic tax-benefit system to compare to other OpenFisca implementations."""
+from __future__ import print_function
+from __future__ import unicode_literals
 
 
 import argparse
@@ -44,18 +46,18 @@ PARENT2 = 1
 Famille = build_entity(
     key = "famille",
     plural = "familles",
-    label = u'Famille',
+    label = 'Famille',
     roles = [
         {
             'key': 'parent',
             'plural': 'parents',
-            'label': u'Parents',
+            'label': 'Parents',
             'subroles': ['demandeur', 'conjoint']
             },
         {
             'key': 'enfant',
             'plural': 'enfants',
-            'label': u'Enfants',
+            'label': 'Enfants',
             }
         ]
     )
@@ -64,7 +66,7 @@ Famille = build_entity(
 Individu = build_entity(
     key = "individu",
     plural = "individus",
-    label = u'Individu',
+    label = 'Individu',
     is_person = True,
     )
 
@@ -74,13 +76,13 @@ Individu = build_entity(
 class age_en_mois(Variable):
     value_type = int
     entity = Individu
-    label = u"Âge (en nombre de mois)"
+    label = "Âge (en nombre de mois)"
 
 
 class birth(Variable):
     value_type = 'Date'
     entity = Individu
-    label = u"Date de naissance"
+    label = "Date de naissance"
 
 
 class city_code(Variable):
@@ -88,7 +90,7 @@ class city_code(Variable):
     max_length = 5
     entity = Famille
     definition_period = ETERNITY
-    label = u"""Code INSEE "city_code" de la commune de résidence de la famille"""
+    label = """Code INSEE "city_code" de la commune de résidence de la famille"""
 
 
 class salaire_brut(Variable):
@@ -102,7 +104,7 @@ class salaire_brut(Variable):
 class age(Variable):
     value_type = int
     entity = Individu
-    label = u"Âge (en nombre d'années)"
+    label = "Âge (en nombre d'années)"
 
     def formula(self, simulation, period):
         birth = simulation.get_array('birth', period)
@@ -117,7 +119,7 @@ class age(Variable):
 class dom_tom(Variable):
     value_type = 'Bool'
     entity = Famille
-    label = u"La famille habite-t-elle les DOM-TOM ?"
+    label = "La famille habite-t-elle les DOM-TOM ?"
 
     def formula(self, simulation, period):
         period = period.start.period('year').offset('first-of')
@@ -128,10 +130,10 @@ class dom_tom(Variable):
 class revenu_disponible(Variable):
     value_type = float
     entity = Individu
-    label = u"Revenu disponible de l'individu"
+    label = "Revenu disponible de l'individu"
 
     def formula(self, simulation, period):
-        period = period.start.period(u'year').offset('first-of')
+        period = period.start.period('year').offset('first-of')
         rsa = simulation.calculate('rsa', period)
         salaire_imposable = simulation.calculate('salaire_imposable', period)
         return rsa + salaire_imposable * 0.7
@@ -140,20 +142,20 @@ class revenu_disponible(Variable):
 class rsa(Variable):
     value_type = float
     entity = Individu
-    label = u"RSA"
+    label = "RSA"
 
     def formula_2010_01_01(self, simulation, period):
-        period = period.start.period(u'month').offset('first-of')
+        period = period.start.period('month').offset('first-of')
         salaire_imposable = simulation.calculate('salaire_imposable', period)
         return (salaire_imposable < 500) * 100.0
 
     def formula_2011_01_01(self, simulation, period):
-        period = period.start.period(u'month').offset('first-of')
+        period = period.start.period('month').offset('first-of')
         salaire_imposable = simulation.calculate('salaire_imposable', period)
         return (salaire_imposable < 500) * 200.0
 
     def formula_2013_01_01(self, simulation, period):
-        period = period.start.period(u'month').offset('first-of')
+        period = period.start.period('month').offset('first-of')
         salaire_imposable = simulation.calculate('salaire_imposable', period)
         return (salaire_imposable < 500) * 300
 
@@ -161,10 +163,10 @@ class rsa(Variable):
 class salaire_imposable(Variable):
     value_type = float
     entity = Individu
-    label = u"Salaire imposable"
+    label = "Salaire imposable"
 
     def formula(individu, period):
-        period = period.start.period(u'year').offset('first-of')
+        period = period.start.period('year').offset('first-of')
         dom_tom = individu.famille('dom_tom', period)
         salaire_net = individu('salaire_net', period)
         return salaire_net * 0.9 - 100 * dom_tom
@@ -173,10 +175,10 @@ class salaire_imposable(Variable):
 class salaire_net(Variable):
     value_type = float
     entity = Individu
-    label = u"Salaire net"
+    label = "Salaire net"
 
     def formula(self, simulation, period):
-        period = period.start.period(u'year').offset('first-of')
+        period = period.start.period('year').offset('first-of')
         salaire_brut = simulation.calculate('salaire_brut', period)
         return salaire_brut * 0.8
 

--- a/openfisca_core/scripts/measure_performances.py
+++ b/openfisca_core/scripts/measure_performances.py
@@ -3,10 +3,7 @@
 
 
 """Measure performances of a basic tax-benefit system to compare to other OpenFisca implementations."""
-from __future__ import print_function
-from __future__ import unicode_literals
-
-
+from __future__ import unicode_literals, print_function, division, absolute_import
 import argparse
 import logging
 import sys

--- a/openfisca_core/scripts/measure_performances_fancy_indexing.py
+++ b/openfisca_core/scripts/measure_performances_fancy_indexing.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import unicode_literals
 import numpy as np
 import timeit
 from openfisca_france import CountryTaxBenefitSystem

--- a/openfisca_core/scripts/measure_performances_fancy_indexing.py
+++ b/openfisca_core/scripts/measure_performances_fancy_indexing.py
@@ -1,5 +1,5 @@
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
+
 import numpy as np
 import timeit
 from openfisca_france import CountryTaxBenefitSystem

--- a/openfisca_core/scripts/migrations/v16_2_to_v17/xml_to_yaml.py
+++ b/openfisca_core/scripts/migrations/v16_2_to_v17/xml_to_yaml.py
@@ -5,8 +5,8 @@
 
 Comments are NOT converted.
 '''
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
+
 
 import os
 import re

--- a/openfisca_core/scripts/migrations/v16_2_to_v17/xml_to_yaml.py
+++ b/openfisca_core/scripts/migrations/v16_2_to_v17/xml_to_yaml.py
@@ -5,6 +5,8 @@
 
 Comments are NOT converted.
 '''
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import re
@@ -19,14 +21,14 @@ node_keywords = ['reference', 'description']
 
 def custom_str_representer(dumper, data):
     if re.match(r'^\d{4}-\d{2}-\d{2}$', data):
-        tag = u'tag:yaml.org,2002:timestamp'
+        tag = 'tag:yaml.org,2002:timestamp'
         return dumper.represent_scalar(tag, data)
     return dumper.represent_str(data)
 
 
 def custom_unicode_representer(dumper, data):
     if re.match(r'^\d{4}-\d{2}-\d{2}$', data):
-        tag = u'tag:yaml.org,2002:timestamp'
+        tag = 'tag:yaml.org,2002:timestamp'
         return dumper.represent_scalar(tag, data)
     return dumper.represent_unicode(data)
 
@@ -126,7 +128,7 @@ def transform_etree_to_json_recursive(xml_node):
         elif key in {'description', 'reference'}:
             json_node[key] = to_unicode(value)
         else:
-            raise ValueError(u'Unknown attribute "{}": "{}"'.format(key, value).encode('utf-8'))
+            raise ValueError('Unknown attribute "{}": "{}"'.format(key, value).encode('utf-8'))
 
     if xml_node.tag == 'NODE':
         json_node['type'] = 'node'
@@ -167,7 +169,7 @@ def transform_etree_to_json_recursive(xml_node):
             elif child.tag == 'MONTANT':
                 json_node['amount'] = new_child
             else:
-                raise ValueError(u'Unknown TRANCHE child {}'.format(child.tag).encode('utf-8'))
+                raise ValueError('Unknown TRANCHE child {}'.format(child.tag).encode('utf-8'))
 
     elif xml_node.tag == 'TAUX':
         json_node = transform_values_history(xml_node, value_format)
@@ -185,7 +187,7 @@ def transform_etree_to_json_recursive(xml_node):
         pass
 
     else:
-        raise ValueError(u'Unknown tag {}'.format(xml_node.tag).encode('utf-8'))
+        raise ValueError('Unknown tag {}'.format(xml_node.tag).encode('utf-8'))
 
     return name, json_node
 
@@ -216,7 +218,7 @@ def merge(name_list, json_list, path_list):
                     'type': 'node',
                     }
 
-        assert name not in pointer, u'{} is defined twice'.format('.'.join(path) + '.' + 'name').encode('utf-8')
+        assert name not in pointer, '{} is defined twice'.format('.'.join(path) + '.' + 'name').encode('utf-8')
         pointer[name] = json_tree
 
     return merged_json

--- a/openfisca_core/scripts/migrations/v16_2_to_v17/xml_to_yaml_country_template.py
+++ b/openfisca_core/scripts/migrations/v16_2_to_v17/xml_to_yaml_country_template.py
@@ -7,9 +7,7 @@ Usage :
 or just (output is written in a directory called `yaml_parameters`):
   `python xml_to_yaml_country_template.py`
 '''
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
+from __future__ import unicode_literals, print_function, division, absolute_import
 import sys
 import os
 

--- a/openfisca_core/scripts/migrations/v16_2_to_v17/xml_to_yaml_country_template.py
+++ b/openfisca_core/scripts/migrations/v16_2_to_v17/xml_to_yaml_country_template.py
@@ -7,12 +7,14 @@ Usage :
 or just (output is written in a directory called `yaml_parameters`):
   `python xml_to_yaml_country_template.py`
 '''
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import sys
 import os
 
 from openfisca_country_template import CountryTaxBenefitSystem, COUNTRY_DIR
-import xml_to_yaml
+from . import xml_to_yaml
 
 tax_benefit_system = CountryTaxBenefitSystem()
 

--- a/openfisca_core/scripts/migrations/v16_2_to_v17/xml_to_yaml_extension_template.py
+++ b/openfisca_core/scripts/migrations/v16_2_to_v17/xml_to_yaml_extension_template.py
@@ -7,11 +7,13 @@ Usage :
 or just (output is written in a directory called `yaml_parameters`):
   `python xml_to_yaml_extension_template.py`
 '''
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import sys
 import os
 
-import xml_to_yaml
+from . import xml_to_yaml
 import openfisca_extension_template
 
 if len(sys.argv) > 1:

--- a/openfisca_core/scripts/migrations/v16_2_to_v17/xml_to_yaml_extension_template.py
+++ b/openfisca_core/scripts/migrations/v16_2_to_v17/xml_to_yaml_extension_template.py
@@ -7,8 +7,7 @@ Usage :
 or just (output is written in a directory called `yaml_parameters`):
   `python xml_to_yaml_extension_template.py`
 '''
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 
 import sys
 import os

--- a/openfisca_core/scripts/openfisca_command.py
+++ b/openfisca_core/scripts/openfisca_command.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import argparse
 import sys
 

--- a/openfisca_core/scripts/openfisca_command.py
+++ b/openfisca_core/scripts/openfisca_command.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import argparse
 import sys
 

--- a/openfisca_core/scripts/remove_fuzzy.py
+++ b/openfisca_core/scripts/remove_fuzzy.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 # remove_fuzzy.py : Remove the fuzzy attribute in xml files and add END tags.
 # See https://github.com/openfisca/openfisca-core/issues/437
 

--- a/openfisca_core/scripts/remove_fuzzy.py
+++ b/openfisca_core/scripts/remove_fuzzy.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # remove_fuzzy.py : Remove the fuzzy attribute in xml files and add END tags.
 # See https://github.com/openfisca/openfisca-core/issues/437
 

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import argparse
 import logging
 import sys

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import argparse
 import logging
 import sys

--- a/openfisca_core/scripts/simulation_generator.py
+++ b/openfisca_core/scripts/simulation_generator.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import numpy as np
 
 import random

--- a/openfisca_core/scripts/simulation_generator.py
+++ b/openfisca_core/scripts/simulation_generator.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import numpy as np
 
 import random

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from os import linesep
 import tempfile
 import logging

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
+from __future__ import unicode_literals
 from os import linesep
 import tempfile
 import logging
@@ -104,7 +105,7 @@ class Simulation(object):
 
             if not persons_json:
                 raise SituationParsingError([self.tax_benefit_system.person_entity.plural],
-                    u'No {0} found. At least one {0} must be defined to run a simulation.'.format(self.tax_benefit_system.person_entity.key))
+                    'No {0} found. At least one {0} must be defined to run a simulation.'.format(self.tax_benefit_system.person_entity.key))
             self.persons = self.tax_benefit_system.person_entity(self, persons_json)
         else:
             self.persons = self.tax_benefit_system.person_entity(self)
@@ -129,8 +130,8 @@ class Simulation(object):
         if self._data_storage_dir is None:
             self._data_storage_dir = tempfile.mkdtemp(prefix = "openfisca_")
             log.warn((
-                u"Intermediate results will be stored on disk in {} in case of memory overflow. "
-                u"You should remove this directory once you're done with your simulation."
+                "Intermediate results will be stored on disk in {} in case of memory overflow. "
+                "You should remove this directory once you're done with your simulation."
                 ).format(self._data_storage_dir).encode('utf-8'))
         return self._data_storage_dir
 
@@ -196,13 +197,13 @@ class Simulation(object):
 
         # Check that the requested period matches definition_period
         if variable.definition_period == periods.YEAR and period.unit == periods.MONTH:
-            raise ValueError(u"Unable to compute variable '{0}' for period {1}: '{0}' can only be computed for year-long periods. You can use the DIVIDE option to get an estimate of {0} by dividing the yearly value by 12, or change the requested period to 'period.this_year'.".format(
+            raise ValueError("Unable to compute variable '{0}' for period {1}: '{0}' can only be computed for year-long periods. You can use the DIVIDE option to get an estimate of {0} by dividing the yearly value by 12, or change the requested period to 'period.this_year'.".format(
                 variable.name,
                 period,
                 ).encode('utf-8'))
 
         if variable.definition_period not in [periods.MONTH, periods.YEAR]:
-            raise ValueError(u"Unable to sum constant variable '{}' over period {}: only variables defined monthly or yearly can be summed over time.".format(
+            raise ValueError("Unable to sum constant variable '{}' over period {}: only variables defined monthly or yearly can be summed over time.".format(
                 variable.name,
                 period).encode('utf-8'))
 
@@ -219,7 +220,7 @@ class Simulation(object):
 
         # Check that the requested period matches definition_period
         if variable.definition_period != periods.YEAR:
-            raise ValueError(u"Unable to divide the value of '{}' over time on period {}: only variables defined yearly can be divided over time.".format(
+            raise ValueError("Unable to divide the value of '{}' over time on period {}: only variables defined yearly can be divided over time.".format(
                 variable_name,
                 period).encode('utf-8'))
 
@@ -232,7 +233,7 @@ class Simulation(object):
         elif period.unit == periods.YEAR:
             return self.calculate(variable_name, period, **parameters)
 
-        raise ValueError(u"Unable to divide the value of '{}' to match period {}.".format(
+        raise ValueError("Unable to divide the value of '{}' to match period {}.".format(
             variable_name,
             period).encode('utf-8'))
 
@@ -284,19 +285,19 @@ class Simulation(object):
             return  # For variables which values are constant in time, all periods are accepted
 
         if variable.definition_period == periods.MONTH and period.unit != periods.MONTH:
-            raise ValueError(u"Unable to compute variable '{0}' for period {1}: '{0}' must be computed for a whole month. You can use the ADD option to sum '{0}' over the requested period, or change the requested period to 'period.first_month'.".format(
+            raise ValueError("Unable to compute variable '{0}' for period {1}: '{0}' must be computed for a whole month. You can use the ADD option to sum '{0}' over the requested period, or change the requested period to 'period.first_month'.".format(
                 variable.name,
                 period
                 ).encode('utf-8'))
 
         if variable.definition_period == periods.YEAR and period.unit != periods.YEAR:
-            raise ValueError(u"Unable to compute variable '{0}' for period {1}: '{0}' must be computed for a whole year. You can use the DIVIDE option to get an estimate of {0} by dividing the yearly value by 12, or change the requested period to 'period.this_year'.".format(
+            raise ValueError("Unable to compute variable '{0}' for period {1}: '{0}' must be computed for a whole year. You can use the DIVIDE option to get an estimate of {0} by dividing the yearly value by 12, or change the requested period to 'period.this_year'.".format(
                 variable.name,
                 period
                 ).encode('utf-8'))
 
         if period.size != 1:
-            raise ValueError(u"Unable to compute variable '{0}' for period {1}: '{0}' must be computed for a whole {2}. You can use the ADD option to sum '{0}' over the requested period.".format(
+            raise ValueError("Unable to compute variable '{0}' for period {1}: '{0}' must be computed for a whole {2}. You can use the ADD option to sum '{0}' over the requested period.".format(
                 variable.name,
                 period,
                 'month' if variable.definition_period == periods.MONTH else 'year'
@@ -305,15 +306,15 @@ class Simulation(object):
     def _check_formula_result(self, value, variable, entity, period):
 
         assert isinstance(value, np.ndarray), (linesep.join([
-            u"You tried to compute the formula '{0}' for the period '{1}'.".format(variable.name, str(period)).encode('utf-8'),
-            u"The formula '{0}@{1}' should return a Numpy array;".format(variable.name, str(period)).encode('utf-8'),
-            u"instead it returned '{0}' of {1}.".format(value, type(value)).encode('utf-8'),
-            u"Learn more about Numpy arrays and vectorial computing:",
-            u"<http://openfisca.org/doc/coding-the-legislation/25_vectorial_computing.html.>"
+            "You tried to compute the formula '{0}' for the period '{1}'.".format(variable.name, str(period)).encode('utf-8'),
+            "The formula '{0}@{1}' should return a Numpy array;".format(variable.name, str(period)).encode('utf-8'),
+            "instead it returned '{0}' of {1}.".format(value, type(value)).encode('utf-8'),
+            "Learn more about Numpy arrays and vectorial computing:",
+            "<http://openfisca.org/doc/coding-the-legislation/25_vectorial_computing.html.>"
             ]))
 
         assert value.size == entity.count, \
-            u"Function {}@{}<{}>() --> <{}>{} returns an array of size {}, but size {} is expected for {}".format(
+            "Function {}@{}<{}>() --> <{}>{} returns an array of size {}, but size {} is expected for {}".format(
                 variable.name, entity.key, str(period), str(period), stringify_array(value),
                 value.size, entity.count, entity.key).encode('utf-8')
 
@@ -322,7 +323,7 @@ class Simulation(object):
                 # cf https://stackoverflow.com/questions/6736590/fast-check-for-nan-in-numpy
                 if np.isnan(np.min(value)):
                     nan_count = np.count_nonzero(np.isnan(value))
-                    raise NaNCreationError(u"Function {}@{}<{}>() --> <{}>{} returns {} NaN value(s)".format(
+                    raise NaNCreationError("Function {}@{}<{}>() --> <{}>{} returns {} NaN value(s)".format(
                         variable.name, entity.key, str(period), str(period), stringify_array(value),
                         nan_count).encode('utf-8'))
             except TypeError:
@@ -345,11 +346,11 @@ class Simulation(object):
         the parameter max_nb_cycles of the calculate method.
         """
         def get_error_message():
-            return u"Circular definition detected on formula {}@{}. Formulas and periods involved: {}.".format(
+            return "Circular definition detected on formula {}@{}. Formulas and periods involved: {}.".format(
                 variable.name,
                 period,
-                u", ".join(sorted(set(
-                    u"{}@{}".format(variable_name, period2)
+                ", ".join(sorted(set(
+                    "{}@{}".format(variable_name, period2)
                     for variable_name, periods in requested_periods_by_variable_name.items()
                     for period2 in periods
                     ))).encode('utf-8'),
@@ -471,7 +472,7 @@ def check_type(input, input_type, path = []):
         }
     if not isinstance(input, input_type):
         raise SituationParsingError(path,
-            u"Invalid type: must be of type '{}'.".format(json_type_map[input_type]))
+            "Invalid type: must be of type '{}'.".format(json_type_map[input_type]))
 
 
 class SituationParsingError(Exception):

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
+from __future__ import unicode_literals
 import glob
 from inspect import isclass
 from os import path, linesep
@@ -104,7 +105,7 @@ class TaxBenefitSystem(object):
         baseline_variable = self.get_variable(name)
         if baseline_variable and not update:
             raise VariableNameConflict(
-                u'Variable "{}" is already defined. Use `update_variable` to replace it.'.format(name))
+                'Variable "{}" is already defined. Use `update_variable` to replace it.'.format(name))
 
         variable = variable_class(baseline_variable = baseline_variable)
         self.variables[variable.name] = variable
@@ -174,7 +175,7 @@ class TaxBenefitSystem(object):
                 if isclass(pot_variable) and issubclass(pot_variable, Variable) and pot_variable.__module__ == module_name:
                     self.add_variable(pot_variable)
         except Exception:
-            log.error(u'Unable to load OpenFisca variables from file "{}"'.format(file_path))
+            log.error('Unable to load OpenFisca variables from file "{}"'.format(file_path))
             raise
 
     def add_variables_from_directory(self, directory):
@@ -218,9 +219,9 @@ class TaxBenefitSystem(object):
                 extension_directory = package.__path__[0]
             except ImportError:
                 message = linesep.join([traceback.format_exc(),
-                                        u'Error loading extension: `{}` is neither a directory, nor a package.'.format(extension),
-                                        u'Are you sure it is installed in your environment? If so, look at the stack trace above to determine the origin of this error.',
-                                        u'See more at <https://github.com/openfisca/openfisca-extension-template#installing>.'])
+                                        'Error loading extension: `{}` is neither a directory, nor a package.'.format(extension),
+                                        'Are you sure it is installed in your environment? If so, look at the stack trace above to determine the origin of this error.',
+                                        'See more at <https://github.com/openfisca/openfisca-extension-template#installing>.'])
                 raise ValueError(message)
 
         self.add_variables_from_directory(extension_directory)
@@ -248,19 +249,19 @@ class TaxBenefitSystem(object):
         try:
             reform_package, reform_name = reform_path.rsplit('.', 1)
         except ValueError:
-            raise ValueError(u'`{}` does not seem to be a path pointing to a reform. A path looks like `some_country_package.reforms.some_reform.`'.format(reform_path).encode('utf-8'))
+            raise ValueError('`{}` does not seem to be a path pointing to a reform. A path looks like `some_country_package.reforms.some_reform.`'.format(reform_path).encode('utf-8'))
         try:
             reform_module = importlib.import_module(reform_package)
         except ImportError:
             message = linesep.join([traceback.format_exc(),
-                                    u'Could not import `{}`.'.format(reform_package).encode('utf-8'),
-                                    u'Are you sure of this reform module name? If so, look at the stack trace above to determine the origin of this error.'])
+                                    'Could not import `{}`.'.format(reform_package).encode('utf-8'),
+                                    'Are you sure of this reform module name? If so, look at the stack trace above to determine the origin of this error.'])
             raise ValueError(message)
         reform = getattr(reform_module, reform_name, None)
         if reform is None:
-            raise ValueError(u'{} has no attribute {}'.format(reform_package, reform_name).encode('utf-8'))
+            raise ValueError('{} has no attribute {}'.format(reform_package, reform_name).encode('utf-8'))
         if not issubclass(reform, Reform):
-            raise ValueError(u'`{}` does not seem to be a valid Openfisca reform.'.format(reform_path).encode('utf-8'))
+            raise ValueError('`{}` does not seem to be a valid Openfisca reform.'.format(reform_path).encode('utf-8'))
 
         return reform(self)
 

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import glob
 from inspect import isclass
 from os import path, linesep

--- a/openfisca_core/taxscales.py
+++ b/openfisca_core/taxscales.py
@@ -2,6 +2,7 @@
 
 
 from __future__ import division
+from __future__ import unicode_literals
 
 from bisect import bisect_left, bisect_right
 import copy
@@ -282,7 +283,7 @@ def combine_tax_scales(node):
         child = node[child_name]
 
         if not isinstance(child, AbstractTaxScale):
-            log.info(u'Skipping {} with value {} because it is not a tax scale'.format(child_name, child))
+            log.info('Skipping {} with value {} because it is not a tax scale'.format(child_name, child))
             continue
 
         if combined_tax_scales is None:

--- a/openfisca_core/taxscales.py
+++ b/openfisca_core/taxscales.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import division
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 
 from bisect import bisect_left, bisect_right
 import copy

--- a/openfisca_core/tools/__init__.py
+++ b/openfisca_core/tools/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from builtins import str
 
 

--- a/openfisca_core/tools/__init__.py
+++ b/openfisca_core/tools/__init__.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+from builtins import str
+
+
 import os
 from ..indexed_enums import Enum, EnumArray
-from openfisca_core.commons import unicode_type
 
 
 def assert_near(value, target_value, absolute_error_margin = None, message = '', relative_error_margin = None):
@@ -26,7 +29,7 @@ def assert_near(value, target_value, absolute_error_margin = None, message = '',
         value = np.array(value)
     if isinstance(target_value, (list, tuple)):
         target_value = np.array(target_value)
-    if isinstance(message, unicode_type):
+    if isinstance(message, str):
         message = message.encode('utf-8')
     if isinstance(value, np.ndarray):
         if isinstance(target_value, Enum) or (isinstance(target_value, np.ndarray) and target_value.dtype == object):

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -4,6 +4,10 @@
 A module to run openfisca yaml tests
 """
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from builtins import str
+
 import collections
 import copy
 import glob
@@ -18,7 +22,7 @@ import yaml
 
 from openfisca_core import conv, periods, scenarios
 from openfisca_core.tools import assert_near
-from openfisca_core.commons import unicode_type, to_unicode
+from openfisca_core.commons import to_unicode
 
 
 log = logging.getLogger(__name__)
@@ -27,22 +31,22 @@ try:
     from yaml import CLoader as Loader, CDumper as Dumper
 except ImportError:
     log.warning(
-        u' '
-        u'libyaml is not installed in your environement, this can make your '
-        u'test suite slower to run. Once you have installed libyaml, run `pip '
-        u'uninstall pyyaml && pip install pyyaml` so that it is used in your '
-        u'Python environement.')
+        ' '
+        'libyaml is not installed in your environement, this can make your '
+        'test suite slower to run. Once you have installed libyaml, run `pip '
+        'uninstall pyyaml && pip install pyyaml` so that it is used in your '
+        'Python environement.')
     from yaml import Loader, Dumper
 
 
 # Yaml module configuration
 
 
-class unicode_folder(unicode_type):
+class unicode_folder(str):
     pass
 
 
-class unicode_literal(unicode_type):
+class unicode_literal(str):
     pass
 
 
@@ -51,11 +55,11 @@ Dumper.add_representer(collections.OrderedDict, lambda dumper, data: dumper.repr
 Dumper.add_representer(dict, lambda dumper, data: dumper.represent_dict((copy.deepcopy(key), value) for key, value in data.items()))
 Dumper.add_representer(np.ndarray, lambda dumper, data: dumper.represent_list(data.tolist()))
 Dumper.add_representer(tuple, lambda dumper, data: dumper.represent_list(data))
-Dumper.add_representer(unicode_folder, lambda dumper, data: dumper.represent_scalar(u'tag:yaml.org,2002:str', data, style='>'))
-Dumper.add_representer(unicode_literal, lambda dumper, data: dumper.represent_scalar(u'tag:yaml.org,2002:str', data, style='|'))
-Dumper.add_representer(periods.Instant, lambda dumper, data: dumper.represent_scalar(u'tag:yaml.org,2002:str', str(data)))
-Dumper.add_representer(periods.Period, lambda dumper, data: dumper.represent_scalar(u'tag:yaml.org,2002:str', str(data)))
-Dumper.add_representer(unicode_type, lambda dumper, data: dumper.represent_scalar(u'tag:yaml.org,2002:str', data))
+Dumper.add_representer(unicode_folder, lambda dumper, data: dumper.represent_scalar('tag:yaml.org,2002:str', data, style='>'))
+Dumper.add_representer(unicode_literal, lambda dumper, data: dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|'))
+Dumper.add_representer(periods.Instant, lambda dumper, data: dumper.represent_scalar('tag:yaml.org,2002:str', str(data)))
+Dumper.add_representer(periods.Period, lambda dumper, data: dumper.represent_scalar('tag:yaml.org,2002:str', str(data)))
+Dumper.add_representer(str, lambda dumper, data: dumper.represent_scalar('tag:yaml.org,2002:str', data))
 
 
 # Exposed methods
@@ -132,15 +136,15 @@ def _generate_tests_from_file(tax_benefit_system, path_to_file, options):
 
     for test_index, (path_to_file, name, period_str, test) in enumerate(tests, 1):
         if name_filter is not None and name_filter not in filename \
-                and name_filter not in (test.get('name', u'')) \
+                and name_filter not in (test.get('name', '')) \
                 and name_filter not in (test.get('keywords', [])):
             continue
 
         keywords = test.get('keywords', [])
         title = "{}: {}{} - {}".format(
             os.path.basename(path_to_file),
-            u'[{}] '.format(u', '.join(keywords)).encode('utf-8') if keywords else '',
-            name.encode('utf-8'),
+            '[{}] '.format(', '.join(keywords)) if keywords else '',
+            name,
             period_str,
             )
 
@@ -185,7 +189,7 @@ def _parse_test_file(tax_benefit_system, yaml_path):
         )(tests)
 
     if error is not None:
-        embedding_error = conv.embed_error(tests, u'errors', error)
+        embedding_error = conv.embed_error(tests, 'errors', error)
         assert embedding_error is None, embedding_error
         raise ValueError("Error in test {}:\n{}".format(yaml_path, yaml.dump(tests, Dumper=Dumper, allow_unicode = True,
             default_flow_style = False, indent = 2, width = 120)))
@@ -208,7 +212,7 @@ def _parse_test_file(tax_benefit_system, yaml_path):
             raise
 
         if error is not None:
-            embedding_error = conv.embed_error(test, u'errors', error)
+            embedding_error = conv.embed_error(test, 'errors', error)
             assert embedding_error is None, embedding_error
             raise ValueError("Error in test {}:\n{}\nYaml test content: \n{}\n".format(
                 yaml_path, error, yaml.dump(test, Dumper=Dumper, allow_unicode = True,
@@ -228,7 +232,7 @@ def _run_test(period_str, test, verbose = False, only_variables = None, ignore_v
     scenario = test['scenario']
     scenario.suggest()
     simulation = scenario.new_simulation(trace = verbose)
-    output_variables = test.get(u'output_variables')
+    output_variables = test.get('output_variables')
     if output_variables is not None:
         try:
             for variable_name, expected_value in output_variables.items():
@@ -242,7 +246,7 @@ def _run_test(period_str, test, verbose = False, only_variables = None, ignore_v
                             simulation.calculate(variable_name, requested_period),
                             expected_value_at_period,
                             absolute_error_margin = absolute_error_margin,
-                            message = u'{}@{}: '.format(variable_name, requested_period),
+                            message = '{}@{}: '.format(variable_name, requested_period),
                             relative_error_margin = relative_error_margin,
                             )
                 else:
@@ -250,7 +254,7 @@ def _run_test(period_str, test, verbose = False, only_variables = None, ignore_v
                         simulation.calculate(variable_name),
                         expected_value,
                         absolute_error_margin = absolute_error_margin,
-                        message = u'{}@{}: '.format(variable_name, period_str),
+                        message = '{}@{}: '.format(variable_name, period_str),
                         relative_error_margin = relative_error_margin,
                         )
         finally:

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -4,8 +4,7 @@
 A module to run openfisca yaml tests
 """
 
-from __future__ import unicode_literals
-from __future__ import print_function
+from __future__ import unicode_literals, print_function, division, absolute_import
 from builtins import str
 
 import collections

--- a/openfisca_core/tracers.py
+++ b/openfisca_core/tracers.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+from __future__ import unicode_literals
 import numpy as np
 
 import logging
@@ -85,8 +87,8 @@ class Tracer(object):
     @staticmethod
     def _get_key(variable_name, period, **parameters):
         if parameters.get('extra_params'):
-            return u"{}<{}><{}>".format(variable_name, period, '><'.join(map(str, parameters['extra_params'])))
-        return u"{}<{}>".format(variable_name, period)
+            return "{}<{}><{}>".format(variable_name, period, '><'.join(map(str, parameters['extra_params'])))
+        return "{}<{}>".format(variable_name, period)
 
     def record_calculation_start(self, variable_name, period, **parameters):
         """
@@ -124,7 +126,7 @@ class Tracer(object):
 
         if not key == expected_key:
             raise ValueError(
-                u"Something went wrong with the simulation tracer: result of '{0}' was expected, got results for '{1}' instead. This does not make sense as the last variable we started computing was '{0}'."
+                "Something went wrong with the simulation tracer: result of '{0}' was expected, got results for '{1}' instead. This does not make sense as the last variable we started computing was '{0}'."
                 .format(expected_key, key).encode('utf-8')
                 )
         self.trace[key]['value'] = result
@@ -142,7 +144,7 @@ class Tracer(object):
 
         if not key == expected_key:
             raise ValueError(
-                u"Something went wrong with the simulation tracer: calculation of '{1}' was aborted, whereas the last variable we started computing was '{0}'."
+                "Something went wrong with the simulation tracer: calculation of '{1}' was aborted, whereas the last variable we started computing was '{0}'."
                 .format(expected_key, key).encode('utf-8')
                 )
 

--- a/openfisca_core/tracers.py
+++ b/openfisca_core/tracers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
+
 import numpy as np
 
 import logging

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-
+from __future__ import unicode_literals
 import datetime
 import inspect
 import re
@@ -44,7 +44,7 @@ VALUE_TYPES = {
         },
     str: {
         'dtype': object,
-        'default': u'',
+        'default': '',
         'json_type': 'String',
         'is_period_size_independent': True
         },
@@ -179,7 +179,7 @@ class Variable(object):
 
         if unexpected_attrs:
             raise ValueError(
-                u'Unexpected attributes in definition of variable "{}": {!r}'
+                'Unexpected attributes in definition of variable "{}": {!r}'
                 .format(self.name, ', '.join(sorted(unexpected_attrs.keys()))))
 
         self.is_neutralized = False
@@ -259,7 +259,7 @@ class Variable(object):
                 requested_period_last_or_next_value,
                 requested_period_last_value
                 }:
-            raise ValueError(u'Unexpected base_function {}'.format(base_function).encode('utf-8'))
+            raise ValueError('Unexpected base_function {}'.format(base_function).encode('utf-8'))
 
         if self.is_period_size_independent and base_function is None:
             return requested_period_last_value
@@ -282,7 +282,7 @@ class Variable(object):
             starting_date = self.parse_formula_name(formula_name)
 
             if self.end is not None and starting_date > self.end:
-                raise ValueError(u'You declared that "{}" ends on "{}", but you wrote a formula to calculate it from "{}" ({}). The "end" attribute of a variable must be posterior to the start dates of all its formulas.'
+                raise ValueError('You declared that "{}" ends on "{}", but you wrote a formula to calculate it from "{}" ({}). The "end" attribute of a variable must be posterior to the start dates of all its formulas.'
                     .format(self.name, self.end, starting_date, formula_name).encode('utf-8'))
 
             formulas[str(starting_date)] = formula
@@ -312,7 +312,7 @@ class Variable(object):
 
         def raise_error():
             raise ValueError(
-                u'Unrecognized formula name in variable "{}". Expecting "formula_YYYY" or "formula_YYYY_MM" or "formula_YYYY_MM_DD where YYYY, MM and DD are year, month and day. Found: "{}".'
+                'Unrecognized formula name in variable "{}". Expecting "formula_YYYY" or "formula_YYYY_MM" or "formula_YYYY_MM_DD where YYYY, MM and DD are year, month and day. Found: "{}".'
                 .format(self.name, attribute_name).encode('utf-8'))
 
         if attribute_name == FORMULA_NAME_PREFIX:
@@ -358,6 +358,9 @@ class Variable(object):
             source_file_path = absolute_file_path.replace(tax_benefit_system.get_package_metadata()['location'], '')
         try:
             source_lines, start_line_number = inspect.getsourcelines(cls)
+            # Python 2 backward compatibility
+            if isinstance(source_lines[0], bytes):
+                source_lines = [source_line.decode('utf-8') for source_line in source_lines]
             source_code = textwrap.dedent(''.join(source_lines))
         except (IOError, TypeError):
             source_code, start_line_number = None, None
@@ -423,6 +426,6 @@ def get_neutralized_variable(variable):
     """
     result = variable.clone()
     result.is_neutralized = True
-    result.label = u'[Neutralized]' if variable.label is None else u'[Neutralized] {}'.format(variable.label),
+    result.label = '[Neutralized]' if variable.label is None else '[Neutralized] {}'.format(variable.label),
 
     return result

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -228,7 +228,7 @@ class Variable(object):
             try:
                 return datetime.datetime.strptime(end, '%Y-%m-%d').date()
             except ValueError:
-                raise ValueError(u"Incorrect 'end' attribute format in '{}'. 'YYYY-MM-DD' expected where YYYY, MM and DD are year, month and day. Found: {}".format(self.name, end).encode('utf-8'))
+                raise ValueError("Incorrect 'end' attribute format in '{}'. 'YYYY-MM-DD' expected where YYYY, MM and DD are year, month and day. Found: {}".format(self.name, end).encode('utf-8'))
 
     def set_reference(self, reference):
         if reference:

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import datetime
 import inspect
 import re

--- a/openfisca_web_api_preview/app.py
+++ b/openfisca_web_api_preview/app.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from copy import deepcopy
 import os
 from os import linesep
@@ -24,16 +25,16 @@ def init_tracker(url, idsite, tracker_token):
         from openfisca_tracker.piwik import PiwikTracker
         tracker = PiwikTracker(url, idsite, tracker_token)
 
-        info = linesep.join([u'You chose to activate the `tracker` module. ',
-                             u'Tracking data will be sent to: ' + url,
-                             u'For more information, see <https://github.com/openfisca/openfisca-core#tracker-configuration>.'])
+        info = linesep.join(['You chose to activate the `tracker` module. ',
+                             'Tracking data will be sent to: ' + url,
+                             'For more information, see <https://github.com/openfisca/openfisca-core#tracker-configuration>.'])
         log.info(info)
         return tracker
 
     except ImportError:
         message = linesep.join([traceback.format_exc(),
-                                u'You chose to activate the `tracker` module, but it is not installed.',
-                                u'For more information, see <https://github.com/openfisca/openfisca-core#tracker-installation>.'])
+                                'You chose to activate the `tracker` module, but it is not installed.',
+                                'For more information, see <https://github.com/openfisca/openfisca-core#tracker-installation>.'])
         log.warn(message)
 
 

--- a/openfisca_web_api_preview/app.py
+++ b/openfisca_web_api_preview/app.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from copy import deepcopy
 import os
 from os import linesep

--- a/openfisca_web_api_preview/loader/__init__.py
+++ b/openfisca_web_api_preview/loader/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from openfisca_web_api_preview.loader.parameters import build_parameters
 from openfisca_web_api_preview.loader.variables import build_variables
 from openfisca_web_api_preview.loader.spec import build_openAPI_specification

--- a/openfisca_web_api_preview/loader/__init__.py
+++ b/openfisca_web_api_preview/loader/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from openfisca_web_api_preview.loader.parameters import build_parameters
 from openfisca_web_api_preview.loader.variables import build_variables
 from openfisca_web_api_preview.loader.spec import build_openAPI_specification

--- a/openfisca_web_api_preview/loader/parameters.py
+++ b/openfisca_web_api_preview/loader/parameters.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from openfisca_core.parameters import Parameter, ParameterNode, Scale
 
 
@@ -63,7 +64,7 @@ def walk_node(node, parameters, path_fragments):
         else:
             object_transformed = {
                 'description': getattr(child, "description", None),
-                'id': u'.'.join(path_fragments + [child_name]),
+                'id': '.'.join(path_fragments + [child_name]),
                 }
             if isinstance(child, Scale):
                 object_transformed['brackets'] = transform_scale(child)

--- a/openfisca_web_api_preview/loader/parameters.py
+++ b/openfisca_web_api_preview/loader/parameters.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from openfisca_core.parameters import Parameter, ParameterNode, Scale
 
 

--- a/openfisca_web_api_preview/loader/spec.py
+++ b/openfisca_web_api_preview/loader/spec.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import os
 import yaml
 

--- a/openfisca_web_api_preview/loader/spec.py
+++ b/openfisca_web_api_preview/loader/spec.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import os
-
 import yaml
 
 from openfisca_core.indexed_enums import Enum

--- a/openfisca_web_api_preview/loader/tax_benefit_system.py
+++ b/openfisca_web_api_preview/loader/tax_benefit_system.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import importlib
 import traceback
 import logging
@@ -13,9 +14,9 @@ def build_tax_benefit_system(country_package_name):
         country_package = importlib.import_module(country_package_name)
     except ImportError:
         message = linesep.join([traceback.format_exc(),
-                                u'Could not import module `{}`.'.format(country_package_name).encode('utf-8'),
-                                u'Are you sure it is installed in your environment? If so, look at the stack trace above to determine the origin of this error.',
-                                u'See more at <https://github.com/openfisca/country-template#installing>.',
+                                'Could not import module `{}`.'.format(country_package_name),
+                                'Are you sure it is installed in your environment? If so, look at the stack trace above to determine the origin of this error.',
+                                'See more at <https://github.com/openfisca/country-template#installing>.',
                                 linesep])
         raise ValueError(message)
     try:

--- a/openfisca_web_api_preview/loader/tax_benefit_system.py
+++ b/openfisca_web_api_preview/loader/tax_benefit_system.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import importlib
 import traceback
 import logging

--- a/openfisca_web_api_preview/loader/variables.py
+++ b/openfisca_web_api_preview/loader/variables.py
@@ -39,6 +39,9 @@ def build_source_url(country_package_metadata, source_file_path, start_line_numb
 
 def build_formula(formula, country_package_metadata, source_file_path, tax_benefit_system):
     source_code, start_line_number = inspect.getsourcelines(formula)
+    # Python 2 backward compatibility
+    if isinstance(source_code[0], bytes):
+        source_code = [source_line.decode('utf-8') for source_line in source_code]
     source_code = textwrap.dedent(''.join(source_code))
     return {
         'source': build_source_url(

--- a/openfisca_web_api_preview/loader/variables.py
+++ b/openfisca_web_api_preview/loader/variables.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import datetime
 import inspect
 import textwrap

--- a/openfisca_web_api_preview/loader/variables.py
+++ b/openfisca_web_api_preview/loader/variables.py
@@ -39,9 +39,6 @@ def build_source_url(country_package_metadata, source_file_path, start_line_numb
 
 def build_formula(formula, country_package_metadata, source_file_path, tax_benefit_system):
     source_code, start_line_number = inspect.getsourcelines(formula)
-    if source_code[0].lstrip(' ').startswith('@'):  # remove decorator
-        source_code = source_code[1:]
-        start_line_number = start_line_number + 1
     source_code = textwrap.dedent(''.join(source_code))
     return {
         'source': build_source_url(

--- a/openfisca_web_api_preview/loader/variables.py
+++ b/openfisca_web_api_preview/loader/variables.py
@@ -28,7 +28,7 @@ def get_default_value(variable):
 
 def build_source_url(country_package_metadata, source_file_path, start_line_number, source_code):
     nb_lines = source_code.count('\n')
-    return u'{}/blob/{}{}#L{}-L{}'.format(
+    return '{}/blob/{}{}#L{}-L{}'.format(
         country_package_metadata['repository_url'],
         country_package_metadata['version'],
         source_file_path,

--- a/openfisca_web_api_preview/loader/variables.py
+++ b/openfisca_web_api_preview/loader/variables.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import datetime
 import inspect
 import textwrap

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import sys
 import logging
 import argparse

--- a/openfisca_web_api_preview/scripts/serve.py
+++ b/openfisca_web_api_preview/scripts/serve.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import sys
 import logging
 import argparse

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '23.3.1',
+    version = '23.3.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from setuptools import setup, find_packages
 
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'test': [
             'nose',
             'flake8 >= 3.4.0, < 3.5.0',
-            'openfisca-country-template >= 3.2.2rc0, < 4.0.0',
+            'openfisca-country-template >= 3.2.3, < 4.0.0',
             'openfisca-extension-template >= 1.1.3, < 2.0.0',
             ],
         'tracker': [

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 
+from __future__ import unicode_literals
 from setuptools import setup, find_packages
 
 
@@ -17,7 +18,7 @@ setup(
         "Programming Language :: Python",
         "Topic :: Scientific/Engineering :: Information Analysis",
         ],
-    description = u'A versatile microsimulation free software',
+    description = 'A versatile microsimulation free software',
     keywords = 'benefit microsimulation social tax',
     license = 'https://www.fsf.org/licensing/licenses/agpl-3.0.html',
     url = 'https://github.com/openfisca/openfisca-core',

--- a/tests/core/parameter_validation/test_parameter_validation.py
+++ b/tests/core/parameter_validation/test_parameter_validation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import os
 
 from nose.tools import assert_in, raises

--- a/tests/core/parameter_validation/test_parameter_validation.py
+++ b/tests/core/parameter_validation/test_parameter_validation.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import os
 
 from nose.tools import assert_in, raises

--- a/tests/core/parameters_fancy_indexing/test_fancy_indexing.py
+++ b/tests/core/parameters_fancy_indexing/test_fancy_indexing.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import os
 
 import numpy as np

--- a/tests/core/parameters_fancy_indexing/test_fancy_indexing.py
+++ b/tests/core/parameters_fancy_indexing/test_fancy_indexing.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import os
 
 import numpy as np

--- a/tests/core/test_axes.py
+++ b/tests/core/test_axes.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from openfisca_core.tools import assert_near
 from openfisca_core import conv
 from openfisca_core.scenarios import AbstractScenario

--- a/tests/core/test_axes.py
+++ b/tests/core/test_axes.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from openfisca_core.tools import assert_near
 from openfisca_core import conv
 from openfisca_core.scenarios import AbstractScenario

--- a/tests/core/test_base_functions.py
+++ b/tests/core/test_base_functions.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import numpy as np
 from openfisca_core.tools import assert_near
 

--- a/tests/core/test_base_functions.py
+++ b/tests/core/test_base_functions.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import numpy as np
 from openfisca_core.tools import assert_near
 

--- a/tests/core/test_calculate_output.py
+++ b/tests/core/test_calculate_output.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from nose.tools import raises
 
 from openfisca_core.model_api import *  # noqa analysis:ignore

--- a/tests/core/test_calculate_output.py
+++ b/tests/core/test_calculate_output.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from nose.tools import raises
 
 from openfisca_core.model_api import *  # noqa analysis:ignore

--- a/tests/core/test_columns.py
+++ b/tests/core/test_columns.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import openfisca_country_template as country_template
 from openfisca_country_template.entities import Person
 

--- a/tests/core/test_columns.py
+++ b/tests/core/test_columns.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import openfisca_country_template as country_template
 from openfisca_country_template.entities import Person
 
@@ -20,7 +21,7 @@ class input_variable(Variable):
     value_type = int
     entity = Person
     definition_period = MONTH
-    label = u"Input variable. No formula."
+    label = "Input variable. No formula."
 
 
 tax_benefit_system.add_variable(input_variable)
@@ -30,7 +31,7 @@ class variable_with_formula(Variable):
     value_type = int
     entity = Person
     definition_period = MONTH
-    label = u"Variable with formula"
+    label = "Variable with formula"
 
     def formula(individu, period):
         return individu.empty_array()

--- a/tests/core/test_countries.py
+++ b/tests/core/test_countries.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from nose.tools import raises, assert_raises
 
 from openfisca_core.variables import Variable
@@ -63,7 +64,7 @@ def test_calculate_divide():
 class income_tax_no_period(Variable):
     value_type = float
     entity = Person
-    label = u"Salaire net (buggy)"
+    label = "Salaire net (buggy)"
     definition_period = MONTH
 
     def formula(individu, period):
@@ -159,7 +160,7 @@ def test_calculate_variable_with_wrong_definition_period():
     expected_words = ['period', '2016', 'month', 'basic_income', 'ADD']
 
     for word in expected_words:
-        assert word in error_message, u'Expected "{}" in error message "{}"'.format(word, error_message).encode('utf-8')
+        assert word in error_message, 'Expected "{}" in error message "{}"'.format(word, error_message).encode('utf-8')
 
 
 @raises(ValueError)

--- a/tests/core/test_countries.py
+++ b/tests/core/test_countries.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from nose.tools import raises, assert_raises
 
 from openfisca_core.variables import Variable

--- a/tests/core/test_countries.py
+++ b/tests/core/test_countries.py
@@ -160,7 +160,7 @@ def test_calculate_variable_with_wrong_definition_period():
     expected_words = ['period', '2016', 'month', 'basic_income', 'ADD']
 
     for word in expected_words:
-        assert word in error_message, 'Expected "{}" in error message "{}"'.format(word, error_message).encode('utf-8')
+        assert word in error_message, 'Expected "{}" in error message "{}"'.format(word, error_message)
 
 
 @raises(ValueError)

--- a/tests/core/test_cycles.py
+++ b/tests/core/test_cycles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from nose.tools import raises
 
 from openfisca_core import periods

--- a/tests/core/test_cycles.py
+++ b/tests/core/test_cycles.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
+from __future__ import unicode_literals
 from nose.tools import raises
 
 from openfisca_core import periods
@@ -113,7 +114,7 @@ tax_benefit_system = CountryTaxBenefitSystem()
 tax_benefit_system.add_variables(variable1, variable2, variable3, variable4,
     variable5, variable6, cotisation, variable7, variable8)
 
-reference_period = periods.period(u'2013-01')
+reference_period = periods.period('2013-01')
 
 
 @raises(AssertionError)

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from copy import deepcopy
 
 from openfisca_core.tools import assert_near

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from copy import deepcopy
 
 from openfisca_core.tools import assert_near

--- a/tests/core/test_extensions.py
+++ b/tests/core/test_extensions.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from nose.tools import raises
 
 from openfisca_country_template import CountryTaxBenefitSystem

--- a/tests/core/test_extensions.py
+++ b/tests/core/test_extensions.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from nose.tools import raises
 
 from openfisca_country_template import CountryTaxBenefitSystem

--- a/tests/core/test_extra_params.py
+++ b/tests/core/test_extra_params.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from nose.tools import assert_equal
 
 from openfisca_core import periods
@@ -52,7 +53,7 @@ class formula_4(Variable):
 tax_benefit_system = CountryTaxBenefitSystem()
 tax_benefit_system.add_variables(formula_1, formula_2, formula_3, formula_4)
 
-reference_period = periods.period(u'2013-01')
+reference_period = periods.period('2013-01')
 
 
 def get_simulation():

--- a/tests/core/test_extra_params.py
+++ b/tests/core/test_extra_params.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from nose.tools import assert_equal
 
 from openfisca_core import periods

--- a/tests/core/test_formula_helpers.py
+++ b/tests/core/test_formula_helpers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import numpy
 from nose.tools import raises
 

--- a/tests/core/test_formula_helpers.py
+++ b/tests/core/test_formula_helpers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import numpy
 from nose.tools import raises
 

--- a/tests/core/test_formulas.py
+++ b/tests/core/test_formulas.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
+from __future__ import unicode_literals
 import numpy as np
 
 from openfisca_core.periods import MONTH
@@ -19,7 +20,7 @@ class choice(Variable):
 class uses_multiplication(Variable):
     value_type = int
     entity = Person
-    label = u'Variable with formula that uses multiplication'
+    label = 'Variable with formula that uses multiplication'
     definition_period = MONTH
 
     def formula(person, period):
@@ -31,7 +32,7 @@ class uses_multiplication(Variable):
 class uses_switch(Variable):
     value_type = int
     entity = Person
-    label = u'Variable with formula that uses switch'
+    label = 'Variable with formula that uses switch'
     definition_period = MONTH
 
     def formula(person, period):

--- a/tests/core/test_formulas.py
+++ b/tests/core/test_formulas.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import numpy as np
 
 from openfisca_core.periods import MONTH

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import numpy as np
 
 from nose.tools import assert_equal, assert_is_none

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import numpy as np
 
 from nose.tools import assert_equal, assert_is_none

--- a/tests/core/test_json_to_test_case.py
+++ b/tests/core/test_json_to_test_case.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from nose.tools import raises
 
 from openfisca_core.json_to_test_case import check_entities_and_role

--- a/tests/core/test_json_to_test_case.py
+++ b/tests/core/test_json_to_test_case.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from nose.tools import raises
 
 from openfisca_core.json_to_test_case import check_entities_and_role

--- a/tests/core/test_opt_out_cache.py
+++ b/tests/core/test_opt_out_cache.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
+from __future__ import unicode_literals
 from openfisca_country_template import CountryTaxBenefitSystem
 from openfisca_country_template.entities import Person
 from openfisca_core.variables import Variable
@@ -10,14 +11,14 @@ from openfisca_core.periods import MONTH
 class input(Variable):
     value_type = int
     entity = Person
-    label = u"Input variable"
+    label = "Input variable"
     definition_period = MONTH
 
 
 class intermediate(Variable):
     value_type = int
     entity = Person
-    label = u"Intermediate result that don't need to be cached"
+    label = "Intermediate result that don't need to be cached"
     definition_period = MONTH
 
     def formula(person, period):
@@ -27,7 +28,7 @@ class intermediate(Variable):
 class output(Variable):
     value_type = int
     entity = Person
-    label = u'Output variable'
+    label = 'Output variable'
     definition_period = MONTH
 
     def formula(person, period):

--- a/tests/core/test_opt_out_cache.py
+++ b/tests/core/test_opt_out_cache.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from openfisca_country_template import CountryTaxBenefitSystem
 from openfisca_country_template.entities import Person
 from openfisca_core.variables import Variable

--- a/tests/core/test_parameters.py
+++ b/tests/core/test_parameters.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from nose.tools import assert_equal, raises
 import tempfile
 

--- a/tests/core/test_parameters.py
+++ b/tests/core/test_parameters.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from nose.tools import assert_equal, raises
 import tempfile
 

--- a/tests/core/test_periods.py
+++ b/tests/core/test_periods.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from nose.tools import assert_equal, raises
 
 from openfisca_core.periods import Period, Instant, YEAR, MONTH, period
@@ -12,77 +13,77 @@ first_march = Instant((2014, 3, 1))
 # Test Period -> String
 
 def test_year():
-    assert_equal(to_unicode(Period((YEAR, first_jan, 1))), u'2014')
+    assert_equal(to_unicode(Period((YEAR, first_jan, 1))), '2014')
 
 
 def test_12_months_is_a_year():
-    assert_equal(to_unicode(Period((MONTH, first_jan, 12))), u'2014')
+    assert_equal(to_unicode(Period((MONTH, first_jan, 12))), '2014')
 
 
 def test_rolling_year():
-    assert_equal(to_unicode(Period((MONTH, first_march, 12))), u'year:2014-03')
-    assert_equal(to_unicode(Period((YEAR, first_march, 1))), u'year:2014-03')
+    assert_equal(to_unicode(Period((MONTH, first_march, 12))), 'year:2014-03')
+    assert_equal(to_unicode(Period((YEAR, first_march, 1))), 'year:2014-03')
 
 
 def test_month():
-    assert_equal(to_unicode(Period((MONTH, first_jan, 1))), u'2014-01')
+    assert_equal(to_unicode(Period((MONTH, first_jan, 1))), '2014-01')
 
 
 def test_several_months():
-    assert_equal(to_unicode(Period((MONTH, first_jan, 3))), u'month:2014-01:3')
-    assert_equal(to_unicode(Period((MONTH, first_march, 3))), u'month:2014-03:3')
+    assert_equal(to_unicode(Period((MONTH, first_jan, 3))), 'month:2014-01:3')
+    assert_equal(to_unicode(Period((MONTH, first_march, 3))), 'month:2014-03:3')
 
 
 def test_several_years():
-    assert_equal(to_unicode(Period((YEAR, first_jan, 3))), u'year:2014:3')
-    assert_equal(to_unicode(Period((YEAR, first_march, 3))), u'year:2014-03:3')
+    assert_equal(to_unicode(Period((YEAR, first_jan, 3))), 'year:2014:3')
+    assert_equal(to_unicode(Period((YEAR, first_march, 3))), 'year:2014-03:3')
 
 # Test String -> Period
 
 
 def test_parsing_year():
-    assert_equal(period(u'2014'), Period((YEAR, first_jan, 1)))
+    assert_equal(period('2014'), Period((YEAR, first_jan, 1)))
 
 
 def test_parsing_month():
-    assert_equal(period(u'2014-01'), Period((MONTH, first_jan, 1)))
+    assert_equal(period('2014-01'), Period((MONTH, first_jan, 1)))
 
 
 def test_parsing_rolling_year():
-    assert_equal(period(u'year:2014-03'), Period((YEAR, first_march, 1)))
+    assert_equal(period('year:2014-03'), Period((YEAR, first_march, 1)))
 
 
 def test_parsing_several_months():
-    assert_equal(period(u'month:2014-03:3'), Period((MONTH, first_march, 3)))
+    assert_equal(period('month:2014-03:3'), Period((MONTH, first_march, 3)))
 
 
 def test_parsing_several_years():
-    assert_equal(period(u'year:2014:2'), Period((YEAR, first_jan, 2)))
+    assert_equal(period('year:2014:2'), Period((YEAR, first_jan, 2)))
 
 
 @raises(ValueError)
 def test_wrong_syntax_several_years():
-    period(u'2014:2')
+    period('2014:2')
 
 
 @raises(ValueError)
 def test_wrong_syntax_several_months():
-    period(u'2014-2:2')
+    period('2014-2:2')
 
 
 @raises(ValueError)
 def test_daily_period():
-    period(u'2014-2-3')
+    period('2014-2-3')
 
 
 @raises(ValueError)
 def test_daily_period_2():
-    period(u'2014-2-3:2')
+    period('2014-2-3:2')
 
 
 @raises(ValueError)
 def test_ambiguous_period():
-    period(u'month:2014')
+    period('month:2014')
 
 
 @raises(TypeError)

--- a/tests/core/test_periods.py
+++ b/tests/core/test_periods.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from nose.tools import assert_equal, raises
 
 from openfisca_core.periods import Period, Instant, YEAR, MONTH, period

--- a/tests/core/test_reforms.py
+++ b/tests/core/test_reforms.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import warnings
 
 
@@ -20,7 +21,7 @@ class goes_to_school(Variable):
     value_type = bool
     default_value = True
     entity = Person
-    label = u"The person goes to school (only relevant for children)"
+    label = "The person goes to school (only relevant for children)"
     definition_period = MONTH
 
 
@@ -139,7 +140,7 @@ def test_update_items():
 
     yield (
         check_update_items,
-        u'Replace an item by a new item',
+        'Replace an item by a new item',
         ValuesHistory('dummy_name', {"2013-01-01": {'value': 0.0}, "2014-01-01": {'value': None}}),
         periods.period(2013).start,
         periods.period(2013).stop,
@@ -148,7 +149,7 @@ def test_update_items():
         )
     yield (
         check_update_items,
-        u'Replace an item by a new item in a list of items, the last being open',
+        'Replace an item by a new item in a list of items, the last being open',
         ValuesHistory('dummy_name', {"2014-01-01": {'value': 9.53}, "2015-01-01": {'value': 9.61}, "2016-01-01": {'value': 9.67}}),
         periods.period(2015).start,
         periods.period(2015).stop,
@@ -157,7 +158,7 @@ def test_update_items():
         )
     yield (
         check_update_items,
-        u'Open the stop instant to the future',
+        'Open the stop instant to the future',
         ValuesHistory('dummy_name', {"2013-01-01": {'value': 0.0}, "2014-01-01": {'value': None}}),
         periods.period(2013).start,
         None,  # stop instant
@@ -166,7 +167,7 @@ def test_update_items():
         )
     yield (
         check_update_items,
-        u'Insert a new item in the middle of an existing item',
+        'Insert a new item in the middle of an existing item',
         ValuesHistory('dummy_name', {"2010-01-01": {'value': 0.0}, "2014-01-01": {'value': None}}),
         periods.period(2011).start,
         periods.period(2011).stop,
@@ -175,7 +176,7 @@ def test_update_items():
         )
     yield (
         check_update_items,
-        u'Insert a new open item coming after the last open item',
+        'Insert a new open item coming after the last open item',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2015).start,
         None,  # stop instant
@@ -184,7 +185,7 @@ def test_update_items():
         )
     yield (
         check_update_items,
-        u'Insert a new item starting at the same date than the last open item',
+        'Insert a new item starting at the same date than the last open item',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2014).start,
         periods.period(2014).stop,
@@ -193,7 +194,7 @@ def test_update_items():
         )
     yield (
         check_update_items,
-        u'Insert a new open item starting at the same date than the last open item',
+        'Insert a new open item starting at the same date than the last open item',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2014).start,
         None,  # stop instant
@@ -202,7 +203,7 @@ def test_update_items():
         )
     yield (
         check_update_items,
-        u'Insert a new item coming before the first item',
+        'Insert a new item coming before the first item',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2005).start,
         periods.period(2005).stop,
@@ -211,7 +212,7 @@ def test_update_items():
         )
     yield (
         check_update_items,
-        u'Insert a new item coming before the first item with a hole',
+        'Insert a new item coming before the first item with a hole',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2003).start,
         periods.period(2003).stop,
@@ -220,7 +221,7 @@ def test_update_items():
         )
     yield (
         check_update_items,
-        u'Insert a new open item starting before the start date of the first item',
+        'Insert a new open item starting before the start date of the first item',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2005).start,
         None,  # stop instant
@@ -229,7 +230,7 @@ def test_update_items():
         )
     yield (
         check_update_items,
-        u'Insert a new open item starting at the same date than the first item',
+        'Insert a new open item starting at the same date than the first item',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2006).start,
         None,  # stop instant
@@ -242,7 +243,7 @@ def test_add_variable():
 
     class new_variable(Variable):
         value_type = int
-        label = u"Nouvelle variable introduite par la réforme"
+        label = "Nouvelle variable introduite par la réforme"
         entity = Household
         definition_period = MONTH
 
@@ -271,7 +272,7 @@ def test_add_variable():
 def test_add_dated_variable():
     class new_dated_variable(Variable):
         value_type = int
-        label = u"Nouvelle variable introduite par la réforme"
+        label = "Nouvelle variable introduite par la réforme"
         entity = Household
         definition_period = MONTH
 
@@ -395,7 +396,7 @@ def test_attributes_conservation():
     class some_variable(Variable):
         value_type = int
         entity = Person
-        label = u"Variable with many attributes"
+        label = "Variable with many attributes"
         definition_period = MONTH
         set_input = set_input_divide_by_period
         calculate_output = calculate_output_add

--- a/tests/core/test_reforms.py
+++ b/tests/core/test_reforms.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import warnings
 
 

--- a/tests/core/test_scenarios.py
+++ b/tests/core/test_scenarios.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import numpy as np
 from openfisca_core.tools import assert_near
 

--- a/tests/core/test_scenarios.py
+++ b/tests/core/test_scenarios.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import numpy as np
 from openfisca_core.tools import assert_near
 

--- a/tests/core/test_simulations.py
+++ b/tests/core/test_simulations.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from openfisca_country_template.situation_examples import single
 
 from openfisca_core.simulations import Simulation

--- a/tests/core/test_simulations.py
+++ b/tests/core/test_simulations.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from openfisca_country_template.situation_examples import single
 
 from openfisca_core.simulations import Simulation

--- a/tests/core/test_tax_scales.py
+++ b/tests/core/test_tax_scales.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
+from __future__ import unicode_literals
 import numpy as np
 
 from openfisca_core.taxscales import MarginalRateTaxScale, combine_tax_scales

--- a/tests/core/test_tax_scales.py
+++ b/tests/core/test_tax_scales.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import numpy as np
 
 from openfisca_core.taxscales import MarginalRateTaxScale, combine_tax_scales

--- a/tests/core/test_tracer.py
+++ b/tests/core/test_tracer.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from nose.tools import raises, assert_equals
 
 from openfisca_core.tracers import Tracer

--- a/tests/core/test_tracer.py
+++ b/tests/core/test_tracer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from nose.tools import raises, assert_equals
 
 from openfisca_core.tracers import Tracer

--- a/tests/core/test_variables.py
+++ b/tests/core/test_variables.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import datetime
 from nose.tools import raises
 

--- a/tests/core/test_variables.py
+++ b/tests/core/test_variables.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import datetime
 from nose.tools import raises
 
@@ -57,7 +58,7 @@ class variable__no_date(Variable):
     value_type = int
     entity = Person
     definition_period = MONTH
-    label = u"Variable without date."
+    label = "Variable without date."
 
 
 def test_before_add__variable__no_date():
@@ -77,7 +78,7 @@ class variable__strange_end_attribute(Variable):
     value_type = int
     entity = Person
     definition_period = MONTH
-    label = u"Variable with dubious end attribute, no formula."
+    label = "Variable with dubious end attribute, no formula."
     end = '1989-00-00'
 
 
@@ -99,7 +100,7 @@ class variable__end_attribute(Variable):
     value_type = int
     entity = Person
     definition_period = MONTH
-    label = u"Variable with end attribute, no formula."
+    label = "Variable with end attribute, no formula."
     end = '1989-12-31'
 
 
@@ -117,7 +118,7 @@ class end_attribute__one_simple_formula(Variable):
     value_type = int
     entity = Person
     definition_period = MONTH
-    label = u"Variable with end attribute, one formula without date."
+    label = "Variable with end attribute, one formula without date."
     end = '1989-12-31'
 
     def formula(individu, period):
@@ -163,7 +164,7 @@ class no_end_attribute__one_formula__strange_name(Variable):
     value_type = int
     entity = Person
     definition_period = MONTH
-    label = u"Variable without end attribute, one stangely named formula."
+    label = "Variable without end attribute, one stangely named formula."
 
     def formula_2015_toto(individu, period):
         return vectorize(individu, 100)
@@ -180,7 +181,7 @@ class no_end_attribute__one_formula__start(Variable):
     value_type = int
     entity = Person
     definition_period = MONTH
-    label = u"Variable without end attribute, one dated formula."
+    label = "Variable without end attribute, one dated formula."
 
     def formula_2000_01_01(individu, period):
         return vectorize(individu, 100)
@@ -215,7 +216,7 @@ class no_end_attribute__one_formula__eternity(Variable):
     value_type = int
     entity = Person
     definition_period = ETERNITY  # For this entity, this variable shouldn't evolve through time
-    label = u"Variable without end attribute, one dated formula."
+    label = "Variable without end attribute, one dated formula."
 
     def formula_2000_01_01(individu, period):
         return vectorize(individu, 100)
@@ -240,7 +241,7 @@ class no_end_attribute__formulas__start_formats(Variable):
     value_type = int
     entity = Person
     definition_period = MONTH
-    label = u"Variable without end attribute, multiple dated formulas."
+    label = "Variable without end attribute, multiple dated formulas."
 
     def formula_2000(individu, period):
         return vectorize(individu, 100)
@@ -296,7 +297,7 @@ class no_attribute__formulas__different_names__dates_overlap(Variable):
     value_type = int
     entity = Person
     definition_period = MONTH
-    label = u"Variable, no end attribute, multiple dated formulas with different names but same dates."
+    label = "Variable, no end attribute, multiple dated formulas with different names but same dates."
 
     def formula_2000(individu, period):
         return vectorize(individu, 100)
@@ -316,7 +317,7 @@ class no_attribute__formulas__different_names__no_overlap(Variable):
     value_type = int
     entity = Person
     definition_period = MONTH
-    label = u"Variable, no end attribute, multiple dated formulas with different names and no date overlap."
+    label = "Variable, no end attribute, multiple dated formulas with different names and no date overlap."
 
     def formula_2000_01_01(individu, period):
         return vectorize(individu, 100)
@@ -347,7 +348,7 @@ class end_attribute__one_formula__start(Variable):
     value_type = int
     entity = Person
     definition_period = MONTH
-    label = u"Variable with end attribute, one dated formula."
+    label = "Variable with end attribute, one dated formula."
     end = '2001-12-31'
 
     def formula_2000_01_01(individu, period):
@@ -377,7 +378,7 @@ class stop_attribute_before__one_formula__start(Variable):
     value_type = int
     entity = Person
     definition_period = MONTH
-    label = u"Variable with stop attribute only coming before formula start."
+    label = "Variable with stop attribute only coming before formula start."
     end = '1990-01-01'
 
     def formula_2000_01_01(individu, period):
@@ -394,7 +395,7 @@ class end_attribute_restrictive__one_formula(Variable):
     value_type = int
     entity = Person
     definition_period = MONTH
-    label = u"Variable with end attribute, one dated formula and dates intervals overlap."
+    label = "Variable with end attribute, one dated formula and dates intervals overlap."
     end = '2001-01-01'
 
     def formula_2001_01_01(individu, period):
@@ -424,7 +425,7 @@ class end_attribute__formulas__different_names(Variable):
     value_type = int
     entity = Person
     definition_period = MONTH
-    label = u"Variable with end attribute, multiple dated formulas with different names."
+    label = "Variable with end attribute, multiple dated formulas with different names."
     end = '2010-12-31'
 
     def formula_2000_01_01(individu, period):

--- a/tests/core/test_yaml.py
+++ b/tests/core/test_yaml.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import pkg_resources
 import os
 import sys

--- a/tests/core/test_yaml.py
+++ b/tests/core/test_yaml.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import pkg_resources
 import os
 import sys

--- a/tests/core/test_yaml.py
+++ b/tests/core/test_yaml.py
@@ -18,11 +18,6 @@ tax_benefit_system = CountryTaxBenefitSystem()
 openfisca_core_dir = pkg_resources.get_distribution('OpenFisca-Core').location
 yaml_tests_dir = os.path.join(openfisca_core_dir, 'tests', 'core', 'yaml_tests')
 
-# When tests are run by the CI, openfisca_core is not installed in editable mode, therefore the tests are not packaged with the ditribution. We thus get them from ~/openfisca-core/tests/core/yaml_tests
-if not os.path.isdir(yaml_tests_dir):
-    ci_yaml_tests_dir = os.path.join(os.path.expanduser('~'), 'openfisca-core', 'tests', 'core', 'yaml_tests')
-    yaml_tests_dir = ci_yaml_tests_dir if os.path.isdir(ci_yaml_tests_dir) else yaml_tests_dir
-
 
 # Declare that these two functions are not tests to run with nose
 nottest(run_tests)

--- a/tests/web_api/basic_case/__init__.py
+++ b/tests/web_api/basic_case/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import pkg_resources
 from openfisca_web_api_preview.app import create_app
 from openfisca_core.scripts import build_tax_benefit_system

--- a/tests/web_api/basic_case/__init__.py
+++ b/tests/web_api/basic_case/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import pkg_resources
 from openfisca_web_api_preview.app import create_app
 from openfisca_core.scripts import build_tax_benefit_system

--- a/tests/web_api/basic_case/test_calculate.py
+++ b/tests/web_api/basic_case/test_calculate.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import os
 import json
 from http.client import BAD_REQUEST, OK, NOT_FOUND

--- a/tests/web_api/basic_case/test_calculate.py
+++ b/tests/web_api/basic_case/test_calculate.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import os
 import json
 from http.client import BAD_REQUEST, OK, NOT_FOUND
@@ -208,8 +209,8 @@ def test_encoding_variable_value():
     assert_equal(response.status_code, BAD_REQUEST, response.data.decode('utf-8'))
     response_json = json.loads(response.data.decode('utf-8'))
     assert_in(
-        u"'Locataire ou sous-locataire d‘un logement loué vide non-HLM' is not a valid value for 'housing_occupancy_status'. Possible values are ",
-        dpath.get(response_json, u'households/_/housing_occupancy_status/2017-07')
+        "'Locataire ou sous-locataire d‘un logement loué vide non-HLM' is not a valid value for 'housing_occupancy_status'. Possible values are ",
+        dpath.get(response_json, 'households/_/housing_occupancy_status/2017-07')
         )
 
 
@@ -236,7 +237,7 @@ def test_encoding_entity_name():
     # In Python 3, there is no encoding issue.
     if response.status_code != OK:
         assert_in(
-            u"'O‘Ryan' is not a valid ASCII value.",
+            "'O‘Ryan' is not a valid ASCII value.",
             response_json['error']
             )
 
@@ -279,6 +280,6 @@ def test_encoding_period_id():
     # In Python 3, there is no encoding issue.
     if "Expected a period" not in to_unicode(response.data):
         assert_in(
-            u"'à' is not a valid ASCII value.",
+            "'à' is not a valid ASCII value.",
             response_json['error']
             )

--- a/tests/web_api/basic_case/test_headers.py
+++ b/tests/web_api/basic_case/test_headers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from nose.tools import assert_equal
 from . import distribution, subject
 

--- a/tests/web_api/basic_case/test_headers.py
+++ b/tests/web_api/basic_case/test_headers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from nose.tools import assert_equal
 from . import distribution, subject
 

--- a/tests/web_api/basic_case/test_helpers.py
+++ b/tests/web_api/basic_case/test_helpers.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import os
 
 from nose.tools import assert_equal
@@ -36,19 +37,19 @@ def test_transform_values_history_with_stop_date():
 
 
 def test_get_value():
-    values = {u'2013-01-01': 0.03, u'2017-01-01': 0.02, u'2015-01-01': 0.04}
+    values = {'2013-01-01': 0.03, '2017-01-01': 0.02, '2015-01-01': 0.04}
 
-    assert_equal(get_value(u'2013-01-01', values), 0.03)
-    assert_equal(get_value(u'2014-01-01', values), 0.03)
-    assert_equal(get_value(u'2015-02-01', values), 0.04)
-    assert_equal(get_value(u'2016-12-31', values), 0.04)
-    assert_equal(get_value(u'2017-01-01', values), 0.02)
-    assert_equal(get_value(u'2018-01-01', values), 0.02)
+    assert_equal(get_value('2013-01-01', values), 0.03)
+    assert_equal(get_value('2014-01-01', values), 0.03)
+    assert_equal(get_value('2015-02-01', values), 0.04)
+    assert_equal(get_value('2016-12-31', values), 0.04)
+    assert_equal(get_value('2017-01-01', values), 0.02)
+    assert_equal(get_value('2018-01-01', values), 0.02)
 
 
 def test_get_value_with_none():
-    values = {u'2015-01-01': 0.04, u'2017-01-01': None}
+    values = {'2015-01-01': 0.04, '2017-01-01': None}
 
-    assert_equal(get_value(u'2016-12-31', values), 0.04)
-    assert_equal(get_value(u'2017-01-01', values), None)
-    assert_equal(get_value(u'2011-01-01', values), None)
+    assert_equal(get_value('2016-12-31', values), 0.04)
+    assert_equal(get_value('2017-01-01', values), None)
+    assert_equal(get_value('2011-01-01', values), None)

--- a/tests/web_api/basic_case/test_helpers.py
+++ b/tests/web_api/basic_case/test_helpers.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import os
 
 from nose.tools import assert_equal

--- a/tests/web_api/basic_case/test_parameters.py
+++ b/tests/web_api/basic_case/test_parameters.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from http.client import OK, NOT_FOUND
 import json
 from nose.tools import assert_equal

--- a/tests/web_api/basic_case/test_parameters.py
+++ b/tests/web_api/basic_case/test_parameters.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from http.client import OK, NOT_FOUND
 import json
 from nose.tools import assert_equal
@@ -17,8 +18,8 @@ def test_return_code():
 def test_response_data():
     parameters = json.loads(parameters_response.data.decode('utf-8'))
     assert_equal(
-        parameters[u'taxes.income_tax_rate'],
-        {u'description': u'Income tax rate'}
+        parameters['taxes.income_tax_rate'],
+        {'description': 'Income tax rate'}
         )
 
 
@@ -40,9 +41,9 @@ def test_parameter_values():
     assert_equal(
         parameter,
         {
-            u'id': u'taxes.income_tax_rate',
-            u'description': u'Income tax rate',
-            u'values': {u'2015-01-01': 0.15, u'2014-01-01': 0.14, u'2013-01-01': 0.13, u'2012-01-01': 0.16}
+            'id': 'taxes.income_tax_rate',
+            'description': 'Income tax rate',
+            'values': {'2015-01-01': 0.15, '2014-01-01': 0.14, '2013-01-01': 0.13, '2012-01-01': 0.16}
             }
         )
 
@@ -53,9 +54,9 @@ def test_stopped_parameter_values():
     assert_equal(
         parameter,
         {
-            u'id': u'benefits.housing_allowance',
-            u'description': u'Housing allowance amount (as a fraction of the rent)',
-            u'values': {u'2016-12-01': None, u'2010-01-01': 0.25}
+            'id': 'benefits.housing_allowance',
+            'description': 'Housing allowance amount (as a fraction of the rent)',
+            'values': {'2016-12-01': None, '2010-01-01': 0.25}
             }
         )
 
@@ -66,14 +67,14 @@ def test_bareme():
     assert_equal(
         parameter,
         {
-            u'id': u'taxes.social_security_contribution',
-            u'description': u'Social security contribution tax scale',
-            u'brackets': {
-                u'2013-01-01': {"0.0": 0.03, "12000.0": 0.10},
-                u'2014-01-01': {"0.0": 0.03, "12100.0": 0.10},
-                u'2015-01-01': {"0.0": 0.04, "12200.0": 0.12},
-                u'2016-01-01': {"0.0": 0.04, "12300.0": 0.12},
-                u'2017-01-01': {"0.0": 0.02, "6000.0": 0.06, "12400.0": 0.12},
+            'id': 'taxes.social_security_contribution',
+            'description': 'Social security contribution tax scale',
+            'brackets': {
+                '2013-01-01': {"0.0": 0.03, "12000.0": 0.10},
+                '2014-01-01': {"0.0": 0.03, "12100.0": 0.10},
+                '2015-01-01': {"0.0": 0.04, "12200.0": 0.12},
+                '2016-01-01': {"0.0": 0.04, "12300.0": 0.12},
+                '2017-01-01': {"0.0": 0.02, "6000.0": 0.06, "12400.0": 0.12},
                 }
             }
         )
@@ -85,9 +86,9 @@ def test_bareme():
 #     assert_equal(
 #         parameter,
 #         {
-#             u'id': u'contribution_sociale.crds.activite.abattement',
-#             u'description': u"Abattement sur les revenus d\'activité, du chômage et des préretraites",
-#             u'brackets': {
+#             'id': 'contribution_sociale.crds.activite.abattement',
+#             'description': "Abattement sur les revenus d\'activité, du chômage et des préretraites",
+#             'brackets': {
 #                 "1998-01-01": {"0.0": 0.05},
 #                 "2005-01-01": {"0.0": 0.03},
 #                 "2011-01-01": {"0.0": 0.03, "4.0": 0},

--- a/tests/web_api/basic_case/test_spec.py
+++ b/tests/web_api/basic_case/test_spec.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import json
 from http.client import OK
 

--- a/tests/web_api/basic_case/test_spec.py
+++ b/tests/web_api/basic_case/test_spec.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import json
 from http.client import OK
 

--- a/tests/web_api/basic_case/test_trace.py
+++ b/tests/web_api/basic_case/test_trace.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 import json
 
 from nose.tools import assert_equal, assert_is_instance

--- a/tests/web_api/basic_case/test_trace.py
+++ b/tests/web_api/basic_case/test_trace.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import json
 
 from nose.tools import assert_equal, assert_is_instance

--- a/tests/web_api/basic_case/test_variables.py
+++ b/tests/web_api/basic_case/test_variables.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from http.client import OK, NOT_FOUND
 import json
 from nose.tools import assert_equal, assert_regexp_matches, assert_in, assert_is_none, assert_not_in

--- a/tests/web_api/basic_case/test_variables.py
+++ b/tests/web_api/basic_case/test_variables.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from http.client import OK, NOT_FOUND
 import json
 from nose.tools import assert_equal, assert_regexp_matches, assert_in, assert_is_none, assert_not_in
@@ -23,8 +24,8 @@ def test_return_code():
 def test_response_data():
     variables = json.loads(variables_response.data.decode('utf-8'))
     assert_equal(
-        variables[u'birth'],
-        {u'description': u'Birth date'}
+        variables['birth'],
+        {'description': 'Birth date'}
         )
 
 
@@ -50,12 +51,12 @@ def check_input_variable_value(key, expected_value):
 
 def test_input_variable_value():
     expected_values = {
-        u'description': u'Birth date',
-        u'valueType': u'Date',
-        u'defaultValue': u'1970-01-01',
-        u'definitionPeriod': u'ETERNITY',
-        u'entity': u'person',
-        u'references': [u'https://en.wiktionary.org/wiki/birthdate'],
+        'description': 'Birth date',
+        'valueType': 'Date',
+        'defaultValue': '1970-01-01',
+        'definitionPeriod': 'ETERNITY',
+        'entity': 'person',
+        'references': ['https://en.wiktionary.org/wiki/birthdate'],
         }
 
     for key, expected_value in expected_values.items():
@@ -80,11 +81,11 @@ def check_variable_value(key, expected_value):
 
 def test_variable_value():
     expected_values = {
-        u'description': u'Income tax',
-        u'valueType': u'Float',
-        u'defaultValue': 0,
-        u'definitionPeriod': u'MONTH',
-        u'entity': u'person',
+        'description': 'Income tax',
+        'valueType': 'Float',
+        'defaultValue': 0,
+        'definitionPeriod': 'MONTH',
+        'entity': 'person',
         }
 
     for key, expected_value in expected_values.items():
@@ -121,10 +122,10 @@ def test_variable_with_enum():
     assert_equal(variable['defaultValue'], 'tenant')
     assert_in('possibleValues', variable.keys())
     assert_equal(variable['possibleValues'], {
-        u'free_lodger': u'Free lodger',
-        u'homeless': u'Homeless',
-        u'owner': u'Owner',
-        u'tenant': u'Tenant'})
+        'free_lodger': 'Free lodger',
+        'homeless': 'Homeless',
+        'owner': 'Owner',
+        'tenant': 'Tenant'})
 
 
 dated_variable_response = subject.get('/variable/basic_income')

--- a/tests/web_api/basic_case/test_variables.py
+++ b/tests/web_api/basic_case/test_variables.py
@@ -14,7 +14,7 @@ def assert_items_equal(x, y):
 # /variables
 
 variables_response = subject.get('/variables')
-GITHUB_URL_REGEX = '^https://github\.com/openfisca/openfisca-country-template/blob/\d+\.\d+\.\d+((.dev|rc)\d+)?/openfisca_country_template/variables/(.)+\.py#L\d+-L\d+$'
+GITHUB_URL_REGEX = '^https://github\.com/openfisca/country-template/blob/\d+\.\d+\.\d+((.dev|rc)\d+)?/openfisca_country_template/variables/(.)+\.py#L\d+-L\d+$'
 
 
 def test_return_code():

--- a/tests/web_api/case_with_extension/test_extensions.py
+++ b/tests/web_api/case_with_extension/test_extensions.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from http.client import OK
 from nose.tools import assert_equal
 from openfisca_core.scripts import build_tax_benefit_system

--- a/tests/web_api/case_with_extension/test_extensions.py
+++ b/tests/web_api/case_with_extension/test_extensions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function, division, absolute_import
 from http.client import OK
 from nose.tools import assert_equal
 from openfisca_core.scripts import build_tax_benefit_system


### PR DESCRIPTION
Minor Change without impacts for reusers:
  - Make code more Python3-like by backporting unicode litterals.
  - With this backport, all strings are by default unicodes.
  - The `u` prefix for strings should *not* be used anymore.
  - Each new module must start by `from __future__ import unicode_literals` for the backport to be effective.

### Rationale

We've paid the price for compatibility with Python 3, let's start to enjoy some of its  benefits 🙂.

The general idea is to:
- Opportunistically apply Python-3 standards to our codebase
- Rely on `__future__` (Python builtins backports) and `future` (extra library) to keep compatibility with Python 2
- When we drop compatibility with Python 2, we'll mostly just have  imports to remove

See this talk: https://www.youtube.com/watch?v=klaGx9Q_SOA 