### PR TITLE
Keep float as float32 when outputting them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,56 @@
 
 ### 23.5.1 [#708](https://github.com/openfisca/openfisca-core/pull/708)
 
-- Addresses the typecasting from `float32` to `float64` made when outputing numbers in the API and in `openfisca-run-test`.
-- The typecasting added random decimal numbers that brought no extra value to the users.
+- Correct the output of results that showed random decimal numbers at the end of `floats`.
+- Address the typecasting from `float32` to `float64` made when outputing numbers in the Web API and in `openfisca-run-test`.
+
+For the following situation :
+
+Before:
+```json
+{
+  "households": {
+    "smith": {
+      "parents": [
+        "bob"
+      ]
+    }
+  }, 
+  "persons": {
+    "bob": {
+      "salary": {
+        "2017-01": 1000
+      }, 
+      "tax_incentive": {
+        "2017-01": 333.3333435058594
+      }
+    }
+  }
+}
+```
+
+After:
+```json
+{
+  "households": {
+    "smith": {
+      "parents": [
+        "bob"
+      ]
+    }
+  }, 
+  "persons": {
+    "bob": {
+      "salary": {
+        "2017-01": 1000
+      }, 
+      "tax_incentive": {
+        "2017-01": 333.33334
+      }
+    }
+  }
+}
+```
 
 ## 23.5.0 [#705](https://github.com/openfisca/openfisca-core/pull/705)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 23.5.1 [#708](https://github.com/openfisca/openfisca-core/pull/708)
+
+- Addresses the typecasting from `float32` to `float64` made when outputing numbers in the API and in `openfisca-run-test`.
+- The typecasting added random decimal numbers that brought no extra value to the users.
+
 ## 23.5.0 [#705](https://github.com/openfisca/openfisca-core/pull/705)
 
 * On the Web API, expose a welcome message (with a 300 code) on `/` instead of a 404 error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,55 +2,23 @@
 
 ### 23.5.1 [#708](https://github.com/openfisca/openfisca-core/pull/708)
 
-- Correct the output of results that showed random decimal numbers at the end of `floats`.
-- Address the typecasting from `float32` to `float64` made when outputing numbers in the Web API and in `openfisca-run-test`.
+- Remove the irrelevant decimals that were added at the end of `float` results in the Web API and the test runner.
+  - These decimals were added while converting a Numpy `float32` to a regular 64-bits Python `float`.
 
-For the following situation :
+For instance, the former Web API response extract:
 
-Before:
 ```json
-{
-  "households": {
-    "smith": {
-      "parents": [
-        "bob"
-      ]
-    }
-  }, 
-  "persons": {
-    "bob": {
-      "salary": {
-        "2017-01": 1000
-      }, 
-      "tax_incentive": {
+  "tax_incentive": {
         "2017-01": 333.3333435058594
       }
-    }
-  }
-}
 ```
 
-After:
+becomes:
+
 ```json
-{
-  "households": {
-    "smith": {
-      "parents": [
-        "bob"
-      ]
-    }
-  }, 
-  "persons": {
-    "bob": {
-      "salary": {
-        "2017-01": 1000
-      }, 
-      "tax_incentive": {
+"tax_incentive": {
         "2017-01": 333.33334
       }
-    }
-  }
-}
 ```
 
 ## 23.5.0 [#705](https://github.com/openfisca/openfisca-core/pull/705)

--- a/openfisca_core/tools/__init__.py
+++ b/openfisca_core/tools/__init__.py
@@ -38,9 +38,8 @@ def assert_near(value, target_value, absolute_error_margin = None, message = '',
             else:
                 assert (target_value == value.decode()).all(), "Expected {}, got {}".format(target_value, value)
         else:
-
-            target_value = np.array(target_value).astype(float)
-            value = np.array(value).astype(float)
+            target_value = np.array(target_value).astype(np.float32)
+            value = np.array(value).astype(np.float32)
             diff = abs(target_value - value)
 
             if absolute_error_margin is not None:

--- a/openfisca_web_api_preview/app.py
+++ b/openfisca_web_api_preview/app.py
@@ -138,6 +138,8 @@ def create_app(tax_benefit_system,
 
                 if variable.value_type == Enum:
                     entity_result = result.decode()[entity_index].name
+                elif variable.value_type == float:
+                    entity_result = float(str(result[entity_index]))  # To turn the float32 into a regular float without adding confusing extra decimals. There must be a better way.
                 else:
                     entity_result = result.tolist()[entity_index]
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '23.5.0',
+    version = '23.5.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
Fixes #699 

#### Technical changes
- Addresses the typecasting made when outputing numbers in the API and in `openfisca-run-test` from `float32` to `float64`.
- The typecasting added random decimal numbers that bring no extra value to users.
