### PR TITLE
Revert side-effects of 23.4.0 on  parameters overview route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
+### 23.5.2 [#710](https://github.com/openfisca/openfisca-core/pull/710)
+
+- Revert the undesired side effects of `23.4.0` on the `parameters/` overview route of the Web API
+  - This route now behaves the exact same way than before `23.4.0`
+  - The keys of the `/parameters` JSON object are back to using the `.` notation
+  - Parameter nodes are for now not exposed in the `parameters/` overview (but each of them is exposed in `/parameter/path/to/node`)
+
 ### 23.5.1 [#708](https://github.com/openfisca/openfisca-core/pull/708)
+_Note: this version has been unpublished due to an issue introduced by 23.4.0 in the Web API. Please use 23.5.2 or a more recent version._
 
 - Remove the irrelevant decimals that were added at the end of `float` results in the Web API and the test runner.
   - These decimals were added while converting a Numpy `float32` to a regular 64-bits Python `float`.
@@ -22,6 +30,7 @@ becomes:
 ```
 
 ## 23.5.0 [#705](https://github.com/openfisca/openfisca-core/pull/705)
+_Note: this version has been unpublished due to an issue introduced by 23.4.0 in the Web API. Please use 23.5.2 or a more recent version._
 
 * On the Web API, expose a welcome message (with a 300 code) on `/` instead of a 404 error.
 
@@ -55,10 +64,12 @@ HTTP/1.1 300 MULTIPLE CHOICES
 
 
 ### 23.4.1 [#700](https://github.com/openfisca/openfisca-core/pull/700)
+_Note: this version has been unpublished due to an issue introduced by 23.4.0 in the Web API. Please use 23.5.2 or a more recent version._
 
 * Fix API source IP detection through proxies.
 
 ## 23.4.0 [#694](https://github.com/openfisca/openfisca-core/pull/694)
+_Note: this version has been unpublished as it introduced an issue in the Web API. Please use 23.5.2 or a more recent version._
 
 * Use `/` rather than `.` in the path to access a parameter:
   - For instance `/parameter/benefits.basic_income` becomes `/parameter/benefits/basic_income`

--- a/openfisca_web_api_preview/app.py
+++ b/openfisca_web_api_preview/app.py
@@ -69,7 +69,7 @@ def create_app(tax_benefit_system,
 
     @app.route('/parameters')
     def get_parameters():
-        return jsonify(data['parameters_description'])
+        return jsonify(data['parameters_overview'])
 
     @app.route('/parameter/<path:parameter_id>')
     def get_parameter(parameter_id):
@@ -84,7 +84,7 @@ def create_app(tax_benefit_system,
 
     @app.route('/variables')
     def get_variables():
-        return jsonify(data['variables_description'])
+        return jsonify(data['variables_overview'])
 
     @app.route('/variable/<id>')
     def get_variable(id):

--- a/openfisca_web_api_preview/loader/__init__.py
+++ b/openfisca_web_api_preview/loader/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals, print_function, division, absolute_import
-from openfisca_web_api_preview.loader.parameters import build_parameters
+from openfisca_web_api_preview.loader.parameters import build_parameters, build_parameters_overview
 from openfisca_web_api_preview.loader.variables import build_variables
 from openfisca_web_api_preview.loader.spec import build_openAPI_specification
 
@@ -23,8 +23,8 @@ def build_data(tax_benefit_system):
         'country_package_metadata': tax_benefit_system.get_package_metadata(),
         'openAPI_spec': openAPI_spec,
         'parameters': parameters,
-        'parameters_description': extract_description(parameters),
+        'parameters_overview': build_parameters_overview(parameters),
         'variables': variables,
-        'variables_description': extract_description(variables),
+        'variables_overview': extract_description(variables),
         'host': None  # Will be set by mirroring requests
         }

--- a/openfisca_web_api_preview/loader/parameters.py
+++ b/openfisca_web_api_preview/loader/parameters.py
@@ -101,3 +101,11 @@ def build_parameters(tax_benefit_system, country_package_metadata):
         )
 
     return {parameter['id'].replace('.', '/'): parameter for parameter in api_parameters}
+
+
+def build_parameters_overview(parameters):
+    return {
+        parameter['id']: {'description': parameter['description']}
+        for parameter in parameters.values()
+        if parameter.get('subparams') is None  # For now and for backward compat, don't show nodes in overview
+        }

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Core',
-    version = '23.5.1',
+    version = '23.5.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/web_api/test_parameters.py
+++ b/tests/web_api/test_parameters.py
@@ -19,8 +19,12 @@ def test_return_code():
 def test_response_data():
     parameters = json.loads(parameters_response.data.decode('utf-8'))
     assert_equal(
-        parameters['taxes/income_tax_rate'],
+        parameters['taxes.income_tax_rate'],
         {'description': 'Income tax rate'}
+        )
+    assert_equal(
+        parameters.get('taxes'),
+        None
         )
 
 


### PR DESCRIPTION
Fixes #709

- Revert the undesired side effects of `23.4.0` on the `parameters/` overview route of the Web API
  - This route now behaves the exact same way than before `23.4.0`
  - The keys of the `/parameters` JSON object are back to using the `.` notation
  - Parameter nodes are for now not exposed in the `/parameters` overview (but each of them is exposed in `/parameter/path/to/node`)