### PR TITLE
 Add a `/entities` endpoint to the API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist/
 /tags
 .tags*
 .noseids
+.pytest_cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+### 24.3.0 [#714](https://github.com/openfisca/openfisca-core/pull/714)
+
+- Introduce the `/entities` endpoint for the Web API.
+  - Expose information about the country package's entities, and their roles.
+```json
+{
+            "description": "Household",
+            "documentation": "Household is an example of a group entity. A group entity contains one or more individual·s.[...]",
+            "plural": "households",
+            "roles": {
+                "parent": {
+                    "description": "The one or two adults in charge of the household.",
+                    "max": 2,
+                    "plural": "parents"
+                    },
+                "child": {
+                    "description": "Other individuals living in the household.",
+                    "plural": "children"
+                    }
+                }
+            }
+```
+
 ## 24.2.0 [#712](https://github.com/openfisca/openfisca-core/pull/712)
 
 - Allow to dump and restore a simulation in a directory

--- a/openfisca_web_api/app.py
+++ b/openfisca_web_api/app.py
@@ -113,6 +113,10 @@ def create_app(tax_benefit_system,
             raise abort(404)
         return jsonify(variable)
 
+    @app.route('/entities')
+    def get_entities():
+        return jsonify('hello')
+
     @app.route('/spec')
     def get_spec():
         # Ugly Python2-compatible way

--- a/openfisca_web_api/app.py
+++ b/openfisca_web_api/app.py
@@ -115,7 +115,7 @@ def create_app(tax_benefit_system,
 
     @app.route('/entities')
     def get_entities():
-        return jsonify('hello')
+        return jsonify(data['entities'])
 
     @app.route('/spec')
     def get_spec():

--- a/openfisca_web_api/loader/__init__.py
+++ b/openfisca_web_api/loader/__init__.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals, print_function, division, absolute_impo
 
 from openfisca_web_api.loader.parameters import build_parameters
 from openfisca_web_api.loader.variables import build_variables
+from openfisca_web_api.loader.entities import build_entities
 from openfisca_web_api.loader.spec import build_openAPI_specification
 
 
@@ -18,5 +19,6 @@ def build_data(tax_benefit_system):
         'openAPI_spec': openAPI_spec,
         'parameters': parameters,
         'variables': variables,
+        'entities': build_entities(tax_benefit_system),
         'host': None  # Will be set by mirroring requests
         }

--- a/openfisca_web_api/loader/entities.py
+++ b/openfisca_web_api/loader/entities.py
@@ -5,7 +5,8 @@ from __future__ import unicode_literals, print_function, division, absolute_impo
 def build_entities(tax_benefit_system):
     entities = {
         entity.key: {
-            "plural": entity.plural
+            "plural": entity.plural,
+            "description": entity.doc
         }
         for entity in tax_benefit_system.entities
     }

--- a/openfisca_web_api/loader/entities.py
+++ b/openfisca_web_api/loader/entities.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals, print_function, division, absolute_import
+
+def build_entities(tax_benefit_system):
+    entities = {
+        entity.key: {
+            "plural": entity.plural
+        }
+        for entity in tax_benefit_system.entities
+    }
+    return entities
+
+

--- a/openfisca_web_api/loader/entities.py
+++ b/openfisca_web_api/loader/entities.py
@@ -20,7 +20,7 @@ def build_entity(entity):
         'description': to_unicode(entity.label),
         'documentation': formatted_doc
         }
-    if hasattr(entity, 'roles'):
+    if not entity.is_person:
         formatted_entity['roles'] = {
             role.key: build_role(role)
             for role in entity.roles
@@ -39,5 +39,4 @@ def build_role(role):
     if role.subroles:
         formatted_role['max'] = len(role.subroles)
 
-    formatted_role['mandatory'] = True if formatted_role.get('max') else False
     return formatted_role

--- a/openfisca_web_api/loader/entities.py
+++ b/openfisca_web_api/loader/entities.py
@@ -14,29 +14,29 @@ def build_entities(tax_benefit_system):
 
 def build_entity(entity):
 
-    entity_formated = {
+    formatted_entity = {
         'plural': entity.plural,
-        'description': to_unicode(entity.doc)
+        'description': to_unicode(entity.label),
+        'documentation': to_unicode(entity.doc)
         }
     if hasattr(entity, 'roles'):
-        entity_formated['roles'] = \
-            {
+        formatted_entity['roles'] = {
             role.key: build_role(role)
             for role in entity.roles
             }
-    return entity_formated
+    return formatted_entity
 
 
 def build_role(role):
-    role_formated = {
+    formatted_role = {
         'plural': role.plural,
         'description': role.doc
         }
 
     if role.max:
-        role_formated['max'] = role.max
+        formatted_role['max'] = role.max
     if role.subroles:
-        role_formated['max'] = len(role.subroles)
+        formatted_role['max'] = len(role.subroles)
 
-    role_formated['mandatory'] = True if role_formated.get('max') else False
-    return role_formated
+    formatted_role['mandatory'] = True if formatted_role.get('max') else False
+    return formatted_role

--- a/openfisca_web_api/loader/entities.py
+++ b/openfisca_web_api/loader/entities.py
@@ -2,14 +2,40 @@
 
 from __future__ import unicode_literals, print_function, division, absolute_import
 
+
 def build_entities(tax_benefit_system):
     entities = {
-        entity.key: {
-            "plural": entity.plural,
-            "description": entity.doc
-        }
+        entity.key: build_entity(entity)
         for entity in tax_benefit_system.entities
-    }
+        }
     return entities
 
 
+def build_entity(entity):
+
+    entity_formated = {
+        "description": entity.doc,
+        'plural': entity.plural,
+        }
+    if hasattr(entity, 'roles'):
+        entity_formated['roles'] = \
+            {
+            role.key: build_role(role)
+            for role in entity.roles
+            }
+    return entity_formated
+
+
+def build_role(role):
+    role_formated = {
+        'plural': role.plural,
+        'description': role.doc
+        }
+
+    if role.max:
+        role_formated['max'] = role.max
+    if role.subroles:
+        role_formated['max'] = len(role.subroles)
+
+    role_formated['mandatory'] = True if role_formated.get('max') else False
+    return role_formated

--- a/openfisca_web_api/loader/entities.py
+++ b/openfisca_web_api/loader/entities.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals, print_function, division, absolute_import
+from openfisca_core.commons import to_unicode
 
 
 def build_entities(tax_benefit_system):
@@ -14,8 +15,8 @@ def build_entities(tax_benefit_system):
 def build_entity(entity):
 
     entity_formated = {
-        "description": entity.doc,
         'plural': entity.plural,
+        'description': to_unicode(entity.doc)
         }
     if hasattr(entity, 'roles'):
         entity_formated['roles'] = \

--- a/openfisca_web_api/loader/entities.py
+++ b/openfisca_web_api/loader/entities.py
@@ -13,11 +13,12 @@ def build_entities(tax_benefit_system):
 
 
 def build_entity(entity):
+    formatted_doc = to_unicode(entity.doc.strip())
 
     formatted_entity = {
         'plural': entity.plural,
         'description': to_unicode(entity.label),
-        'documentation': to_unicode(entity.doc)
+        'documentation': formatted_doc
         }
     if hasattr(entity, 'roles'):
         formatted_entity['roles'] = {

--- a/openfisca_web_api/openAPI.yml
+++ b/openfisca_web_api/openAPI.yml
@@ -16,13 +16,18 @@ tags:
   - name: "Parameters"
     description: "A parameter is a numeric property of the legislation that can evolve over time."
     externalDocs:
-      description: "Parameter official documentation"
+      description: "Parameters documentation"
       url: "https://openfisca.org/doc/parameters"
   - name: "Variables"
     description: "A variable depends on a person, or an entity (e.g. zip code, salary, income tax)."
     externalDocs:
-      description: "Variable official documentation"
+      description: "Variables documentation"
       url: "https://openfisca.org/doc/variables"
+  - name: "Entities"
+    description: "An entity is a person of a group of individuals (such as a household)."
+    externalDocs:
+      description: "Entities documentation"
+      url: "https://openfisca.org/doc/person,_entities,_role.html"
   - name: "Calculations"
   - name: "Documentation"
 paths:
@@ -138,6 +143,21 @@ paths:
           description: "The requested variable does not exist"
           headers:
             $ref: '#/commons/Headers'
+  /entities:
+    get:
+      tags:
+      - "Entities"
+      summary: "List all available Entities"
+      operationId: "getVariables"
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "The list of the entities as well as their information is sent back in the response body"
+          headers:
+            $ref: '#/commons/Headers'
+          schema:
+            $ref: "#/definitions/Entities"
   /trace:
     post:
       summary: "Explore a simulation's steps in details."
@@ -318,6 +338,28 @@ definitions:
       type: "number"
       format: "float"
 
+  Entities:
+    type: "object"
+    properties:
+      description:
+        type: "string"
+      documentation:
+        type: "string"
+      plural:
+        type: "string"
+      roles:
+        type: "object"
+        additionalProperties:
+         $ref: "#/definitions/Roles"
+  Roles:
+    type: "object"
+    properties:
+      description:
+        type: "string"
+      max:
+        type: "integer"
+      plural:
+        type: "string"
   SituationInput:
     example:
       individus:

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.2.0',
+    version = '24.3.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/web_api/test_entities.py
+++ b/tests/web_api/test_entities.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals, print_function, division, absolute_import
 from http.client import OK
 from nose.tools import assert_equal
+import json
 from . import subject
 
 
@@ -15,3 +16,9 @@ def test_return_code():
     assert_equal(entities_response.status_code, OK)
 
 
+def test_response_data():
+    entities = json.loads(entities_response.data.decode('utf-8'))
+    assert_equal(
+        entities['household'],
+        {'plural': 'households'}
+        )

--- a/tests/web_api/test_entities.py
+++ b/tests/web_api/test_entities.py
@@ -18,7 +18,24 @@ def test_return_code():
 
 def test_response_data():
     entities = json.loads(entities_response.data.decode('utf-8'))
+    test_description = '''
+Household is an example of a group entity.
+A group entity contains one or more individual·s.
+Each individual in a group entity has a role (e.g. parent or children). Some roles can only be held by a limited number of individuals (e.g. a 'first_parent' can only be held by one individual), while others can have an unlimited number of individuals (e.g. 'children').
+
+Example:
+Housing variables (e.g. housing_tax') are usually defined for a group entity such as 'Household'.
+
+Usage:
+Check the number of individuals of a specific role (e.g. check if there is a 'second_parent' with household.nb_persons(Household.SECOND_PARENT)).
+Calculate a variable applied to each individual of the group entity (e.g. calculate the 'salary' of each member of the 'Household' with salaries = household.members('salary', period = MONTH); sum_salaries = household.sum(salaries)).
+
+For more information, see: https://openfisca.org/doc/coding-the-legislation/50_entities.html
+'''
     assert_equal(
         entities['household'],
-        {'plural': 'households'}
+        {
+            'description': test_description,
+            'plural': 'households'
+         }
         )

--- a/tests/web_api/test_entities.py
+++ b/tests/web_api/test_entities.py
@@ -30,12 +30,10 @@ def test_response_data():
             'roles': {
                 'child': {
                     'description': 'Other individuals living in the household.',
-                    'mandatory': False,
                     'plural': 'children'
                 },
                 'parent': {
                     'description': 'The one or two adults in charge of the household.',
-                    'mandatory': False,
                     'max': 2,
                     'plural': "parents"
                     }

--- a/tests/web_api/test_entities.py
+++ b/tests/web_api/test_entities.py
@@ -19,7 +19,7 @@ def test_return_code():
 
 def test_response_data():
     entities = json.loads(entities_response.data.decode('utf-8'))
-    test_documentation = to_unicode(openfisca_country_template.entities.Household.doc)
+    test_documentation = to_unicode(openfisca_country_template.entities.Household.doc.strip())
 
     assert_equal(
         entities['household'],

--- a/tests/web_api/test_entities.py
+++ b/tests/web_api/test_entities.py
@@ -4,8 +4,9 @@ from __future__ import unicode_literals, print_function, division, absolute_impo
 from http.client import OK
 from nose.tools import assert_equal
 import json
+import openfisca_country_template
+from openfisca_core.commons import to_unicode
 from . import subject
-
 
 entities_response = subject.get('/entities')
 
@@ -18,20 +19,8 @@ def test_return_code():
 
 def test_response_data():
     entities = json.loads(entities_response.data.decode('utf-8'))
-    test_documentation = '''
-Household is an example of a group entity.
-A group entity contains one or more individual·s.
-Each individual in a group entity has a role (e.g. parent or children). Some roles can only be held by a limited number of individuals (e.g. a 'first_parent' can only be held by one individual), while others can have an unlimited number of individuals (e.g. 'children').
+    test_documentation = to_unicode(openfisca_country_template.entities.Household.doc)
 
-Example:
-Housing variables (e.g. housing_tax') are usually defined for a group entity such as 'Household'.
-
-Usage:
-Check the number of individuals of a specific role (e.g. check if there is a 'second_parent' with household.nb_persons(Household.SECOND_PARENT)).
-Calculate a variable applied to each individual of the group entity (e.g. calculate the 'salary' of each member of the 'Household' with salaries = household.members('salary', period = MONTH); sum_salaries = household.sum(salaries)).
-
-For more information, see: https://openfisca.org/doc/coding-the-legislation/50_entities.html
-'''
     assert_equal(
         entities['household'],
         {
@@ -39,16 +28,16 @@ For more information, see: https://openfisca.org/doc/coding-the-legislation/50_e
             'documentation': test_documentation,
             'plural': 'households',
             'roles': {
+                'child': {
+                    'description': 'Other individuals living in the household.',
+                    'mandatory': False,
+                    'plural': 'children'
+                },
                 'parent': {
                     'description': 'The one or two adults in charge of the household.',
                     'mandatory': False,
                     'max': 2,
                     'plural': "parents"
-                    },
-                'child': {
-                    'description': 'Other individuals living in the household.',
-                    'mandatory': False,
-                    'plural': 'children'
                     }
                 }
             }

--- a/tests/web_api/test_entities.py
+++ b/tests/web_api/test_entities.py
@@ -31,7 +31,7 @@ def test_response_data():
                 'child': {
                     'description': 'Other individuals living in the household.',
                     'plural': 'children'
-                },
+                    },
                 'parent': {
                     'description': 'The one or two adults in charge of the household.',
                     'max': 2,

--- a/tests/web_api/test_entities.py
+++ b/tests/web_api/test_entities.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals, print_function, division, absolute_import
+from http.client import OK
+from nose.tools import assert_equal
+from . import subject
+
+
+entities_response = subject.get('/entities')
+
+# /entities
+
+
+def test_return_code():
+    assert_equal(entities_response.status_code, OK)
+
+

--- a/tests/web_api/test_entities.py
+++ b/tests/web_api/test_entities.py
@@ -18,7 +18,7 @@ def test_return_code():
 
 def test_response_data():
     entities = json.loads(entities_response.data.decode('utf-8'))
-    test_description = '''
+    test_documentation = '''
 Household is an example of a group entity.
 A group entity contains one or more individual·s.
 Each individual in a group entity has a role (e.g. parent or children). Some roles can only be held by a limited number of individuals (e.g. a 'first_parent' can only be held by one individual), while others can have an unlimited number of individuals (e.g. 'children').
@@ -35,7 +35,21 @@ For more information, see: https://openfisca.org/doc/coding-the-legislation/50_e
     assert_equal(
         entities['household'],
         {
-            'description': test_description,
-            'plural': 'households'
-         }
+            'description': 'Household',
+            'documentation': test_documentation,
+            'plural': 'households',
+            'roles': {
+                'parent': {
+                    'description': 'The one or two adults in charge of the household.',
+                    'mandatory': False,
+                    'max': 2,
+                    'plural': "parents"
+                    },
+                'child': {
+                    'description': 'Other individuals living in the household.',
+                    'mandatory': False,
+                    'plural': 'children'
+                    }
+                }
+            }
         )

--- a/tests/web_api/test_spec.py
+++ b/tests/web_api/test_spec.py
@@ -31,6 +31,7 @@ def test_paths():
         "/parameters",
         "/variable/{variableID}",
         "/variables",
+        "/entities",
         "/trace",
         "/calculate",
         "/spec"]


### PR DESCRIPTION
Fixes #561 
#### New features
- Get information on a country package's entities, and their roles
- Introduce the `/entities` endpoint for the Web API
```json
{
            "description": "[...]",
            "plural": "households",
            "roles": {
                "parent": {
                    "description": "The one or two adults in charge of the household.",
                    "mandatory": "true",
                    "max": 2,
                    "plural": "parents"
                    },
                "child": {
                    "description": "Other individuals living in the household.",
                    "mandatory": "false",
                    "plural": "children"
                    }
                }
            }
```
