### PR TITLE
Add editorial content on parameter and variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist/
 .tags*
 .noseids
 .pytest_cache
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 24.4.0 [#717](https://github.com/openfisca/openfisca-core/pull/717)
+
+- User can add general documentation on parameters and variables
+  - Introduce `Parameter.documentation` and `Variable.documentation` attributes
+- User can access `documentation` through Web API
+    - on `/variable` leafs as `/variable/housing_allowance`
+    - on `/variable` formulas for formulas docstrings
+    - on `/parameter` leafs as `/parameter/benefits/housing_allowance` 
+
+- `/variable/housing_allowance` example:
+  
+      ```
+      {
+        "description": "Housing allowance",
+        "documentation": "This allowance was introduced on the 1st of Jan 1980.\nIt needs the 'rent' value (same month) but doesn't care about the 'housing_occupancy_status'.",
+        "entity": "household",
+        "formulas": {
+          "1980-01-01": {
+            "content": "def formula_1980(household, period, parameters):\n    '''This is my specific life statement.'''\n    return     household('rent', period) * parameters(period).benefits.housing_allowance\n",
+            "documentation": "This is my specific life statement.",
+            "source": "https://github.com/openfisca/country-template/blob/3.3.0/openfisca_country_template/variables/benefits.py#L47-L49"
+          },
+          "2016-12-01": null
+        },
+        "id": "housing_allowance",
+        (...)
+      }
+      ```
+
 ### 24.3.2 [#727](https://github.com/openfisca/openfisca-core/pull/727)
 
 - Add a style formatter that follows community code conventions
@@ -52,7 +81,7 @@ from openfisca_core.tools.simulation_dumper import restore_simulation
 simulation = restore_simulation('/path/to/directory', tax_benefit_system)
 ```
 
-## 24.1.0 [#713](https://github.com/openfisca/openfisca-core/pull/713)
+### 24.1.0 [#713](https://github.com/openfisca/openfisca-core/pull/713)
 
 - Enhance navigation within the Openfisca Web API.
 - Provides a direct link to individual parameters and variables from the `/parameters` and `/variables` routes.
@@ -82,6 +111,7 @@ becomes:
         },
     ...
 ```
+
 ### 24.0.1 [#711](https://github.com/openfisca/openfisca-core/pull/711)
 
 - Fix spelling in warning about libyaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,17 @@
 
 ## 24.4.0 [#717](https://github.com/openfisca/openfisca-core/pull/717)
 
-- In python, the user can add multiline documentation on parameters and variables
+- In Python, allow multiline documentation on parameters and variables
   - Introduce `documentation` attribute on `ParameterNode`, `Parameter` and `Variable` classes
 
-- Through Web API, the user can access a multiline `documentation` attribute on parameters, variables and variables' formulas
+- In the Web API, expose this documentation as a `documentation` property for parameters, variables and variables' formulas
     - on `/parameter` nodes as `/parameter/benefits`
       > = python `ParameterNode.documentation`  
-      > = yaml parameter node (`index.yaml`) `documentation` string attribute
+      > = YAML parameter node (`index.yaml`) `documentation` string attribute
     - on `/parameter` leafs as `/parameter/benefits/housing_allowance`
       > = python `Parameter.documentation`  
-      > = yaml parameter `documentation` string attribute
-    - on `/variable` leafs as `/variable/housing_allowance`
+      > = YAML parameter `documentation` string attribute
+    - on `/variable` as `/variable/housing_allowance`
       > = python `Variable.documentation`
     - on every `/variable` leaf formula
       > = python `Variable` formula **docstring**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,32 +2,20 @@
 
 ## 24.4.0 [#717](https://github.com/openfisca/openfisca-core/pull/717)
 
-- User can add general documentation on parameters and variables
-  - Introduce `Parameter.documentation` and `Variable.documentation` attributes
-- User can access `documentation` through Web API
-    - on `/variable` leafs as `/variable/housing_allowance`
-    - on `/variable` formulas for formulas docstrings
-    - on `/parameter` leafs as `/parameter/benefits/housing_allowance` 
+- In python, the user can add multiline documentation on parameters and variables
+  - Introduce `documentation` attribute on `ParameterNode`, `Parameter` and `Variable` classes
 
-- `/variable/housing_allowance` example:
-  
-      ```
-      {
-        "description": "Housing allowance",
-        "documentation": "This allowance was introduced on the 1st of Jan 1980.\nIt needs the 'rent' value (same month) but doesn't care about the 'housing_occupancy_status'.",
-        "entity": "household",
-        "formulas": {
-          "1980-01-01": {
-            "content": "def formula_1980(household, period, parameters):\n    '''This is my specific life statement.'''\n    return     household('rent', period) * parameters(period).benefits.housing_allowance\n",
-            "documentation": "This is my specific life statement.",
-            "source": "https://github.com/openfisca/country-template/blob/3.3.0/openfisca_country_template/variables/benefits.py#L47-L49"
-          },
-          "2016-12-01": null
-        },
-        "id": "housing_allowance",
-        (...)
-      }
-      ```
+- Through Web API, the user can access a multiline `documentation` attribute on parameters, variables and variables' formulas
+    - on `/parameter` nodes as `/parameter/benefits`
+      > = python `ParameterNode.documentation`  
+      > = yaml parameter node (`index.yaml`) `documentation` string attribute
+    - on `/parameter` leafs as `/parameter/benefits/housing_allowance`
+      > = python `Parameter.documentation`  
+      > = yaml parameter `documentation` string attribute
+    - on `/variable` leafs as `/variable/housing_allowance`
+      > = python `Variable.documentation`
+    - on every `/variable` leaf formula
+      > = python `Variable` formula **docstring**
 
 ### 24.3.2 [#727](https://github.com/openfisca/openfisca-core/pull/727)
 

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -91,7 +91,7 @@ class Parameter(object):
         :param string name: Name of the parameter, e.g. "taxes.some_tax.some_param"
         :param dict data: Data loaded from a YAML file.
         :param string file_path: File the parameter was loaded from.
-        :param string documentation: Some documentation describing parameter usage and context.
+        :param string documentation: Documentation describing parameter usage and context.
 
 
         Instantiate a parameter without metadata:
@@ -321,7 +321,7 @@ class ParameterNode(object):
         :param string name: Name of the node, eg "taxes.some_tax".
         :param string directory_path: Directory containing YAML files describing the node.
         :param dict data: Object representing the parameter node. It usually has been extracted from a YAML file.
-        :param string documentation: Some documentation describing parameter node usage and context.
+        :param string documentation: Documentation describing parameter node usage and context.
         :param string file_path: YAML file from which the `data` has been extracted from.
 
 
@@ -367,8 +367,8 @@ class ParameterNode(object):
                     if child_name == 'index':
                         data = _load_yaml_file(child_path)
                         _validate_parameter(self, data, allowed_keys = ['metadata', 'description', 'documentation', 'reference'])
-                        self.description = data.get('description', None)
-                        self.documentation = data.get('documentation', None)
+                        self.description = data.get('description')
+                        self.documentation = data.get('documentation')
                         _set_backward_compatibility_metadata(self, data)
                         self.metadata.update(data.get('metadata', {}))
                     else:
@@ -387,9 +387,8 @@ class ParameterNode(object):
         else:
             self.file_path = file_path
             _validate_parameter(self, data, data_type = dict, allowed_keys = self._allowed_keys)
-            # We allow to set a reference, a description and a documentation for a node.
-            self.description = data.get('description', None)
-            self.documentation = data.get('documentation', None)
+            self.description = data.get('description')
+            self.documentation = data.get('documentation')
             _set_backward_compatibility_metadata(self, data)
             self.metadata.update(data.get('metadata', {}))
             for child_name, child in data.items():

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -121,18 +121,22 @@ class Parameter(object):
         _validate_parameter(self, data, data_type = dict)
         self.description = None
         self.metadata = {}
+        self.documentation = None
         self.values_history = self  # Only for backward compatibility
 
         # Normal parameter declaration: the values are declared under the 'values' key: parse the description and metadata.
         if data.get('values'):
             # 'unit' and 'reference' are only listed here for backward compatibility
-            _validate_parameter(self, data, allowed_keys = set(['values', 'description', 'metadata', 'unit', 'reference']))
+            _validate_parameter(self, data, allowed_keys = set(['values', 'description', 'metadata', 'unit', 'reference', 'documentation']))
             self.description = data.get('description')
+
             _set_backward_compatibility_metadata(self, data)
             self.metadata.update(data.get('metadata', {}))
 
             _validate_parameter(self, data['values'], data_type = dict)
             values = data['values']
+
+            self.documentation = data.get('documentation')
 
         else:  # Simplified parameter declaration: only values are provided
             values = data

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -88,9 +88,10 @@ class Parameter(object):
     """
         A parameter of the legislation. Parameters can change over time.
 
-        :param name: name of the parameter, e.g. "taxes.some_tax.some_param"
-        :param data: Data loaded from a YAML file.
-        :param file_path: File the parameter was loaded from.
+        :param string name: Name of the parameter, e.g. "taxes.some_tax.some_param"
+        :param dict data: Data loaded from a YAML file.
+        :param string file_path: File the parameter was loaded from.
+        :param string documentation: Some documentation describing parameter usage and context.
 
 
         Instantiate a parameter without metadata:
@@ -258,9 +259,9 @@ class ParameterAtInstant(object):
 
     def __init__(self, name, instant_str, data = None, file_path = None, metadata = None):
         """
-            :param name: name of the parameter, e.g. "taxes.some_tax.some_param"
-            :param instant_str: Date of the value in the format `YYYY-MM-DD`.
-            :param data: Data, usually loaded from a YAML file.
+            :param string name: name of the parameter, e.g. "taxes.some_tax.some_param"
+            :param string instant_str: Date of the value in the format `YYYY-MM-DD`.
+            :param dict data: Data, usually loaded from a YAML file.
         """
         self.name = name
         self.instant_str = instant_str
@@ -320,6 +321,7 @@ class ParameterNode(object):
         :param string name: Name of the node, eg "taxes.some_tax".
         :param string directory_path: Directory containing YAML files describing the node.
         :param dict data: Object representing the parameter node. It usually has been extracted from a YAML file.
+        :param string documentation: Some documentation describing parameter node usage and context.
         :param string file_path: YAML file from which the `data` has been extracted from.
 
 
@@ -347,6 +349,7 @@ class ParameterNode(object):
         self.name = name
         self.children = {}
         self.description = None
+        self.documentation = None
         self.file_path = None
         self.metadata = {}
 
@@ -363,8 +366,9 @@ class ParameterNode(object):
 
                     if child_name == 'index':
                         data = _load_yaml_file(child_path)
-                        _validate_parameter(self, data, allowed_keys = ['metadata', 'description', 'reference'])
+                        _validate_parameter(self, data, allowed_keys = ['metadata', 'description', 'documentation', 'reference'])
                         self.description = data.get('description', None)
+                        self.documentation = data.get('documentation', None)
                         _set_backward_compatibility_metadata(self, data)
                         self.metadata.update(data.get('metadata', {}))
                     else:
@@ -383,8 +387,9 @@ class ParameterNode(object):
         else:
             self.file_path = file_path
             _validate_parameter(self, data, data_type = dict, allowed_keys = self._allowed_keys)
-            # We allow to set a reference and a description for a node.
+            # We allow to set a reference, a description and a documentation for a node.
             self.description = data.get('description', None)
+            self.documentation = data.get('documentation', None)
             _set_backward_compatibility_metadata(self, data)
             self.metadata.update(data.get('metadata', {}))
             for child_name, child in data.items():

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -147,6 +147,10 @@ class Variable(object):
        .. py:attribute:: unit
 
            Free text field describing the unit of the variable. Only used as metadata.
+        
+       .. py:attribute:: documentation
+
+           Free multilines text field describing the variable context and usage.
     """
 
     def __init__(self, baseline_variable = None):
@@ -175,7 +179,7 @@ class Variable(object):
         self.reference = self.set(attr, 'reference', setter = self.set_reference)
         self.cerfa_field = self.set(attr, 'cerfa_field', allowed_type = (basestring_type, dict))
         self.unit = self.set(attr, 'unit', allowed_type = basestring_type)
-        self.doc = self.set(attr, 'doc', allowed_type = basestring_type, setter = self.set_doc)
+        self.documentation = self.set(attr, 'documentation', allowed_type = basestring_type, setter = self.set_documentation)
         self.set_input = self.set_set_input(attr.pop('set_input', None))
         self.calculate_output = self.set_calculate_output(attr.pop('calculate_output', None))
         self.is_period_size_independent = self.set(attr, 'is_period_size_independent', allowed_type = bool, default = VALUE_TYPES[self.value_type]['is_period_size_independent'])
@@ -256,9 +260,9 @@ class Variable(object):
 
         return reference
 
-    def set_doc(self, doc):
-        if doc:
-            return textwrap.dedent(doc)
+    def set_documentation(self, documentation):
+        if documentation:
+            return textwrap.dedent(documentation)
 
     def set_base_function(self, base_function):
         if not base_function and self.baseline_variable:

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -175,7 +175,7 @@ class Variable(object):
         self.reference = self.set(attr, 'reference', setter = self.set_reference)
         self.cerfa_field = self.set(attr, 'cerfa_field', allowed_type = (basestring_type, dict))
         self.unit = self.set(attr, 'unit', allowed_type = basestring_type)
-        self.doc = self.set(attr, 'doc', allowed_type = basestring_type)
+        self.doc = self.set(attr, 'doc', allowed_type = basestring_type, setter = self.set_doc)
         self.set_input = self.set_set_input(attr.pop('set_input', None))
         self.calculate_output = self.set_calculate_output(attr.pop('calculate_output', None))
         self.is_period_size_independent = self.set(attr, 'is_period_size_independent', allowed_type = bool, default = VALUE_TYPES[self.value_type]['is_period_size_independent'])
@@ -255,6 +255,10 @@ class Variable(object):
                             self.name, type(reference)))
 
         return reference
+
+    def set_doc(self, doc):
+        if doc:
+            return textwrap.dedent(doc)
 
     def set_base_function(self, base_function):
         if not base_function and self.baseline_variable:

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -147,7 +147,7 @@ class Variable(object):
        .. py:attribute:: unit
 
            Free text field describing the unit of the variable. Only used as metadata.
-        
+
        .. py:attribute:: documentation
 
            Free multilines text field describing the variable context and usage.

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -175,6 +175,7 @@ class Variable(object):
         self.reference = self.set(attr, 'reference', setter = self.set_reference)
         self.cerfa_field = self.set(attr, 'cerfa_field', allowed_type = (basestring_type, dict))
         self.unit = self.set(attr, 'unit', allowed_type = basestring_type)
+        self.doc = self.set(attr, 'doc', allowed_type = basestring_type)
         self.set_input = self.set_set_input(attr.pop('set_input', None))
         self.calculate_output = self.set_calculate_output(attr.pop('calculate_output', None))
         self.is_period_size_independent = self.set(attr, 'is_period_size_independent', allowed_type = bool, default = VALUE_TYPES[self.value_type]['is_period_size_independent'])

--- a/openfisca_web_api/loader/parameters.py
+++ b/openfisca_web_api/loader/parameters.py
@@ -81,6 +81,7 @@ def walk_node(node, parameters, path_fragments, country_package_metadata):
         elif isinstance(child, Scale):
             api_parameter['brackets'] = build_api_scale(child)
         elif isinstance(child, ParameterNode):
+            api_parameter['documentation'] = child.documentation
             api_parameter['subparams'] = {
                 grandchild_name: {
                     'description': grandchild.description,

--- a/openfisca_web_api/loader/parameters.py
+++ b/openfisca_web_api/loader/parameters.py
@@ -76,12 +76,14 @@ def walk_node(node, parameters, path_fragments, country_package_metadata):
         if child.file_path:
             api_parameter['source'] = build_source_url(child.file_path, country_package_metadata)
         if isinstance(child, Parameter):
-            api_parameter['documentation'] = child.documentation
+            if child.documentation:
+                api_parameter['documentation'] = child.documentation.strip()
             api_parameter['values'] = build_api_values_history(child)
         elif isinstance(child, Scale):
             api_parameter['brackets'] = build_api_scale(child)
         elif isinstance(child, ParameterNode):
-            api_parameter['documentation'] = child.documentation
+            if child.documentation:
+                api_parameter['documentation'] = child.documentation.strip()
             api_parameter['subparams'] = {
                 grandchild_name: {
                     'description': grandchild.description,

--- a/openfisca_web_api/loader/parameters.py
+++ b/openfisca_web_api/loader/parameters.py
@@ -76,6 +76,7 @@ def walk_node(node, parameters, path_fragments, country_package_metadata):
         if child.file_path:
             api_parameter['source'] = build_source_url(child.file_path, country_package_metadata)
         if isinstance(child, Parameter):
+            api_parameter['documentation'] = child.documentation
             api_parameter['values'] = build_api_values_history(child)
         elif isinstance(child, Scale):
             api_parameter['brackets'] = build_api_scale(child)

--- a/openfisca_web_api/loader/variables.py
+++ b/openfisca_web_api/loader/variables.py
@@ -43,7 +43,10 @@ def build_formula(formula, country_package_metadata, source_file_path, tax_benef
     # Python 2 backward compatibility
     if isinstance(source_code[0], bytes):
         source_code = [source_line.decode('utf-8') for source_line in source_code]
+    
+    documentation = formula.__doc__.strip() if formula.__doc__ else ""
     source_code = textwrap.dedent(''.join(source_code))
+    
     return {
         'source': build_source_url(
             country_package_metadata,
@@ -51,6 +54,7 @@ def build_formula(formula, country_package_metadata, source_file_path, tax_benef
             start_line_number,
             source_code
             ),
+        'documentation': to_unicode(documentation),
         'content': to_unicode(source_code),
         }
 
@@ -80,7 +84,7 @@ def build_variable(variable, country_package_metadata, tax_benefit_system):
         }
 
     if variable.documentation:
-        result['documentation'] = variable.documentation
+        result['documentation'] = variable.documentation.strip()
 
     if variable.reference:
         result['references'] = variable.reference

--- a/openfisca_web_api/loader/variables.py
+++ b/openfisca_web_api/loader/variables.py
@@ -43,10 +43,10 @@ def build_formula(formula, country_package_metadata, source_file_path, tax_benef
     # Python 2 backward compatibility
     if isinstance(source_code[0], bytes):
         source_code = [source_line.decode('utf-8') for source_line in source_code]
-    
+
     documentation = formula.__doc__.strip() if formula.__doc__ else ""
     source_code = textwrap.dedent(''.join(source_code))
-    
+
     return {
         'source': build_source_url(
             country_package_metadata,

--- a/openfisca_web_api/loader/variables.py
+++ b/openfisca_web_api/loader/variables.py
@@ -44,19 +44,22 @@ def build_formula(formula, country_package_metadata, source_file_path, tax_benef
     if isinstance(source_code[0], bytes):
         source_code = [source_line.decode('utf-8') for source_line in source_code]
 
-    documentation = formula.__doc__.strip() if formula.__doc__ else ""
     source_code = textwrap.dedent(''.join(source_code))
 
-    return {
+    api_formula = {
         'source': build_source_url(
             country_package_metadata,
             source_file_path,
             start_line_number,
             source_code
             ),
-        'documentation': to_unicode(documentation),
         'content': to_unicode(source_code),
         }
+
+    if formula.__doc__:
+        api_formula['documentation'] = to_unicode(textwrap.dedent(formula.__doc__))
+
+    return api_formula
 
 
 def build_formulas(formulas, country_package_metadata, source_file_path, tax_benefit_system):

--- a/openfisca_web_api/loader/variables.py
+++ b/openfisca_web_api/loader/variables.py
@@ -79,6 +79,9 @@ def build_variable(variable, country_package_metadata, tax_benefit_system):
             ),
         }
 
+    if variable.doc:
+        result['documentation'] = variable.doc
+
     if variable.reference:
         result['references'] = variable.reference
 

--- a/openfisca_web_api/loader/variables.py
+++ b/openfisca_web_api/loader/variables.py
@@ -79,8 +79,8 @@ def build_variable(variable, country_package_metadata, tax_benefit_system):
             ),
         }
 
-    if variable.doc:
-        result['documentation'] = variable.doc
+    if variable.documentation:
+        result['documentation'] = variable.documentation
 
     if variable.reference:
         result['references'] = variable.reference

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.3.2',
+    version = '24.4.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ dev_requirements = [
     'flake8 >= 3.5.0, < 3.6.0',
     'autopep8 >= 1.4.0, < 1.5.0',
     'pycodestyle < 2.4.0',
-    'openfisca-country-template >= 3.2.3, < 4.0.0',
+    'openfisca-country-template >= 3.3.1rc1, < 4.0.0',
     'openfisca-extension-template >= 1.1.3, < 2.0.0',
     ] + api_requirements
 

--- a/tests/core/test_parameters.py
+++ b/tests/core/test_parameters.py
@@ -99,4 +99,4 @@ def test_parameter_node_metadata():
 def test_parameter_documentation():
     parameter = tax_benefit_system.parameters.benefits.housing_allowance
     assert_equal(parameter.documentation,
-        'A fraction of the rent. \nFrom the 1st of Dec 2016, the housing allowance no longer exists.\n')
+        'A fraction of the rent.\nFrom the 1st of Dec 2016, the housing allowance no longer exists.\n')

--- a/tests/core/test_parameters.py
+++ b/tests/core/test_parameters.py
@@ -94,3 +94,15 @@ def test_parameter_node_metadata():
 
     parameter_2 = tax_benefit_system.parameters.taxes.housing_tax
     assert_equal(parameter_2.description, 'Housing tax')
+
+
+def test_parameter_documentation():
+    parameter = tax_benefit_system.parameters.benefits.housing_allowance
+    assert_equal(parameter.documentation,
+        'A fraction of the rent. \nFrom the 1st of Dec 2016, the housing allowance no longer exists.\n')
+
+
+@raises(AttributeError)
+def test_parameter_node_wrong_documentation():
+    parameter_node = tax_benefit_system.parameters.benefits
+    parameter_node.documentation

--- a/tests/core/test_parameters.py
+++ b/tests/core/test_parameters.py
@@ -100,9 +100,3 @@ def test_parameter_documentation():
     parameter = tax_benefit_system.parameters.benefits.housing_allowance
     assert_equal(parameter.documentation,
         'A fraction of the rent. \nFrom the 1st of Dec 2016, the housing allowance no longer exists.\n')
-
-
-@raises(AttributeError)
-def test_parameter_node_wrong_documentation():
-    parameter_node = tax_benefit_system.parameters.benefits
-    parameter_node.documentation

--- a/tests/web_api/test_parameters.py
+++ b/tests/web_api/test_parameters.py
@@ -68,7 +68,11 @@ def test_parameter_node():
     assert_equal(response.status_code, OK)
     parameter = json.loads(response.data)
     assert_equal(sorted(list(parameter.keys())), ['description', 'documentation', 'id', 'metadata', 'source', 'subparams'])
-    assert_equal(parameter['documentation'], 'This (optional) file defines metadata for the node parameters.benefits in the parameter tree.')
+    assert_equal(parameter['documentation'],
+                "Government support for the citizens and residents of society. "
+                "\nThey may be provided to people of any income level, as with social security, "
+                "\nbut usually it is intended to ensure that everyone can meet their basic human needs "
+                "\nsuch as food and shelter.\n(See https://en.wikipedia.org/wiki/Welfare)\n")
     assert_equal(parameter['subparams'], {
         'housing_allowance': {'description': 'Housing allowance amount (as a fraction of the rent)'},
         'basic_income': {'description': 'Amount of the basic income'}

--- a/tests/web_api/test_parameters.py
+++ b/tests/web_api/test_parameters.py
@@ -67,11 +67,12 @@ def test_parameter_node():
     response = subject.get('/parameter/benefits')
     assert_equal(response.status_code, OK)
     parameter = json.loads(response.data)
-    assert_equal(sorted(list(parameter.keys())), ['description', 'id', 'metadata', 'source', 'subparams'])
+    assert_equal(sorted(list(parameter.keys())), ['description', 'documentation', 'id', 'metadata', 'source', 'subparams'])
+    assert_equal(parameter['documentation'], 'This (optional) file defines metadata for the node parameters.benefits in the parameter tree.')
     assert_equal(parameter['subparams'], {
         'housing_allowance': {'description': 'Housing allowance amount (as a fraction of the rent)'},
         'basic_income': {'description': 'Amount of the basic income'}
-        })
+        }, parameter['subparams'])
 
 
 def test_stopped_parameter_values():

--- a/tests/web_api/test_parameters.py
+++ b/tests/web_api/test_parameters.py
@@ -52,9 +52,10 @@ def test_legacy_parameter_route():
 def test_parameter_values():
     response = subject.get('/parameter/taxes/income_tax_rate')
     parameter = json.loads(response.data)
-    assert_equal(sorted(list(parameter.keys())), ['description', 'id', 'metadata', 'source', 'values'])
+    assert_equal(sorted(list(parameter.keys())), ['description', 'documentation', 'id', 'metadata', 'source', 'values'])
     assert_equal(parameter['id'], 'taxes.income_tax_rate')
     assert_equal(parameter['description'], 'Income tax rate')
+    assert_equal(parameter['documentation'], None)
     assert_equal(parameter['values'], {'2015-01-01': 0.15, '2014-01-01': 0.14, '2013-01-01': 0.13, '2012-01-01': 0.16})
     assert_equal(parameter['values'], {'2015-01-01': 0.15, '2014-01-01': 0.14, '2013-01-01': 0.13, '2012-01-01': 0.16})
     assert_equal(parameter['metadata'], {'unit': '/1'})

--- a/tests/web_api/test_parameters.py
+++ b/tests/web_api/test_parameters.py
@@ -52,15 +52,21 @@ def test_legacy_parameter_route():
 def test_parameter_values():
     response = subject.get('/parameter/taxes/income_tax_rate')
     parameter = json.loads(response.data)
-    assert_equal(sorted(list(parameter.keys())), ['description', 'documentation', 'id', 'metadata', 'source', 'values'])
+    assert_equal(sorted(list(parameter.keys())), ['description', 'id', 'metadata', 'source', 'values'])
     assert_equal(parameter['id'], 'taxes.income_tax_rate')
     assert_equal(parameter['description'], 'Income tax rate')
-    assert_equal(parameter['documentation'], None)
     assert_equal(parameter['values'], {'2015-01-01': 0.15, '2014-01-01': 0.14, '2013-01-01': 0.13, '2012-01-01': 0.16})
     assert_equal(parameter['values'], {'2015-01-01': 0.15, '2014-01-01': 0.14, '2013-01-01': 0.13, '2012-01-01': 0.16})
     assert_equal(parameter['metadata'], {'unit': '/1'})
     assert_regexp_matches(parameter['source'], GITHUB_URL_REGEX)
     assert_in('taxes/income_tax_rate.yaml', parameter['source'])
+
+    # 'documentation' attribute exists only when a value is defined
+    response = subject.get('/parameter/benefits/housing_allowance')
+    parameter = json.loads(response.data)
+    assert_equal(sorted(list(parameter.keys())), ['description', 'documentation', 'id', 'metadata', 'source', 'values'])
+    assert_equal(parameter['documentation'],
+        'A fraction of the rent.\nFrom the 1st of Dec 2016, the housing allowance no longer exists.')
 
 
 def test_parameter_node():
@@ -72,7 +78,7 @@ def test_parameter_node():
                 "Government support for the citizens and residents of society. "
                 "\nThey may be provided to people of any income level, as with social security, "
                 "\nbut usually it is intended to ensure that everyone can meet their basic human needs "
-                "\nsuch as food and shelter.\n(See https://en.wikipedia.org/wiki/Welfare)\n")
+                "\nsuch as food and shelter.\n(See https://en.wikipedia.org/wiki/Welfare)")
     assert_equal(parameter['subparams'], {
         'housing_allowance': {'description': 'Housing allowance amount (as a fraction of the rent)'},
         'basic_income': {'description': 'Amount of the basic income'}

--- a/tests/web_api/test_variables.py
+++ b/tests/web_api/test_variables.py
@@ -154,3 +154,11 @@ def test_dated_variable_formulas_content():
 def test_variable_encoding():
     variable_response = subject.get('/variable/pension')
     assert_equal(variable_response.status_code, OK)
+
+
+def test_variable_documentation():
+    response = subject.get('/variable/housing_allowance')
+    variable = json.loads(response.data.decode('utf-8'))
+    assert_equal(variable['documentation'],
+        "\nThis allowance was introduced on the 1st of Jan 1980.\nIt needs the 'rent' value "
+        + "(same month) but doesn't care about the 'housing_occupancy_status'.\n")

--- a/tests/web_api/test_variables.py
+++ b/tests/web_api/test_variables.py
@@ -160,5 +160,8 @@ def test_variable_documentation():
     response = subject.get('/variable/housing_allowance')
     variable = json.loads(response.data.decode('utf-8'))
     assert_equal(variable['documentation'],
-        "\nThis allowance was introduced on the 1st of Jan 1980.\nIt needs the 'rent' value "
-        + "(same month) but doesn't care about the 'housing_occupancy_status'.\n")
+        "This allowance was introduced on the 1st of Jan 1980.\nIt needs the 'rent' value "
+        + "(same month) but doesn't care about the 'housing_occupancy_status'.")
+
+    assert_equal(variable['formulas']['1980-01-01']['documentation'],
+        "This is my specific life statement.")

--- a/tests/web_api/test_variables.py
+++ b/tests/web_api/test_variables.py
@@ -163,5 +163,4 @@ def test_variable_documentation():
         "This allowance was introduced on the 1st of Jan 1980.\nIt disappeared in Dec 2016.")
 
     assert_equal(variable['formulas']['1980-01-01']['documentation'],
-        "To compute this allowance, the 'rent' value must be provided for the same month, "
-        "but 'housing_occupancy_status' is not necessary.")
+        "\nTo compute this allowance, the 'rent' value must be provided for the same month, but 'housing_occupancy_status' is not necessary.\n")

--- a/tests/web_api/test_variables.py
+++ b/tests/web_api/test_variables.py
@@ -160,8 +160,8 @@ def test_variable_documentation():
     response = subject.get('/variable/housing_allowance')
     variable = json.loads(response.data.decode('utf-8'))
     assert_equal(variable['documentation'],
-        "This allowance was introduced on the 1st of Jan 1980.\nIt needs the 'rent' value "
-        + "(same month) but doesn't care about the 'housing_occupancy_status'.")
+        "This allowance was introduced on the 1st of Jan 1980.\nIt disappeared in Dec 2016.")
 
     assert_equal(variable['formulas']['1980-01-01']['documentation'],
-        "This is my specific life statement.")
+        "To compute this allowance, the 'rent' value must be provided for the same month, "
+        "but 'housing_occupancy_status' is not necessary.")


### PR DESCRIPTION
Connected to openfisca/legislation-explorer#124

#### New features

Allow for multiline editorial content on parameters and variables:
- Introduce `ParameterNode.documentation`, `Parameter.documentation` and `Variable.documentation` attributes
- User can access a `documentation` attribute through Web API
    - on `/parameter` nodes as `/parameter/benefits`
      > = python `ParameterNode.documentation`  
      > = `documentation` string attribute of `index.yaml`
    - on `/parameter` leafs as `/parameter/benefits/housing_allowance`
      > = python `Parameter.documentation`  
      > = yaml `documentation` string attribute
    - on `/variable` leafs as `/variable/housing_allowance`
      > = python `Variable.documentation`
    - on every `/variable` leaf formula 
      > = python `Variable` formula docstring

Here is web API `/variable/housing_allowance` example:

      {
        "description": "Housing allowance",
        "documentation": "This allowance was introduced on the 1st of Jan 1980.\nIt needs the   'rent' value (same month) but doesn't care about the 'housing_occupancy_status'.",
        "entity": "household",
        "formulas": {
          "1980-01-01": {
            "content": "def formula_1980(household, period, parameters):\n    '''This is my specific life statement.'''\n    return     household('rent', period) * parameters(period).benefits.housing_allowance\n",
            "documentation": "This is my specific life statement.",
            "source": "https://github.com/openfisca/country-template/blob/3.3.0/openfisca_country_template/variables/benefits.py#L47-L49"
          },
          "2016-12-01": null
        },
        "id": "housing_allowance",
        (...)
      }

The formula doctoring is in the formula `content` and `documentation` attributes.