### PR TITLE
Check version and Changelog separately

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,12 +34,6 @@ jobs:
           name: Run tests
           command: make test
 
-      - run:
-          name: Check version number has been properly updated
-          command: |
-            git fetch
-            .circleci/is-version-number-acceptable.sh
-
   deploy_python2:
     docker:
       - image: python:2.7.14
@@ -100,12 +94,6 @@ jobs:
           name: Run tests
           command: make test
 
-      - run:
-          name: Check version number has been properly updated
-          command: |
-            git fetch
-            .circleci/is-version-number-acceptable.sh
-
   deploy_python3:
     docker:
       - image: python:3.6
@@ -129,12 +117,25 @@ jobs:
             source /tmp/venv/openfisca_core/bin/activate
             .circleci/publish-python-package.sh
 
+  check_version_and_changelog:
+    docker:
+      - image: python:3.6
+    steps:
+      - checkout
+
+      - run:
+          name: Check version number has been properly updated
+          command: |
+            git fetch
+            .circleci/is-version-number-acceptable.sh
+
 workflows:
   version: 2
   build_and_deploy:
     jobs:
       - build_python2
       - build_python3
+      - check_version_and_changelog
       - deploy_python2:
           requires:
             - build_python2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,7 @@ workflows:
           requires:
             - build_python2
             - build_python3
+            - check_version_and_changelog
           filters:
             branches:
               only: master
@@ -147,6 +148,7 @@ workflows:
           requires:
             - build_python2
             - build_python3
+            - check_version_and_changelog
           filters:
             branches:
               only: master


### PR DESCRIPTION
This adds a separate CircleCI job common to Python2 and Python3 for checking whether the version number has been bumped in `setup.py` and Changelog was updated.

Rationale:
- we get faster and more relevant feedback on our work while a PR is in progress
- we get highly relevant feedback when Python2 and Python3 tests behave differently
- the version check provides information of a different nature than functional tests

Testing: this PR is tested by introducing a "functional" change (swapping two lines in Core that do not have any ordering dependency, a change with no effect but that is picked up by the diff in the version check), which induces the version check to fail. This commit is then reverted, getting back to green as CircleCI configuration changes are not considered "functional".