### PR TITLE
Use Python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
 
   build_python3:
     docker:
-      - image: python:3.6
+      - image: python:3.7
 
     steps:
       - checkout
@@ -96,7 +96,7 @@ jobs:
 
   deploy_python3:
     docker:
-      - image: python:3.6
+      - image: python:3.7
     environment:
       PYPI_USERNAME: openfisca-bot
       # PYPI_PASSWORD: this value is set in CircleCI's web interface; do not set it here, it is a secret!
@@ -119,7 +119,7 @@ jobs:
 
   check_version_and_changelog:
     docker:
-      - image: python:3.6
+      - image: python:3.7
     steps:
       - checkout
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package contains the core features of OpenFisca, which are meant to be used
 
 ## Environment
 
-OpenFisca runs on Python 3.6. More recent versions should work, but are not tested.
+OpenFisca runs on Python 3.7.
 
 Backward compatibility with Python 2.7 is maintained for now, but will be dropped from January 1st, 2019.
 


### PR DESCRIPTION
Connected to #693 

As suggested by @tchabaud, Python 3.7 is the new stable version of Python 3. Let's use it :)