### PR TITLE
In Python, simplify simulation initialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 24.5.0 [#729](https://github.com/openfisca/openfisca-core/pull/729)
+
+- In Python, simplify simulation initialisation:
+
+Before:
+
+```py
+simulation = ...
+holder = simulation.persons.get_holder('salary')
+holder.set_input('2018-08', [4000])
+```
+
+After:
+
+```py
+simulation = ...
+simulation.set_input('salary', '2018-08', [4000])
+```
+
 ## 24.4.0 [#717](https://github.com/openfisca/openfisca-core/pull/717)
 
 - In Python, allow multiline documentation on parameters and variables
@@ -7,10 +26,10 @@
 
 - In the Web API, expose this documentation as a `documentation` property for parameters, variables and variables' formulas
     - on `/parameter` nodes as `/parameter/benefits`
-      > = python `ParameterNode.documentation`  
+      > = python `ParameterNode.documentation`
       > = YAML parameter node (`index.yaml`) `documentation` string attribute
     - on `/parameter` leafs as `/parameter/benefits/housing_allowance`
-      > = python `Parameter.documentation`  
+      > = python `Parameter.documentation`
       > = YAML parameter `documentation` string attribute
     - on `/variable` as `/variable/housing_allowance`
       > = python `Variable.documentation`

--- a/openfisca_core/scripts/simulation_generator.py
+++ b/openfisca_core/scripts/simulation_generator.py
@@ -3,7 +3,6 @@ import numpy as np
 
 import random
 from openfisca_core.simulations import Simulation
-from openfisca_core.periods import period as make_period
 
 
 def make_simulation(tax_benefit_system, nb_persons, nb_groups, **kwargs):
@@ -66,4 +65,4 @@ def randomly_init_variable(simulation, variable_name, period, max_value, conditi
     variable = simulation.tax_benefit_system.get_variable(variable_name)
     entity = simulation.get_variable_entity(variable_name)
     value = (np.random.rand(entity.count) * max_value * condition).astype(variable.dtype)
-    entity.get_holder(variable_name).set_input(make_period(period), value)
+    simulation.set_input(variable_name, period, value)

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -399,9 +399,7 @@ class Simulation(object):
         """
             Get the :any:`Holder` associated with the variable ``variable_name`` for the simulation
         """
-        variable = self.tax_benefit_system.get_variable(variable_name, check_existence = True)
-        entity = self.entities[variable.entity.key]
-        return entity.get_holder(variable_name)
+        return self.get_variable_entity(variable_name).get_holder(variable_name)
 
     def get_memory_usage(self, variables = None):
         """
@@ -418,6 +416,24 @@ class Simulation(object):
         return result
 
     # ----- Misc ----- #
+
+    def set_input(self, variable, period, value):
+        """
+            Set a variable's value for a given period
+
+            :param variable: the variable to be set
+            :param value: the input value for the variable
+            :param period: the period for which the value is setted
+
+            Example:
+
+            >>> set_input('age', [12, 14], '2018-04')
+            >>> get_array('age', '2018-04')
+            >>> [12, 14]
+
+            If a ``set_input`` property has been set for the variable, this method may accept inputs for periods not matching the ``definition_period`` of the variable. To read more about this, check the `documentation <https://openfisca.org/doc/coding-the-legislation/35_periods.html#automatically-process-variable-inputs-defined-for-periods-not-matching-the-definitionperiod>`.
+        """
+        self.get_holder(variable).set_input(period, value)
 
     def get_variable_entity(self, variable_name):
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.4.0',
+    version = '24.5.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_calculate_output.py
+++ b/tests/core/test_calculate_output.py
@@ -46,15 +46,13 @@ def test_calculate_output_default():
 
 def test_calculate_output_add():
     simulation = Simulation(tax_benefit_system = tax_benefit_system, simulation_json = single)
-    holder = simulation.persons.get_holder('variable_with_calculate_output_add')
-    holder.set_input('2017-01', [10])
-    holder.set_input('2017-05', [20])
-    holder.set_input('2017-12', [70])
+    simulation.set_input('variable_with_calculate_output_add', '2017-01', [10])
+    simulation.set_input('variable_with_calculate_output_add', '2017-05', [20])
+    simulation.set_input('variable_with_calculate_output_add', '2017-12', [70])
     assert_near(simulation.calculate_output('variable_with_calculate_output_add', 2017), 100)
 
 
 def test_calculate_output_divide():
     simulation = Simulation(tax_benefit_system = tax_benefit_system, simulation_json = single)
-    holder = simulation.persons.get_holder('variable_with_calculate_output_divide')
-    holder.set_input(2017, [12000])
+    simulation.set_input('variable_with_calculate_output_divide', 2017, [12000])
     assert_near(simulation.calculate_output('variable_with_calculate_output_divide', '2017-06'), 1000)


### PR DESCRIPTION
Fixes #726 

In Python, simplify simulation initialisation:

Before:

```py
simulation = ...
holder = simulation.persons.get_holder('salary')
holder.set_input('2018-08', [4000])
```

Now:

```py
simulation = ...
simulation.set_input('salary', '2018-08', [4000])
```
