### PR TITLE
Fix type value for string variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-### 24.5.3 [#734](https://github.com/openfisca/openfisca-core/pull/734)
+### 24.5.3 [#737](https://github.com/openfisca/openfisca-core/pull/737)
+
+- Fix an encoding bug of variables with value type str
+- Details:
+  * `str` corresponds to `unicode` in Python 2.7 and `bytes` in Python 3.7
+  * Set encoding with `numpy.unicode_` to dynamically cast to `unicode` both in Python 2.7 and Python 3.7
+
+### 24.5.2 [#734](https://github.com/openfisca/openfisca-core/pull/734)
 
 - Ignore W503 to enforce Knuth's style (W504)
 - Fix failing entities test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## 24.5.3 [#734](https://github.com/openfisca/openfisca-core/pull/734)
+### 24.5.3 [#734](https://github.com/openfisca/openfisca-core/pull/734)
 
 - Ignore W503 to enforce Knuth's style (W504)
 - Fix failing entities test
   - Household description was outdated
 
-## 24.5.1 [#732](https://github.com/openfisca/openfisca-core/pull/732)
+### 24.5.1 [#732](https://github.com/openfisca/openfisca-core/pull/732)
 
 - Further adopt simplified simulation initialisation
   - See [#729](https://github.com/openfisca/openfisca-core/pull/729)
@@ -58,7 +58,7 @@ simulation.set_input('salary', '2018-08', [4000])
   - Use proper JSON Schema type to describe input types
   - Fix property name in the description of `/parameters` and `/variables`
 
-### 24.3.0 [#714](https://github.com/openfisca/openfisca-core/pull/714)
+## 24.3.0 [#714](https://github.com/openfisca/openfisca-core/pull/714)
 
 - Introduce the `/entities` endpoint for the Web API.
   - Expose information about the country package's entities, and their roles.
@@ -99,7 +99,7 @@ from openfisca_core.tools.simulation_dumper import restore_simulation
 simulation = restore_simulation('/path/to/directory', tax_benefit_system)
 ```
 
-### 24.1.0 [#713](https://github.com/openfisca/openfisca-core/pull/713)
+## 24.1.0 [#713](https://github.com/openfisca/openfisca-core/pull/713)
 
 - Enhance navigation within the Openfisca Web API.
 - Provides a direct link to individual parameters and variables from the `/parameters` and `/variables` routes.

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -167,7 +167,7 @@ class Variable(object):
         if self.value_type == str:
             self.max_length = self.set(attr, 'max_length', allowed_type = int)
             if self.max_length:
-                self.dtype = '|S{}'.format(self.max_length)
+                self.dtype = '|U{}'.format(self.max_length)
         if self.value_type == Enum:
             self.default_value = self.set(attr, 'default_value', allowed_type = self.possible_values, required = True)
         else:

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -162,12 +162,11 @@ class Variable(object):
         self.value_type = self.set(attr, 'value_type', required = True, allowed_values = VALUE_TYPES.keys())
         self.dtype = VALUE_TYPES[self.value_type]['dtype']
         self.json_type = VALUE_TYPES[self.value_type]['json_type']
-        if self.value_type == Enum:
-            self.possible_values = self.set(attr, 'possible_values', required = True, setter = self.set_possible_values)
         if self.value_type == str:
             self.max_length = self.set(attr, 'max_length', allowed_type = int)
             self.dtype = '|U'
         if self.value_type == Enum:
+            self.possible_values = self.set(attr, 'possible_values', required = True, setter = self.set_possible_values)
             self.default_value = self.set(attr, 'default_value', allowed_type = self.possible_values, required = True)
         else:
             self.default_value = self.set(attr, 'default_value', allowed_type = self.value_type, default = VALUE_TYPES[self.value_type].get('default'))

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -164,7 +164,7 @@ class Variable(object):
         self.json_type = VALUE_TYPES[self.value_type]['json_type']
         if self.value_type == str:
             self.max_length = self.set(attr, 'max_length', allowed_type = int)
-            self.dtype = '|U'
+            self.dtype = 'unicode_'
         if self.value_type == Enum:
             self.possible_values = self.set(attr, 'possible_values', required = True, setter = self.set_possible_values)
             self.default_value = self.set(attr, 'default_value', allowed_type = self.possible_values, required = True)

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -166,8 +166,7 @@ class Variable(object):
             self.possible_values = self.set(attr, 'possible_values', required = True, setter = self.set_possible_values)
         if self.value_type == str:
             self.max_length = self.set(attr, 'max_length', allowed_type = int)
-            if self.max_length:
-                self.dtype = '|U{}'.format(self.max_length)
+            self.dtype = '|U'
         if self.value_type == Enum:
             self.default_value = self.set(attr, 'default_value', allowed_type = self.possible_values, required = True)
         else:

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.5.2',
+    version = '24.5.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_variables.py
+++ b/tests/core/test_variables.py
@@ -2,7 +2,9 @@
 
 from __future__ import unicode_literals, print_function, division, absolute_import
 import datetime
-from nose.tools import raises
+from numpy import unicode_
+
+from nose.tools import raises, assert_equal
 
 from openfisca_core.model_api import Variable
 from openfisca_core.periods import MONTH, ETERNITY
@@ -474,3 +476,19 @@ def test_unexpected_attr():
         unexpected = '???'
 
     tax_benefit_system.add_variable(variable_with_strange_attr)
+
+
+def test_string_variable_is_always_unicode():
+    class variable__str_with_max(Variable):
+        value_type = str
+        max_length = 5
+        entity = Person
+        definition_period = MONTH
+        label = "String variable of specific max length"
+
+    tax_benefit_system.add_variable(variable__str_with_max)
+    month = '2018-01'
+
+    simulation = new_simulation(tax_benefit_system, month)
+    variable_value = simulation.calculate('variable__str_with_max', month)[0]
+    assert_equal(unicode_, type(variable_value))

--- a/tests/core/test_variables.py
+++ b/tests/core/test_variables.py
@@ -1,26 +1,29 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import datetime
+
+from nose.tools import raises
+
 from numpy import unicode_
 
-from nose.tools import raises, assert_equal
-
 from openfisca_core.model_api import Variable
-from openfisca_core.periods import MONTH, ETERNITY
+from openfisca_core.periods import ETERNITY, MONTH
 from openfisca_core.simulations import Simulation
 from openfisca_core.tools import assert_near
 
 import openfisca_country_template as country_template
-from openfisca_country_template.situation_examples import couple
 from openfisca_country_template.entities import Person
+from openfisca_country_template.situation_examples import couple
+
 
 # Check which date is applied whether it comes from Variable attribute (end)
 # or formula(s) dates.
 
+# SETUP
 
 tax_benefit_system = country_template.CountryTaxBenefitSystem()
-
 
 # HELPERS
 
@@ -478,17 +481,17 @@ def test_unexpected_attr():
     tax_benefit_system.add_variable(variable_with_strange_attr)
 
 
-def test_string_variable_is_always_unicode():
-    class variable__str_with_max(Variable):
+def test_variable_with_value_type_str_is_always_unicode():
+    class variable_with_type_str(Variable):
         value_type = str
         max_length = 5
         entity = Person
         definition_period = MONTH
         label = "String variable of specific max length"
 
-    tax_benefit_system.add_variable(variable__str_with_max)
+    tax_benefit_system.add_variable(variable_with_type_str)
     month = '2018-01'
 
     simulation = new_simulation(tax_benefit_system, month)
-    variable_value = simulation.calculate('variable__str_with_max', month)[0]
-    assert_equal(unicode_, type(variable_value))
+    variable_value = simulation.calculate('variable_with_type_str', month)[0]
+    assert type(variable_value) == unicode_

--- a/tests/web_api/test_trace.py
+++ b/tests/web_api/test_trace.py
@@ -10,6 +10,7 @@ import dpath
 
 from openfisca_core.model_api import Variable
 from openfisca_core.periods import MONTH
+from openfisca_core.simulations import Simulation
 
 from openfisca_country_template import CountryTaxBenefitSystem
 from openfisca_country_template.entities import Person
@@ -67,18 +68,10 @@ class variable__str_with_max(Variable):
     label = "String variable of specific max length"
 
 
-def new_simulation(tax_benefit_system, month):
-    return tax_benefit_system.new_scenario().init_from_attributes(
-        period = month,
-        input_variables = dict(
-            ),
-        ).new_simulation()
-
-
 def test_string_variable_is_always_unicode():
     month = '2018-01'
     tax_benefit_system = CountryTaxBenefitSystem()
     tax_benefit_system.add_variable(variable__str_with_max)
-    simulation = new_simulation(tax_benefit_system, month)
+    simulation = Simulation(tax_benefit_system = tax_benefit_system, simulation_json = single)
     variable_value = simulation.calculate('variable__str_with_max', month)[0]
     assert_equal(unicode_, type(variable_value))

--- a/tests/web_api/test_trace.py
+++ b/tests/web_api/test_trace.py
@@ -75,7 +75,7 @@ def new_simulation(tax_benefit_system, month):
         ).new_simulation()
 
 
-def test_variable__str_with_max():
+def test_string_variable_is_always_unicode():
     month = '2018-01'
     tax_benefit_system = CountryTaxBenefitSystem()
     tax_benefit_system.add_variable(variable__str_with_max)

--- a/tests/web_api/test_trace.py
+++ b/tests/web_api/test_trace.py
@@ -3,17 +3,10 @@
 from __future__ import unicode_literals, print_function, division, absolute_import
 import json
 
-from numpy import unicode_
 from nose.tools import assert_equal, assert_is_instance
 from http.client import OK
 import dpath
 
-from openfisca_core.model_api import Variable
-from openfisca_core.periods import MONTH
-from openfisca_core.simulations import Simulation
-
-from openfisca_country_template import CountryTaxBenefitSystem
-from openfisca_country_template.entities import Person
 from openfisca_country_template.situation_examples import single, couple
 
 from . import subject
@@ -58,20 +51,3 @@ def test_root_nodes():
         dpath.util.get(response_json, 'requestedCalculations'),
         ['disposable_income<2017-01>', 'total_benefits<2017-01>', 'total_taxes<2017-01>']
         )
-
-
-class variable__str_with_max(Variable):
-    value_type = str
-    max_length = 5
-    entity = Person
-    definition_period = MONTH
-    label = "String variable of specific max length"
-
-
-def test_string_variable_is_always_unicode():
-    month = '2018-01'
-    tax_benefit_system = CountryTaxBenefitSystem()
-    tax_benefit_system.add_variable(variable__str_with_max)
-    simulation = Simulation(tax_benefit_system = tax_benefit_system, simulation_json = single)
-    variable_value = simulation.calculate('variable__str_with_max', month)[0]
-    assert_equal(unicode_, type(variable_value))

--- a/tests/web_api/test_trace.py
+++ b/tests/web_api/test_trace.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
-import json
+from __future__ import absolute_import, division, print_function, unicode_literals
 
-from nose.tools import assert_equal, assert_is_instance
+import json
 from http.client import OK
+
 import dpath
 
-from openfisca_country_template.situation_examples import single, couple
+from nose.tools import assert_equal, assert_is_instance
+
+from openfisca_country_template.situation_examples import couple, single
 
 from . import subject
 

--- a/tests/web_api/test_trace.py
+++ b/tests/web_api/test_trace.py
@@ -10,7 +10,6 @@ import dpath
 
 from openfisca_core.model_api import Variable
 from openfisca_core.periods import MONTH
-from openfisca_core.simulations import Simulation
 
 from openfisca_country_template import CountryTaxBenefitSystem
 from openfisca_country_template.entities import Person
@@ -58,6 +57,7 @@ def test_root_nodes():
         dpath.util.get(response_json, 'requestedCalculations'),
         ['disposable_income<2017-01>', 'total_benefits<2017-01>', 'total_taxes<2017-01>']
         )
+
 
 class variable__str_with_max(Variable):
     value_type = str

--- a/tests/web_api/test_trace.py
+++ b/tests/web_api/test_trace.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals, print_function, division, absolute_import
 import json
 
-from numpy import str_
+from numpy import unicode_
 from nose.tools import assert_equal, assert_is_instance
 from http.client import OK
 import dpath
@@ -81,4 +81,4 @@ def test_variable__str_with_max():
     tax_benefit_system.add_variable(variable__str_with_max)
     simulation = new_simulation(tax_benefit_system, month)
     variable_value = simulation.calculate('variable__str_with_max', month)[0]
-    assert_equal(str_, type(variable_value))
+    assert_equal(unicode_, type(variable_value))

--- a/tests/web_api/test_trace.py
+++ b/tests/web_api/test_trace.py
@@ -3,9 +3,17 @@
 from __future__ import unicode_literals, print_function, division, absolute_import
 import json
 
+from numpy import str_
 from nose.tools import assert_equal, assert_is_instance
 from http.client import OK
 import dpath
+
+from openfisca_core.model_api import Variable
+from openfisca_core.periods import MONTH
+from openfisca_core.simulations import Simulation
+
+from openfisca_country_template import CountryTaxBenefitSystem
+from openfisca_country_template.entities import Person
 from openfisca_country_template.situation_examples import single, couple
 
 from . import subject
@@ -50,3 +58,27 @@ def test_root_nodes():
         dpath.util.get(response_json, 'requestedCalculations'),
         ['disposable_income<2017-01>', 'total_benefits<2017-01>', 'total_taxes<2017-01>']
         )
+
+class variable__str_with_max(Variable):
+    value_type = str
+    max_length = 5
+    entity = Person
+    definition_period = MONTH
+    label = "String variable of specific max length"
+
+
+def new_simulation(tax_benefit_system, month):
+    return tax_benefit_system.new_scenario().init_from_attributes(
+        period = month,
+        input_variables = dict(
+            ),
+        ).new_simulation()
+
+
+def test_variable__str_with_max():
+    month = '2018-01'
+    tax_benefit_system = CountryTaxBenefitSystem()
+    tax_benefit_system.add_variable(variable__str_with_max)
+    simulation = new_simulation(tax_benefit_system, month)
+    variable_value = simulation.calculate('variable__str_with_max', month)[0]
+    assert_equal(str_, type(variable_value))


### PR DESCRIPTION
Relates to #701 
 
Bug detected by sending `https://fr.openfisca.org/legislation/swagger` example for `/trace` endpoint to local web api. The web api answer was:
`{"error":"Internal server error: Object of type bytes is not JSON serializable"}`

---

#### Technical changes

- Fix an encoding bug of variables with value type str
- Details:
  * `str` corresponds to `unicode` in Python 2.7 and `bytes` in Python 3.7
  * Set encoding with `numpy.unicode_` to dynamically cast to `unicode` both in Python 2.7 and Python 3.7

---

*Note:*

A numpy array containing values for a variable with `value_type = str`, automatically converts the values to:
* `numpy.str_` in Python 2.7
* `numpy.bytes_` in Python 3.7

In this PR, we update such variables `dtype` in `openfisca_core/variables.py` and this dtype gives:
*  `numpy.bytes_` for `|S` dtype value
* `numpy.unicode_` for `|U` or `unicode_` dtype value
