### PR TITLE
Restore max_length shortening effect on variable of type str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 24.5.4 [#738](https://github.com/openfisca/openfisca-core/pull/738)
+
+- Restore `max_length` shortening effect on variable of type str 
+- Details:
+  * Bug introduced in previous revision (24.5.3)  
+
 ### 24.5.3 [#737](https://github.com/openfisca/openfisca-core/pull/737)
 
 - Fix an encoding bug of variables with value type str

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -164,7 +164,8 @@ class Variable(object):
         self.json_type = VALUE_TYPES[self.value_type]['json_type']
         if self.value_type == str:
             self.max_length = self.set(attr, 'max_length', allowed_type = int)
-            self.dtype = 'unicode_'
+            if self.max_length:
+                self.dtype = '|U{}'.format(self.max_length)
         if self.value_type == Enum:
             self.possible_values = self.set(attr, 'possible_values', required = True, setter = self.set_possible_values)
             self.default_value = self.set(attr, 'default_value', allowed_type = self.possible_values, required = True)

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.5.3',
+    version = '24.5.4',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
Fixes #737 

#### Technical changes

- Bug fix 
  - Restore string variables `max_length` in numpy encoding
  - This restores `max_length` shortening effect on longer str variables values

