### PR TITLE
Fix str variable test and default_value encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 25.5.5 [#739](https://github.com/openfisca/openfisca-core/pull/739)
+
+- Make str variable `default_value` of unicode type for Python 2 backward compatibility
+- Details:
+  * Introduce test check on str variable `max_length` effect
+  * Explicit str variables data type for Python 2 and Python 3
+
 ### 24.5.4 [#738](https://github.com/openfisca/openfisca-core/pull/738)
 
 - Restore `max_length` shortening effect on variable of type str 

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -46,7 +46,7 @@ VALUE_TYPES = {
         'is_period_size_independent': False,
         },
     str: {
-        'dtype': object,
+        'dtype': np.unicode_,
         'default': '',
         'json_type': 'string',
         'formatted_value_type': 'String',

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -208,6 +208,8 @@ class Variable(object):
         if allowed_type is not None and value is not None and not isinstance(value, allowed_type):
             if allowed_type == float and isinstance(value, int):
                 value = float(value)
+            if allowed_type == str:  # Python 2 backward compatibility
+                value = to_unicode(value)
             else:
                 raise ValueError("Invalid value '{}' for attribute '{}' in variable '{}'. Must be of type '{}'."
                     .format(value, attribute_name, self.name, allowed_type).encode('utf-8'))

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.5.4',
+    version = '24.5.5',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_variables.py
+++ b/tests/core/test_variables.py
@@ -485,6 +485,7 @@ def test_variable_with_value_type_str_is_always_unicode():
     class variable_with_type_str(Variable):
         value_type = str
         max_length = 5
+        default_value = "12345678"
         entity = Person
         definition_period = MONTH
         label = "String variable of specific max length"
@@ -495,3 +496,4 @@ def test_variable_with_value_type_str_is_always_unicode():
     simulation = new_simulation(tax_benefit_system, month)
     variable_value = simulation.calculate('variable_with_type_str', month)[0]
     assert type(variable_value) == unicode_
+    assert variable_value == "12345"  # A value longer than 'max_length' is truncated.


### PR DESCRIPTION
Relates to #737  

#### Technical changes

- Make str variable `default_value` of unicode type (Python 2 and Python 3 compatible type)
- Details:
  * Introduce test check on str variable `max_length` effect
  * Explicit str variables data type for Python 2 and Python 3

Note:
Core tests missed checks on `default_value` encoding and `max_length` effect for variables of `value_type = str`. This context was detected by web api `/trace` tests and openfisca-france and led to #737, #738 and this PR.

---

Superseded by #741