### PR TITLE
Fix trace and calculate endpoints responses for str variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,21 @@
 # Changelog
 
-## 24.5.3 [#734](https://github.com/openfisca/openfisca-core/pull/734)
+## 24.5.5 [#742](https://github.com/openfisca/openfisca-core/pull/742)
+
+- Fix the internal server error that appeared for the  `/trace` and (less frequently) `/calculate` route of the Web API
+  - This error appeared when a simulation output was a variable of type string
+
+
+> Note: Versions `24.5.3` and `24.5.4` have been unpublished as they accidentally introduced a breaking change. Please use version `24.5.5` or more recent.
+
+
+### 24.5.2 [#734](https://github.com/openfisca/openfisca-core/pull/734)
 
 - Ignore W503 to enforce Knuth's style (W504)
 - Fix failing entities test
   - Household description was outdated
 
-## 24.5.1 [#732](https://github.com/openfisca/openfisca-core/pull/732)
+### 24.5.1 [#732](https://github.com/openfisca/openfisca-core/pull/732)
 
 - Further adopt simplified simulation initialisation
   - See [#729](https://github.com/openfisca/openfisca-core/pull/729)

--- a/openfisca_web_api/app.py
+++ b/openfisca_web_api/app.py
@@ -163,6 +163,8 @@ def create_app(tax_benefit_system,
                     entity_result = result.decode()[entity_index].name
                 elif variable.value_type == float:
                     entity_result = float(str(result[entity_index]))  # To turn the float32 into a regular float without adding confusing extra decimals. There must be a better way.
+                elif variable.value_type == str:
+                    entity_result = to_unicode(result[entity_index])  # From bytes to unicode
                 else:
                     entity_result = result.tolist()[entity_index]
 

--- a/openfisca_web_api/app.py
+++ b/openfisca_web_api/app.py
@@ -196,6 +196,8 @@ def create_app(tax_benefit_system,
             value = vector_trace['value'].tolist()
             if isinstance(value[0], Enum):
                 value = [item.name for item in value]
+            if isinstance(value[0], bytes):
+                value = [to_unicode(item) for item in value]
             vector_trace['value'] = value
 
         return jsonify({

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ dev_requirements = [
     'flake8 >= 3.5.0, < 3.6.0',
     'autopep8 >= 1.4.0, < 1.5.0',
     'pycodestyle < 2.4.0',
-    'openfisca-country-template >= 3.3.1rc1, < 4.0.0',
+    'openfisca-country-template >= 3.4.0, < 4.0.0',
     'openfisca-extension-template >= 1.1.3, < 2.0.0',
     ] + api_requirements
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.5.2',
+    version = '24.5.5',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/web_api/test_calculate.py
+++ b/tests/web_api/test_calculate.py
@@ -4,11 +4,13 @@ from __future__ import unicode_literals, print_function, division, absolute_impo
 import os
 import json
 from http.client import BAD_REQUEST, OK, NOT_FOUND
+from copy import deepcopy
 
 from nose.tools import assert_equal, assert_in
 import dpath
 
 from openfisca_core.commons import to_unicode
+from openfisca_country_template.situation_examples import couple
 
 from . import subject
 
@@ -283,3 +285,13 @@ def test_encoding_period_id():
             "'à' is not a valid ASCII value.",
             response_json['error']
             )
+
+
+def test_str_variable():
+    new_couple = deepcopy(couple)
+    new_couple['households']['_']['postal_code'] = {'2017-01': None}
+    simulation_json = json.dumps(new_couple)
+
+    response = subject.post('/calculate', data = simulation_json, content_type = 'application/json')
+
+    assert_equal(response.status_code, OK)

--- a/tests/web_api/test_trace.py
+++ b/tests/web_api/test_trace.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals, print_function, division, absolute_import
 import json
+from copy import deepcopy
 
 from nose.tools import assert_equal, assert_is_instance
 from http.client import OK
@@ -53,11 +54,10 @@ def test_root_nodes():
 
 
 def test_str_variable():
-    new_couple = couple.copy()
-    new_couple['households']['_']['postal_code']= { '2017-01': None }
+    new_couple = deepcopy(couple)
+    new_couple['households']['_']['postal_code'] = {'2017-01': None}
     simulation_json = json.dumps(new_couple)
 
     response = subject.post('/trace', data = simulation_json, content_type = 'application/json')
-    response_json = json.loads(response.data.decode('utf-8'))
 
     assert_equal(response.status_code, OK)

--- a/tests/web_api/test_trace.py
+++ b/tests/web_api/test_trace.py
@@ -54,7 +54,7 @@ def test_root_nodes():
 
 def test_str_variable():
     new_couple = couple.copy()
-    new_couple['households']['_']['postal_code'] = None
+    new_couple['households']['_']['postal_code']= { '2017-01': None }
     simulation_json = json.dumps(new_couple)
 
     response = subject.post('/trace', data = simulation_json, content_type = 'application/json')

--- a/tests/web_api/test_trace.py
+++ b/tests/web_api/test_trace.py
@@ -50,3 +50,14 @@ def test_root_nodes():
         dpath.util.get(response_json, 'requestedCalculations'),
         ['disposable_income<2017-01>', 'total_benefits<2017-01>', 'total_taxes<2017-01>']
         )
+
+
+def test_str_variable():
+    new_couple = couple.copy()
+    new_couple['households']['_']['postal_code'] = None
+    simulation_json = json.dumps(new_couple)
+
+    response = subject.post('/trace', data = simulation_json, content_type = 'application/json')
+    response_json = json.loads(response.data.decode('utf-8'))
+
+    assert_equal(response.status_code, OK)


### PR DESCRIPTION
- Fix the internal server error that appeared for the  `/trace` and (less frequently) `/calculate` route of the Web API
  - This error appeared when a simulation output was a variable of type string
