### PR TITLE
Allow empty parameter node files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 24.5.6 [#743](https://github.com/openfisca/openfisca-core/pull/743)
+
+- When there is an empty `index.yaml` in the parameters, ignore it instead of raising an error.
+
 ## 24.5.5 [#742](https://github.com/openfisca/openfisca-core/pull/742)
 
 - Fix the internal server error that appeared for the  `/trace` and (less frequently) `/calculate` route of the Web API

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -365,7 +365,7 @@ class ParameterNode(object):
                         continue
 
                     if child_name == 'index':
-                        data = _load_yaml_file(child_path)
+                        data = _load_yaml_file(child_path) or {}
                         _validate_parameter(self, data, allowed_keys = ['metadata', 'description', 'documentation', 'reference'])
                         self.description = data.get('description')
                         self.documentation = data.get('documentation')

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.5.5',
+    version = '24.5.6',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
#### Technical changes

- Nodes in the parameter hierarchy are now allowed to contain no data at all

Rationale: previously, 11 files in the France parameter hierarchy contained no data and only a single element of metadata, the `reference` field, set to the arbitrary and non-informative value `openfisca`. These were removed by openfisca/openfisca-france#1162 but this breaks parameter validation. Since `reference: openfisca` has zero informational content, I infer the unstated requirement that parameter nodes are allowed to contain no data at all. This introduces a test and a fix for that condition.
