### PR TITLE
Use country package specific examples in the /spec route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
-## 24.5.6 [#743](https://github.com/openfisca/openfisca-core/pull/743)
+## 24.6.0 [#744](https://github.com/openfisca/openfisca-core/pull/744)
+
+- Allow TaxBenefitSystem to define the examples to use in the `/spec` route.
+  - See [docs](http://openfisca.org/doc/openfisca-web-api/config-openapi.html).
+
+### 24.5.6 [#743](https://github.com/openfisca/openfisca-core/pull/743)
 
 - When there is an empty `index.yaml` in the parameters, ignore it instead of raising an error.
 
-## 24.5.5 [#742](https://github.com/openfisca/openfisca-core/pull/742)
+### 24.5.5 [#742](https://github.com/openfisca/openfisca-core/pull/742)
 
 - Fix the internal server error that appeared for the  `/trace` and (less frequently) `/calculate` route of the Web API
   - This error appeared when a simulation output was a variable of type string

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -63,7 +63,7 @@ class TaxBenefitSystem(object):
         # TODO: Currently: Don't use a weakref, because they are cleared by Paste (at least) at each call.
         self._parameters_at_instant_cache = {}  # weakref.WeakValueDictionary()
         self.variables = {}
-
+        self.open_api_config = {}
         self.entities = entities
         if entities is None or len(entities) == 0:
             raise Exception("A tax and benefit sytem must have at least an entity.")

--- a/openfisca_web_api/app.py
+++ b/openfisca_web_api/app.py
@@ -1,18 +1,15 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals, print_function, division, absolute_import
-from copy import deepcopy
 import logging
 import os
 import traceback
 
-import dpath
-
-from openfisca_core.simulations import Simulation, SituationParsingError
+from openfisca_core.simulations import SituationParsingError
 from openfisca_core.commons import to_unicode
-from openfisca_core.indexed_enums import Enum
 from openfisca_web_api.loader import build_data
 from openfisca_web_api.errors import handle_import_error
+from openfisca_web_api import handlers
 
 try:
     from flask import Flask, jsonify, abort, request, make_response
@@ -141,41 +138,12 @@ def create_app(tax_benefit_system,
         request.on_json_loading_failed = handle_invalid_json
         input_data = request.get_json()
         try:
-            simulation = Simulation(tax_benefit_system = tax_benefit_system, simulation_json = input_data)
+            result = handlers.calculate(tax_benefit_system, input_data)
         except SituationParsingError as e:
             abort(make_response(jsonify(e.error), e.code or 400))
         except UnicodeEncodeError as e:
             abort(make_response(jsonify({"error": "'" + e[1] + "' is not a valid ASCII value."}), 400))
-
-        requested_computations = dpath.util.search(input_data, '*/*/*/*', afilter = lambda t: t is None, yielded = True)
-        results = {}
-
-        try:
-            for computation in requested_computations:
-                path = computation[0]
-                entity_plural, entity_id, variable_name, period = path.split('/')
-                variable = tax_benefit_system.get_variable(variable_name)
-                result = simulation.calculate(variable_name, period)
-                entity = simulation.get_entity(plural = entity_plural)
-                entity_index = entity.ids.index(entity_id)
-
-                if variable.value_type == Enum:
-                    entity_result = result.decode()[entity_index].name
-                elif variable.value_type == float:
-                    entity_result = float(str(result[entity_index]))  # To turn the float32 into a regular float without adding confusing extra decimals. There must be a better way.
-                elif variable.value_type == str:
-                    entity_result = to_unicode(result[entity_index])  # From bytes to unicode
-                else:
-                    entity_result = result.tolist()[entity_index]
-
-                dpath.util.new(results, path, entity_result)
-
-        except UnicodeEncodeError as e:
-            abort(make_response(jsonify({"error": "'" + e[1] + "' is not a valid ASCII value."}), 400))
-
-        dpath.util.merge(input_data, results)
-
-        return jsonify(input_data)
+        return jsonify(result)
 
     @app.route('/trace', methods=['POST'])
     def trace():
@@ -183,30 +151,10 @@ def create_app(tax_benefit_system,
         request.on_json_loading_failed = handle_invalid_json
         input_data = request.get_json()
         try:
-            simulation = Simulation(tax_benefit_system = tax_benefit_system, simulation_json = input_data, trace = True)
+            result = handlers.trace(tax_benefit_system, input_data)
         except SituationParsingError as e:
             abort(make_response(jsonify(e.error), e.code or 400))
-
-        requested_computations = dpath.util.search(input_data, '*/*/*/*', afilter = lambda t: t is None, yielded = True)
-        for computation in requested_computations:
-            path = computation[0]
-            entity_plural, entity_id, variable_name, period = path.split('/')
-            simulation.calculate(variable_name, period)
-
-        trace = deepcopy(simulation.tracer.trace)
-        for vector_key, vector_trace in trace.items():
-            value = vector_trace['value'].tolist()
-            if isinstance(value[0], Enum):
-                value = [item.name for item in value]
-            if isinstance(value[0], bytes):
-                value = [to_unicode(item) for item in value]
-            vector_trace['value'] = value
-
-        return jsonify({
-            "trace": trace,
-            "entitiesDescription": {entity.plural: entity.ids for entity in simulation.entities.values()},
-            "requestedCalculations": list(simulation.tracer.requested_calculations)
-            })
+        return jsonify(result)
 
     @app.after_request
     def apply_headers(response):

--- a/openfisca_web_api/handlers.py
+++ b/openfisca_web_api/handlers.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals, print_function, division, absolute_import
+
+from copy import deepcopy
+
+import dpath
+
+from openfisca_core.simulations import Simulation
+from openfisca_core.indexed_enums import Enum
+from openfisca_core.commons import to_unicode
+
+
+def calculate(tax_benefit_system, input_data):
+    simulation = Simulation(tax_benefit_system = tax_benefit_system, simulation_json = input_data)
+
+    requested_computations = dpath.util.search(input_data, '*/*/*/*', afilter = lambda t: t is None, yielded = True)
+    computation_results = {}
+
+    for computation in requested_computations:
+        path = computation[0]
+        entity_plural, entity_id, variable_name, period = path.split('/')
+        variable = tax_benefit_system.get_variable(variable_name)
+        result = simulation.calculate(variable_name, period)
+        entity = simulation.get_entity(plural = entity_plural)
+        entity_index = entity.ids.index(entity_id)
+
+        if variable.value_type == Enum:
+            entity_result = result.decode()[entity_index].name
+        elif variable.value_type == float:
+            entity_result = float(str(result[entity_index]))  # To turn the float32 into a regular float without adding confusing extra decimals. There must be a better way.
+        elif variable.value_type == str:
+            entity_result = to_unicode(result[entity_index])  # From bytes to unicode
+        else:
+            entity_result = result.tolist()[entity_index]
+
+        dpath.util.new(computation_results, path, entity_result)
+
+    dpath.merge(input_data, computation_results)
+
+    return input_data
+
+
+def trace(tax_benefit_system, input_data):
+    simulation = Simulation(tax_benefit_system = tax_benefit_system, simulation_json = input_data, trace = True)
+
+    requested_computations = dpath.util.search(input_data, '*/*/*/*', afilter = lambda t: t is None, yielded = True)
+    for computation in requested_computations:
+        path = computation[0]
+        entity_plural, entity_id, variable_name, period = path.split('/')
+        simulation.calculate(variable_name, period)
+
+    trace = deepcopy(simulation.tracer.trace)
+    for vector_key, vector_trace in trace.items():
+        value = vector_trace['value'].tolist()
+        if isinstance(value[0], Enum):
+            value = [item.name for item in value]
+        if isinstance(value[0], bytes):
+            value = [to_unicode(item) for item in value]
+        vector_trace['value'] = value
+
+    return {
+        "trace": trace,
+        "entitiesDescription": {entity.plural: entity.ids for entity in simulation.entities.values()},
+        "requestedCalculations": list(simulation.tracer.requested_calculations)
+        }

--- a/openfisca_web_api/loader/__init__.py
+++ b/openfisca_web_api/loader/__init__.py
@@ -12,7 +12,7 @@ def build_data(tax_benefit_system):
     country_package_metadata = tax_benefit_system.get_package_metadata()
     parameters = build_parameters(tax_benefit_system, country_package_metadata)
     variables = build_variables(tax_benefit_system, country_package_metadata)
-    openAPI_spec = build_openAPI_specification(tax_benefit_system, country_package_metadata)
+    openAPI_spec = build_openAPI_specification(tax_benefit_system, country_package_metadata, parameters)
     return {
         'tax_benefit_system': tax_benefit_system,
         'country_package_metadata': tax_benefit_system.get_package_metadata(),

--- a/openfisca_web_api/loader/__init__.py
+++ b/openfisca_web_api/loader/__init__.py
@@ -12,13 +12,14 @@ def build_data(tax_benefit_system):
     country_package_metadata = tax_benefit_system.get_package_metadata()
     parameters = build_parameters(tax_benefit_system, country_package_metadata)
     variables = build_variables(tax_benefit_system, country_package_metadata)
-    openAPI_spec = build_openAPI_specification(tax_benefit_system, country_package_metadata, parameters)
-    return {
+    data = {
         'tax_benefit_system': tax_benefit_system,
         'country_package_metadata': tax_benefit_system.get_package_metadata(),
-        'openAPI_spec': openAPI_spec,
+        'openAPI_spec': None,
         'parameters': parameters,
         'variables': variables,
         'entities': build_entities(tax_benefit_system),
-        'host': None  # Will be set by mirroring requests
         }
+    data['openAPI_spec'] = build_openAPI_specification(data)
+
+    return data

--- a/openfisca_web_api/loader/spec.py
+++ b/openfisca_web_api/loader/spec.py
@@ -12,13 +12,14 @@ from openfisca_core.indexed_enums import Enum
 OPEN_API_CONFIG_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), os.path.pardir, 'openAPI.yml')
 
 
-def build_openAPI_specification(tax_benefit_system, country_package_metadata, parameters):
+def build_openAPI_specification(api_data):
+    tax_benefit_system = api_data['tax_benefit_system']
     file = open(OPEN_API_CONFIG_FILE, 'r')
     spec = yaml.load(file)
-    country_package_name = country_package_metadata['name'].title()
+    country_package_name = api_data['country_package_metadata']['name'].title()
     spec['info']['title'] = spec['info']['title'].replace("{COUNTRY_PACKAGE_NAME}", country_package_name)
     spec['info']['description'] = spec['info']['description'].replace("{COUNTRY_PACKAGE_NAME}", country_package_name)
-    spec['info']['version'] = country_package_metadata['version']
+    spec['info']['version'] = api_data['country_package_metadata']['version']
 
     for entity in tax_benefit_system.entities:
         name = entity.key.title()
@@ -33,8 +34,10 @@ def build_openAPI_specification(tax_benefit_system, country_package_metadata, pa
         }
 
     # Get example from the served tax benefist system
-    parameter_example = next(iter(parameters.values()))
+    parameter_example = next(iter(api_data['parameters'].values()))
     dpath.set(spec, 'definitions/Parameter/example', parameter_example)
+    variable_example = next(iter(api_data['variables'].values()))
+    dpath.set(spec, 'definitions/Variable/example', variable_example)
 
     return spec
 

--- a/openfisca_web_api/loader/spec.py
+++ b/openfisca_web_api/loader/spec.py
@@ -57,7 +57,7 @@ def build_openAPI_specification(api_data):
         dpath.new(spec, 'definitions/SituationOutput/example', handlers.calculate(tax_benefit_system, deepcopy(simulation_example)))  # calculate has side-effects
         dpath.new(spec, 'definitions/Trace/example', handlers.trace(tax_benefit_system, simulation_example))
     else:
-        message = "No simulation example has been defined for this tax and benefit system."
+        message = "No simulation example has been defined for this tax and benefit system. If you are the maintainer of {}, you can define an example by following this documentation: http://openfisca.org/doc/openfisca-web-api/config-openapi.html".format(country_package_name)
         dpath.new(spec, 'definitions/SituationInput/example', message)
         dpath.new(spec, 'definitions/SituationOutput/example', message)
         dpath.new(spec, 'definitions/Trace/example', message)

--- a/openfisca_web_api/loader/spec.py
+++ b/openfisca_web_api/loader/spec.py
@@ -17,21 +17,21 @@ def build_openAPI_specification(api_data):
     file = open(OPEN_API_CONFIG_FILE, 'r')
     spec = yaml.load(file)
     country_package_name = api_data['country_package_metadata']['name'].title()
-    spec['info']['title'] = spec['info']['title'].replace("{COUNTRY_PACKAGE_NAME}", country_package_name)
-    spec['info']['description'] = spec['info']['description'].replace("{COUNTRY_PACKAGE_NAME}", country_package_name)
-    spec['info']['version'] = api_data['country_package_metadata']['version']
+    dpath.set('info/title', spec['info']['title'].replace("{COUNTRY_PACKAGE_NAME}", country_package_name))
+    dpath.set('info/description', spec['info']['description'].replace("{COUNTRY_PACKAGE_NAME}", country_package_name))
+    dpath.set('info/version', api_data['country_package_metadata']['version'])
 
     for entity in tax_benefit_system.entities:
         name = entity.key.title()
         spec['definitions'][name] = get_entity_json_schema(entity, tax_benefit_system)
 
     situation_schema = get_situation_json_schema(tax_benefit_system)
-    spec['definitions']['SituationInput'].update(situation_schema)
-    spec['definitions']['SituationOutput'].update(situation_schema)
-    spec['definitions']['Trace']['properties']['entitiesDescription']['properties'] = {
+    dpath.set(spec, 'definitions/SituationInput', situation_schema)
+    dpath.set(spec, 'definitions/SituationOutput', situation_schema)
+    dpath.set(spec, 'definitions/Trace/properties/entitiesDescription/properties', {
         entity.plural: {'type': 'array', 'items': {"type": "string"}}
         for entity in tax_benefit_system.entities
-        }
+        })
 
     # Get example from the served tax benefist system
     parameter_example = tax_benefit_system.open_api_config.get('parameter_example') or next(iter(api_data['parameters'].values()))

--- a/openfisca_web_api/loader/spec.py
+++ b/openfisca_web_api/loader/spec.py
@@ -3,10 +3,12 @@
 from __future__ import unicode_literals, print_function, division, absolute_import
 import os
 import yaml
+from copy import deepcopy
 
 import dpath
 
 from openfisca_core.indexed_enums import Enum
+from openfisca_web_api import handlers
 
 
 OPEN_API_CONFIG_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), os.path.pardir, 'openAPI.yml')
@@ -17,28 +19,48 @@ def build_openAPI_specification(api_data):
     file = open(OPEN_API_CONFIG_FILE, 'r')
     spec = yaml.load(file)
     country_package_name = api_data['country_package_metadata']['name'].title()
-    dpath.set('info/title', spec['info']['title'].replace("{COUNTRY_PACKAGE_NAME}", country_package_name))
-    dpath.set('info/description', spec['info']['description'].replace("{COUNTRY_PACKAGE_NAME}", country_package_name))
-    dpath.set('info/version', api_data['country_package_metadata']['version'])
+    dpath.new(spec, 'info/title', spec['info']['title'].replace("{COUNTRY_PACKAGE_NAME}", country_package_name))
+    dpath.new(spec, 'info/description', spec['info']['description'].replace("{COUNTRY_PACKAGE_NAME}", country_package_name))
+    dpath.new(spec, 'info/version', api_data['country_package_metadata']['version'])
 
     for entity in tax_benefit_system.entities:
         name = entity.key.title()
         spec['definitions'][name] = get_entity_json_schema(entity, tax_benefit_system)
 
     situation_schema = get_situation_json_schema(tax_benefit_system)
-    dpath.set(spec, 'definitions/SituationInput', situation_schema)
-    dpath.set(spec, 'definitions/SituationOutput', situation_schema)
-    dpath.set(spec, 'definitions/Trace/properties/entitiesDescription/properties', {
+    dpath.new(spec, 'definitions/SituationInput', situation_schema)
+    dpath.new(spec, 'definitions/SituationOutput', situation_schema.copy())
+    dpath.new(spec, 'definitions/Trace/properties/entitiesDescription/properties', {
         entity.plural: {'type': 'array', 'items': {"type": "string"}}
         for entity in tax_benefit_system.entities
         })
 
     # Get example from the served tax benefist system
-    parameter_example = tax_benefit_system.open_api_config.get('parameter_example') or next(iter(api_data['parameters'].values()))
-    dpath.set(spec, 'definitions/Parameter/example', parameter_example)
-    variable_example = tax_benefit_system.open_api_config.get('variable_example') or next(iter(api_data['variables'].values()))
-    dpath.set(spec, 'definitions/Variable/example', variable_example)
 
+    if tax_benefit_system.open_api_config.get('parameter_example'):
+        parameter_id = tax_benefit_system.open_api_config['parameter_example']
+        parameter_path = parameter_id.replace('.', '/')
+        parameter_example = api_data['parameters'][parameter_path]
+    else:
+        parameter_example = next(iter(api_data['parameters'].values()))
+    dpath.new(spec, 'definitions/Parameter/example', parameter_example)
+
+    if tax_benefit_system.open_api_config.get('variable_example'):
+        variable_example = api_data['variables'][tax_benefit_system.open_api_config['variable_example']]
+    else:
+        variable_example = next(iter(api_data['variables'].values()))
+    dpath.new(spec, 'definitions/Variable/example', variable_example)
+
+    if tax_benefit_system.open_api_config.get('simulation_example'):
+        simulation_example = tax_benefit_system.open_api_config['simulation_example']
+        dpath.new(spec, 'definitions/SituationInput/example', simulation_example)
+        dpath.new(spec, 'definitions/SituationOutput/example', handlers.calculate(tax_benefit_system, deepcopy(simulation_example)))  # calculate has side-effects
+        dpath.new(spec, 'definitions/Trace/example', handlers.trace(tax_benefit_system, simulation_example))
+    else:
+        message = "No simulation example has been defined for this tax and benefit system."
+        dpath.new(spec, 'definitions/SituationInput/example', message)
+        dpath.new(spec, 'definitions/SituationOutput/example', message)
+        dpath.new(spec, 'definitions/Trace/example', message)
     return spec
 
 

--- a/openfisca_web_api/loader/spec.py
+++ b/openfisca_web_api/loader/spec.py
@@ -4,13 +4,15 @@ from __future__ import unicode_literals, print_function, division, absolute_impo
 import os
 import yaml
 
+import dpath
+
 from openfisca_core.indexed_enums import Enum
 
 
 OPEN_API_CONFIG_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), os.path.pardir, 'openAPI.yml')
 
 
-def build_openAPI_specification(tax_benefit_system, country_package_metadata):
+def build_openAPI_specification(tax_benefit_system, country_package_metadata, parameters):
     file = open(OPEN_API_CONFIG_FILE, 'r')
     spec = yaml.load(file)
     country_package_name = country_package_metadata['name'].title()
@@ -29,6 +31,10 @@ def build_openAPI_specification(tax_benefit_system, country_package_metadata):
         entity.plural: {'type': 'array', 'items': {"type": "string"}}
         for entity in tax_benefit_system.entities
         }
+
+    # Get example from the served tax benefist system
+    parameter_example = next(iter(parameters.values()))
+    dpath.set(spec, 'definitions/Parameter/example', parameter_example)
 
     return spec
 

--- a/openfisca_web_api/loader/spec.py
+++ b/openfisca_web_api/loader/spec.py
@@ -34,9 +34,9 @@ def build_openAPI_specification(api_data):
         }
 
     # Get example from the served tax benefist system
-    parameter_example = next(iter(api_data['parameters'].values()))
+    parameter_example = tax_benefit_system.open_api_config.get('parameter_example') or next(iter(api_data['parameters'].values()))
     dpath.set(spec, 'definitions/Parameter/example', parameter_example)
-    variable_example = next(iter(api_data['variables'].values()))
+    variable_example = tax_benefit_system.open_api_config.get('variable_example') or next(iter(api_data['variables'].values()))
     dpath.set(spec, 'definitions/Variable/example', variable_example)
 
     return spec

--- a/openfisca_web_api/openAPI.yml
+++ b/openfisca_web_api/openAPI.yml
@@ -331,61 +331,8 @@ definitions:
         type: "integer"
       plural:
         type: "string"
-  SituationInput:
-    example:
-      individus:
-        Bill:
-          salaire_de_base:
-            "2017": 20000
-        Bob:
-          salaire_de_base:
-            "2017": 30000
-        Janet: {}
-      menages:
-        menage_1:
-          personne_de_reference: [Bill]
-          conjoint: [Bob]
-          enfants: [Janet]
-          revenu_disponible:
-            "2017": null
-          impots_directs:
-            "2017": null
-      familles:
-        famille_1:
-          parents: [Bill, Bob]
-          enfants: [Janet]
-      foyers_fiscaux:
-        foyer_fiscal_1:
-          declarants: [Bill, Bob]
-          personnes_a_charge: [Janet]
-
-  SituationOutput:
-    example:
-      individus:
-        Bill:
-          salaire_de_base:
-            "2017": 20000
-        Bob:
-          salaire_de_base:
-            "2017": 30000
-        Janet: {}
-      menages:
-        menage_1:
-          personne_de_reference: [Bill]
-          conjoint: [Bob]
-          enfants: [Janet]
-          revenu_disponible:
-            "2017": 36585.89
-          impots_directs:
-            "2017": -3733.72
-      familles:
-        famille_1:
-          parents: [Bill, Bob]
-          enfants: [Janet]
-      foyers_fiscaux:
-        foyer_fiscal_1:
-          declarants: [Bill, Bob]
-          personnes_a_charge: [Janet]
+  SituationInput: null
+  SituationOutput: null
 
   Trace:
     type: object
@@ -410,23 +357,7 @@ definitions:
               type: array
               items:
                 type: string
-    example:
-      requestedCalculations: [revenu_disponible<2017>]
-      entitiesDescription:
-        individus: [Bill, Bob, Janet]
-        menages: [menage_1]
-        familles: [famille_1]
-        foyers_fiscaux: [foyer_fiscal_1]
-      trace:
-        revenu_disponible<2017>:
-          value: 18000
-          dependencies: [impots<2017>, salaire<2017>]
-        impots<2017>:
-          value: 2000
-          dependencies: [salaire<2017>]
-        salaire<2017>:
-          value: 20000
-          dependencies: []
+    example: null
 
 commons:
   Headers:

--- a/openfisca_web_api/openAPI.yml
+++ b/openfisca_web_api/openAPI.yml
@@ -230,32 +230,7 @@ definitions:
         format: "string"
       source:
         type: "string"
-    example:
-      id: "cotsoc.gen.smic_h_b"
-      description: "SMIC horaire brut"
-      values: {"2001-08-01": 6.67,
-                "2002-07-01": 6.83,
-                "2003-07-01": 7.19,
-                "2004-07-01": 7.61,
-                "2005-07-01": 8.03,
-                "2006-07-01": 8.27,
-                "2007-07-01": 8.44,
-                "2008-05-01": 8.63,
-                "2008-07-01": 8.71,
-                "2009-07-01": 8.82,
-                "2010-01-01": 8.86,
-                "2011-01-01": 9.0,
-                "2011-12-01": 9.19,
-                "2012-01-01": 9.22,
-                "2012-07-01": 9.4,
-                "2013-01-01": 9.43,
-                "2014-01-01": 9.53,
-                "2015-01-01": 9.61,
-                "2016-01-01": 9.67,
-                "2017-01-01": 9.76}
-      source: https://github.com/openfisca/openfisca-france/blob/22.2.1/openfisca_france/parameters/cotsoc/gen/smic_h_b.yaml
-      metadata:
-        unit: "currency-EUR"
+    example: null
 
   Parameters:
     type: "object"

--- a/openfisca_web_api/openAPI.yml
+++ b/openfisca_web_api/openAPI.yml
@@ -239,6 +239,8 @@ definitions:
       properties:
         description:
           type: 'string'
+        href:
+          type: 'string'
 
   Variable:
     type: "object"
@@ -283,6 +285,8 @@ definitions:
       type: "object"
       properties:
         description:
+          type: 'string'
+        href:
           type: 'string'
 
   Formula:

--- a/openfisca_web_api/openAPI.yml
+++ b/openfisca_web_api/openAPI.yml
@@ -275,21 +275,7 @@ definitions:
           - Boolean
           - Date
           - String
-    example:
-      defaultValue: 0,
-      definitionPeriod: "MONTH"
-      description: "Aide à l'embauche d'un salarié pour les PME"
-      entity: "individu"
-      id: "aide_embauche_pme"
-      references: [
-                    "http://travail-emploi.gouv.fr/grands-dossiers/embauchepme"
-                  ]
-      source: "https://github.com/openfisca/openfisca-france/blob/18.2.5/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegement.py#L214-L287"
-      valueType: "Float"
-      formulas: { "2016-01-18":{
-                    "content": "def formula_2016_01_18(individu, period, parameters):\n    effectif_entreprise = individu('effectif_entreprise', period)\n    apprenti = individu('apprenti', period)\n    contrat_de_travail_duree = individu('contrat_de_travail_duree', period)\n    TypesContratDeTravailDuree = contrat_de_travail_duree.possible_values\n    contrat_de_travail_debut = individu('contrat_de_travail_debut', period)\n    contrat_de_travail_fin = individu('contrat_de_travail_fin', period)\n    coefficient_proratisation = individu('coefficient_proratisation', period)\n    smic_proratise = individu('smic_proratise', period)\n    salaire_de_base = individu('salaire_de_base', period)\n    exoneration_cotisations_employeur_jei = individu('exoneration_cotisations_employeur_jei', period)\n    aide_premier_salarie = individu('aide_premier_salarie', period)\n\n    # Cette aide est temporaire.\n    # Si toutefois elle est reconduite et modifiée, les dates et le montant seront à implémenter comme\n    # des params xml.\n\n    # jusqu’à 1,3 fois le Smic\n    eligible_salaire = salaire_de_base <= (1.3 * smic_proratise)\n\n    # pour les PME\n    eligible_effectif = effectif_entreprise < 250\n\n    non_cumulee = and_(\n        # non cumulable avec l'aide pour la première embauche\n        # qui est identique, si ce n'est qu'elle couvre tous les salaires\n        aide_premier_salarie == 0,\n        # non cumul avec le dispositif Jeune Entreprise Innovante (JEI)\n        not_(exoneration_cotisations_employeur_jei)\n        )\n\n    eligible_contrat = and_(\n        contrat_de_travail_debut >= datetime64(\"2016-01-18\"),\n        contrat_de_travail_debut <= datetime64(\"2017-06-30\")\n        )\n\n    # Si CDD, durée du contrat doit être > 1 an\n    eligible_duree = or_(\n        # durée indéterminée\n        contrat_de_travail_duree == TypesContratDeTravailDuree.cdi,\n        # durée déterminée supérieure à 1 an\n        and_(\n            # CDD\n            contrat_de_travail_duree == TypesContratDeTravailDuree.cdd,\n            # > 6 mois\n            (contrat_de_travail_fin - contrat_de_travail_debut).astype('timedelta64[M]') >= timedelta64(6, 'M')\n            )\n        )\n\n    # Valable 2 ans seulement\n    eligible_date = datetime64(period.offset(-24, 'month').start) < contrat_de_travail_debut\n\n    eligible = (\n        eligible_salaire * eligible_effectif * non_cumulee * eligible_contrat * eligible_duree *\n        eligible_date * not_(apprenti)\n        )\n    # somme sur 24 mois, à raison de 500 € maximum par trimestre\n    montant_max = 4000\n\n    # Si le salarié est embauché à temps partiel,\n    # l’aide est proratisée en fonction de sa durée de travail.\n    # TODO cette multiplication par le coefficient de proratisation suffit-elle pour le cas du temps partiel ?\n    # A tester\n\n    return eligible * (montant_max / 24) * coefficient_proratisation\n",
-      "source": "https://github.com/openfisca/openfisca-france/blob/21.8.1/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py#L213-L285"
-      } }
+    example: null
 
   Variables:
     type: "object"

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.5.6',
+    version = '24.6.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
Connected to #664 

Country package maintainers can define which examples they want to use in their OpenAPI spec the following way: https://github.com/openfisca/country-template/compare/define-openapi-ex

If no example has been defined:
    - An arbitrary parameter is used for the `/parameter` route example
    - An arbitrary variable is used for the `/variable` route example
    - No example is shown for the `/calculate` and `/trace` routes. Instead, a text message such as the following is displayed:

![image](https://user-images.githubusercontent.com/11834997/47042257-cfe4b680-d158-11e8-888b-769524c68a2b.png)