### PR TITLE
Fix OpenAPI spec host and schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 24.6.1 [#745](https://github.com/openfisca/openfisca-core/pull/745)
+
+- Fix `host` property in the OpenAPI `/spec`
+  - It should not contain the scheme (e.g. `http`)
+- Infer scheme from request
+  - Before, we would assume `https`, which is not always accurate
+
 ## 24.6.0 [#744](https://github.com/openfisca/openfisca-core/pull/744)
 
 - Allow TaxBenefitSystem to define the examples to use in the `/spec` route.

--- a/openfisca_web_api/app.py
+++ b/openfisca_web_api/app.py
@@ -119,7 +119,8 @@ def create_app(tax_benefit_system,
         # Ugly Python2-compatible way
         response = {}
         response.update(data['openAPI_spec'])
-        response.update({'host': request.host_url})
+        response.update({'host': request.host})
+        response.update({'schemes': [request.environ['wsgi.url_scheme']]})
         return jsonify(response)
 
         # Nice Python3 syntax, but doesn't work in Python 2

--- a/openfisca_web_api/openAPI.yml
+++ b/openfisca_web_api/openAPI.yml
@@ -10,8 +10,7 @@ info:
     name: "AGPL"
     url: "https://www.gnu.org/licenses/agpl-3.0"
 host: null
-schemes:
-  - "https"
+schemes: null
 tags:
   - name: "Parameters"
     description: "A parameter is a numeric property of the legislation that can evolve over time."

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.6.0',
+    version = '24.6.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
- Fix `host` property in the OpenAPI `/spec`
  - It should not contain the scheme (e.g. `http`)
- Infer scheme from request
  - Before, we would assume `https`, which is not always accurate