### PR TITLE
Use PyTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-### 24.5.2 [#734](https://github.com/openfisca/openfisca-core/pull/734)
+### 24.6.3 [#746](https://github.com/openfisca/openfisca-core/pull/746)
+
+- Use `pytest` to run tests, as `nose` and `nose2` are not in active development anymore
+- Declare `nose` as a dependency so dependee libraries like `openfisca-france`can use `openfisca-run-test` without having to add `nose` as a dependency
+
+_Note: `openfisca-run-test` still depends on `nose`._
+
+
+### 24.6.2 [#735](https://github.com/openfisca/openfisca-core/pull/735)
 
 - Apply W504 enforcement (Knuth's style)
 - Removes version cap on linting libraries

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 all: test
 
+uninstall:
+	pip freeze | grep -v "^-e" | xargs pip uninstall -y
+
 install:
 	pip install --upgrade pip twine wheel
 	pip install --editable .[dev] --upgrade
@@ -21,8 +24,8 @@ format-style:
 	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
 	autopep8 `git ls-files | grep "\.py$$"`
 
-test: clean check-syntax-errors check-style
-	nosetests
+test: clean check-syntax-errors format-style check-style
+	pytest
 
 api:
 	openfisca serve --country-package openfisca_country_template --extensions openfisca_extension_template

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,3 +18,7 @@ where        = tests
 exe          = true
 with-doctest = true
 
+[tool:pytest]
+addopts      = --showlocals --exitfirst --doctest-modules --disable-pytest-warnings
+testpaths    = tests
+python_files = **/*.py

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.6.2',
+    version = '24.6.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ general_requirements = [
     'dpath == 1.4.0',
     'enum34 >= 1.1.6',
     'future',
+    'nose',  # For openfisca-run-test
     'numpy >= 1.11, < 1.15',
     'psutil == 5.4.6',
     'PyYAML >= 3.10',
@@ -23,9 +24,10 @@ api_requirements = [
     ]
 
 dev_requirements = [
-    'nose',
-    'flake8',
-    'autopep8',
+    'autopep8 == 1.4.0',
+    'flake8 >= 3.5.0, < 3.6.0',
+    'pycodestyle >= 2.3.0, < 2.4.0',  # To avoid incompatibility with flake8
+    'pytest',
     'openfisca-country-template >= 3.4.0, < 4.0.0',
     'openfisca-extension-template >= 1.1.3, < 2.0.0',
     ] + api_requirements


### PR DESCRIPTION
#### Technical changes

- Use `pytest` to run tests.
- Declare `nose` a dependency so dependee libraries can move away from `nose`.
- `nose` is in maintenance mode
- `nose2` was a spin-off of `unittest2`

_Note: `openfisca-run-test` still depends on nose._
