### PR TITLE
Do not format style before check

### DIFF
--- a/.circleci/has-functional-changes.sh
+++ b/.circleci/has-functional-changes.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-IGNORE_DIFF_ON="README.md CONTRIBUTING.md .gitignore .circleci/* .github/* tests/*"
+IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore .circleci/* .github/* tests/*"
 
 last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in master through an unlikely intermediary merge commit
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ format-style:
 	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
 	autopep8 `git ls-files | grep "\.py$$"`
 
-test: clean check-syntax-errors format-style check-style
+test: clean check-syntax-errors check-style
 	pytest
 
 api:


### PR DESCRIPTION
#### Technical changes

- Avoid race condition on CircleCI while formatting before linting
- By doing so, style errors were being overlooked
