### PR TITLE
Improve libyaml doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 24.6.4 [#???](https://github.com/openfisca/openfisca-core/pull/???)
+
+- Improve the warning message incentivizing users to install `libyaml`
+  - `pyyaml` need to be fully reinstalled to use `libyaml`
+
 ### 24.6.3 [#746](https://github.com/openfisca/openfisca-core/pull/746)
 
 - Use `pytest` to run tests, as `nose` and `nose2` are not in active development anymore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 24.6.4 [#???](https://github.com/openfisca/openfisca-core/pull/???)
 
 - Improve the warning message incentivizing users to install `libyaml`
-  - `pyyaml` need to be fully reinstalled to use `libyaml`
+  - `pyyaml` needs to be fully reinstalled to use `libyaml`
 
 ### 24.6.3 [#746](https://github.com/openfisca/openfisca-core/pull/746)
 

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -26,7 +26,7 @@ try:
     from yaml import CLoader as Loader
 except ImportError:
     log.warning(
-        "libyaml is not installed in your environment. This can make OpenFisca slower to start. Once you have installed libyaml, run 'pip uninstall pyyaml && pip install pyyaml' so that it is used in your Python environment." + os.linesep)
+        "libyaml is not installed in your environment. This can make OpenFisca slower to start. Once you have installed libyaml, run 'pip uninstall pyyaml && pip install pyyaml --no-cache-dir' so that it is used in your Python environment." + os.linesep)
     from yaml import Loader
 
 

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -33,7 +33,7 @@ except ImportError:
         ' '
         'libyaml is not installed in your environment, this can make your '
         'test suite slower to run. Once you have installed libyaml, run `pip '
-        'uninstall pyyaml && pip install pyyaml` so that it is used in your '
+        'uninstall pyyaml && pip install pyyaml --no-cache-dir` so that it is used in your '
         'Python environment.')
     from yaml import Loader, Dumper
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.6.3',
+    version = '24.6.4',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
- Improve the warning message incentivizing users to install `libyaml`
  - `pyyaml` need to be fully reinstalled to use `libyaml`