### PR TITLE
Use branch name in CircleCI's cache identifier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-py2-{{ checksum "setup.py" }}
+          key: v1-py2-{{ .Branch }}-{{ checksum "setup.py" }}
 
       - run:
           name: Create a virtualenv
@@ -25,7 +25,7 @@ jobs:
             # pip install --editable git+https://github.com/openfisca/country-template.git@BRANCH_NAME#egg=OpenFisca-Country-Template  # use a specific branch of OpenFisca-Country-Template
 
       - save_cache:
-          key: v1-py2-{{ checksum "setup.py" }}
+          key: v1-py2-{{ .Branch }}-{{ checksum "setup.py" }}
           paths:
             - /tmp/venv/openfisca_core
 
@@ -44,7 +44,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-py2-{{ checksum "setup.py" }}
+          key: v1-py2-{{ .Branch }}-{{ checksum "setup.py" }}
 
       - run:
           name: Check for functional changes
@@ -68,7 +68,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-py3-{{ checksum "setup.py" }}
+          key: v1-py3-{{ .Branch }}-{{ checksum "setup.py" }}
 
       - run:
           name: Create a virtualenv
@@ -84,7 +84,7 @@ jobs:
             # pip install --editable git+https://github.com/openfisca/country-template.git@BRANCH_NAME#egg=OpenFisca-Country-Template  # use a specific branch of OpenFisca-Country-Template
 
       - save_cache:
-          key: v1-py3-{{ checksum "setup.py" }}
+          key: v1-py3-{{ .Branch }}-{{ checksum "setup.py" }}
           paths:
             - /tmp/venv/openfisca_core
 
@@ -103,7 +103,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-py3-{{ checksum "setup.py" }}
+          key: v1-py3-{{ .Branch }}-{{ checksum "setup.py" }}
 
       - run:
           name: Check for functional changes


### PR DESCRIPTION
Fixes #759 

#### Non-technical changes

- Use branch name in CircleCI's cache identifier
