### PR TITLE
Fix inconsistent access to sub-parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
-### 24.9.5 [#771](https://github.com/openfisca/openfisca-core/pull/771)
+### 24.9.7 [#769](https://github.com/openfisca/openfisca-core/pull/769)
+
+- Unify the protocol for appending sub-parameters
+
+### 24.9.6 [#771](https://github.com/openfisca/openfisca-core/pull/771)
 
 - Improve serve command by documenting the bind option
 - Avoid crashing when no arguments are supplied
 
-### 24.9.4 [#774](https://github.com/openfisca/openfisca-core/pull/774)
+### 24.9.5 [#774](https://github.com/openfisca/openfisca-core/pull/774)
 
 - Clarify the error message when assigning a value larger than MaxInt32 to an 'int' variable
 

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -380,15 +380,13 @@ class ParameterNode(object):
                     else:
                         child_name_expanded = _compose_name(name, child_name)
                         child = load_parameter_file(child_path, child_name_expanded)
-                        self.children[child_name] = child
-                        setattr(self, child_name, child)
+                        self.add_child(child_name, child)
 
                 elif os.path.isdir(child_path):
                     child_name = os.path.basename(child_path)
                     child_name_expanded = _compose_name(name, child_name)
                     child = ParameterNode(child_name_expanded, directory_path = child_path)
-                    self.children[child_name] = child
-                    setattr(self, child_name, child)
+                    self.add_child(child_name, child)
 
         else:
             self.file_path = file_path
@@ -404,8 +402,7 @@ class ParameterNode(object):
                 child_name = str(child_name)
                 child_name_expanded = _compose_name(name, child_name)
                 child = _parse_child(child_name_expanded, child, file_path)
-                self.children[child_name] = child
-                setattr(self, child_name, child)
+                self.add_child(child_name, child)
 
     def __call__(self, instant):
         return self.get_at_instant(instant)
@@ -424,7 +421,7 @@ class ParameterNode(object):
         In case of child name conflict, the other node child will replace the current node child.
         """
         for child_name, child in other.children.items():
-            self.children[child_name] = child
+            self.add_child(child_name, child)
 
     def add_child(self, name, child):
         """

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -478,8 +478,11 @@ class ParameterNodeAtInstant(object):
         for child_name, child in node.children.items():
             child_at_instant = child._get_at_instant(instant_str)
             if child_at_instant is not None:
-                self._children[child_name] = child_at_instant
-                setattr(self, child_name, child_at_instant)
+                self.add_child(child_name, child_at_instant)
+
+    def add_child(self, child_name, child_at_instant):
+        self._children[child_name] = child_at_instant
+        setattr(self, child_name, child_at_instant)
 
     def __getattr__(self, key):
         param_name = _compose_name(self._name, item_name = key)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.9.6',
+    version = '24.9.7',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_extensions.py
+++ b/tests/core/test_extensions.py
@@ -31,6 +31,7 @@ def test_load_extension():
     assert tbs.get_variable('local_town_child_allowance') is not None
 
     assert walk_and_count(tbs.parameters) == 9
+    assert tbs.parameters('2016-01').local_town.child_allowance.amount == 100.0
     assert tbs.parameters.local_town.child_allowance.amount is not None
 
 

--- a/tests/core/test_extensions.py
+++ b/tests/core/test_extensions.py
@@ -1,7 +1,9 @@
 from __future__ import unicode_literals, print_function, division, absolute_import
 from nose.tools import raises
 
+from openfisca_core.parameters import ParameterNode
 from openfisca_country_template import CountryTaxBenefitSystem
+
 
 tbs = CountryTaxBenefitSystem()
 
@@ -10,9 +12,27 @@ def test_extension_not_already_loaded():
     assert tbs.get_variable('local_town_child_allowance') is None
 
 
+def walk_and_count(node):
+    c = 0
+    for item_name, item in node.children.items():
+        if isinstance(item, ParameterNode):
+            c += walk_and_count(item)
+        else:
+            c += 1
+    return c
+
+
 def test_load_extension():
+    assert len(tbs.variables) == 16
+    assert walk_and_count(tbs.parameters) == 8
     tbs.load_extension('openfisca_extension_template')
+    
+    assert len(tbs.variables) == 17
     assert tbs.get_variable('local_town_child_allowance') is not None
+
+    assert walk_and_count(tbs.parameters) == 9
+    assert tbs.parameters.local_town.child_allowance.amount is not None
+    
 
 
 def test_unload_extensions():

--- a/tests/core/test_extensions.py
+++ b/tests/core/test_extensions.py
@@ -26,13 +26,12 @@ def test_load_extension():
     assert len(tbs.variables) == 16
     assert walk_and_count(tbs.parameters) == 8
     tbs.load_extension('openfisca_extension_template')
-    
+
     assert len(tbs.variables) == 17
     assert tbs.get_variable('local_town_child_allowance') is not None
 
     assert walk_and_count(tbs.parameters) == 9
     assert tbs.parameters.local_town.child_allowance.amount is not None
-    
 
 
 def test_unload_extensions():

--- a/tests/core/test_extensions.py
+++ b/tests/core/test_extensions.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals, print_function, division, absolute_import
 from nose.tools import raises
 
-from openfisca_core.parameters import ParameterNode
 from openfisca_country_template import CountryTaxBenefitSystem
 
 
@@ -12,43 +11,20 @@ def test_extension_not_already_loaded():
     assert tbs.get_variable('local_town_child_allowance') is None
 
 
-def walk_and_count(node):
-    c = 0
-    for item_name, item in node.children.items():
-        if isinstance(item, ParameterNode):
-            c += walk_and_count(item)
-        else:
-            c += 1
-    return c
-
-
 def test_load_extension():
-    country_template_variables_number = 16
-    country_template_parameters_number = 8
-    assert len(tbs.variables) == country_template_variables_number
-    assert walk_and_count(tbs.parameters) == country_template_parameters_number
-
-    # Access a parameter of the country template > OK
-    assert tbs.parameters('2016-01').benefits.housing_allowance == 0.25
-    assert tbs.parameters.benefits.housing_allowance('2016-01') == 0.25
-    assert tbs.parameters.benefits.housing_allowance is not None
+    tbs = CountryTaxBenefitSystem()
+    assert tbs.get_variable('local_town_child_allowance') is None
 
     tbs.load_extension('openfisca_extension_template')
 
-    # Access a variable of the extension template > OK
-    assert len(tbs.variables) == country_template_variables_number + 1
     assert tbs.get_variable('local_town_child_allowance') is not None
 
-    # Access a parameter of the extension template > KO, sometimes
-    assert walk_and_count(tbs.parameters) == country_template_parameters_number + 1
+
+def test_access_to_parameters():
+    tbs.load_extension('openfisca_extension_template')
+
     assert tbs.parameters('2016-01').local_town.child_allowance.amount == 100.0
     assert tbs.parameters.local_town.child_allowance.amount('2016-01') == 100.0
-    assert tbs.parameters.local_town.child_allowance.amount is not None
-
-
-def test_unload_extensions():
-    tbs = CountryTaxBenefitSystem()
-    assert tbs.get_variable('local_town_child_allowance') is None
 
 
 @raises(ValueError)

--- a/tests/core/test_extensions.py
+++ b/tests/core/test_extensions.py
@@ -23,15 +23,26 @@ def walk_and_count(node):
 
 
 def test_load_extension():
-    assert len(tbs.variables) == 16
-    assert walk_and_count(tbs.parameters) == 8
+    country_template_variables_number = 16
+    country_template_parameters_number = 8
+    assert len(tbs.variables) == country_template_variables_number
+    assert walk_and_count(tbs.parameters) == country_template_parameters_number
+
+    # Access a parameter of the country template > OK
+    assert tbs.parameters('2016-01').benefits.housing_allowance == 0.25
+    assert tbs.parameters.benefits.housing_allowance('2016-01') == 0.25
+    assert tbs.parameters.benefits.housing_allowance is not None
+
     tbs.load_extension('openfisca_extension_template')
 
-    assert len(tbs.variables) == 17
+    # Access a variable of the extension template > OK
+    assert len(tbs.variables) == country_template_variables_number + 1
     assert tbs.get_variable('local_town_child_allowance') is not None
 
-    assert walk_and_count(tbs.parameters) == 9
+    # Access a parameter of the extension template > KO, sometimes
+    assert walk_and_count(tbs.parameters) == country_template_parameters_number + 1
     assert tbs.parameters('2016-01').local_town.child_allowance.amount == 100.0
+    assert tbs.parameters.local_town.child_allowance.amount('2016-01') == 100.0
     assert tbs.parameters.local_town.child_allowance.amount is not None
 
 


### PR DESCRIPTION
Fixes #762 

#### Bug fixes

- In `parameters.py`, there is rampant duplication of the following two lines:

```Python
self.children[child_name] = child
setattr(self, child_name, child)
```

However, in a few cases - including merging parameters from extensions, as in the issue referenced - the array is written to, without the call to setattr taking place. This will result in an inconsistent state and a ParameterNotFound exception even though the parameter seems to have been correctly loaded. This PR aims to channel all additions of a descendant to a parameter node via add_child.