### PR TITLE
Improve serve command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 24.9.5 [#771](https://github.com/openfisca/openfisca-core/pull/771)
+
+- Improve serve command by documenting the bind option
+- Avoid crashing when no arguments are supplied
+
 ### 24.9.4 [#774](https://github.com/openfisca/openfisca-core/pull/774)
 
 - Clarify the error message when assigning a value larger than MaxInt32 to an 'int' variable

--- a/openfisca_core/scripts/openfisca_command.py
+++ b/openfisca_core/scripts/openfisca_command.py
@@ -13,8 +13,9 @@ from openfisca_web_api.scripts.serve import define_command_line_options, main as
 def get_parser():
     parser = argparse.ArgumentParser()
 
-    subparsers = parser.add_subparsers(help='Available commands')
-    parser_serve = subparsers.add_parser('serve', help='Run the OpenFisca Web API')
+    subparsers = parser.add_subparsers(help = 'Available commands', dest = 'command')
+    subparsers.required = True  # Can be added as an argument of add_subparsers in Python 3
+    parser_serve = subparsers.add_parser('serve', help = 'Run the OpenFisca Web API')
     parser_serve = define_command_line_options(parser_serve)
 
     return parser

--- a/openfisca_web_api/scripts/serve.py
+++ b/openfisca_web_api/scripts/serve.py
@@ -34,7 +34,7 @@ def define_command_line_options(parser):
     parser = add_tax_benefit_system_arguments(parser)
 
     # Define server configuration
-    parser.add_argument('-p', '--port', action = 'store', help = "port to serve on", type = int)
+    parser.add_argument('-p', '--port', action = 'store', help = "port to serve on (use --bind to specify host and port)", type = int)
     parser.add_argument('--tracker-url', action = 'store', help = "tracking service url", type = str)
     parser.add_argument('--tracker-idsite', action = 'store', help = "tracking service id site", type = int)
     parser.add_argument('--tracker-token', action = 'store', help = "tracking service authentication token", type = str)
@@ -48,7 +48,7 @@ def read_user_configuration(default_configuration, command_line_parser):
     configuration = default_configuration
     args, unknown_args = command_line_parser.parse_known_args()
 
-    if args.configuration_file:
+    if 'configuration_file' in vars(args) and args.configuration_file:
         file_configuration = {}
         with open(args.configuration_file, "r") as file:
             exec(file.read(), {}, file_configuration)

--- a/openfisca_web_api/scripts/serve.py
+++ b/openfisca_web_api/scripts/serve.py
@@ -48,7 +48,7 @@ def read_user_configuration(default_configuration, command_line_parser):
     configuration = default_configuration
     args, unknown_args = command_line_parser.parse_known_args()
 
-    if 'configuration_file' in vars(args) and args.configuration_file:
+    if args.configuration_file:
         file_configuration = {}
         with open(args.configuration_file, "r") as file:
             exec(file.read(), {}, file_configuration)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.9.5',
+    version = '24.9.6',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
Fixes #634 

We need to be able to specify host as well as port in `openfisca serve`.

Absent a specific `host` option, `openfisca serve --bind 0.0.0.0:7777` will do, as the [documentation](https://openfisca.org/doc/openfisca-python-api/openfisca_serve.html) hints at.

Discoverability of this was limited in two ways:
- the bare command `openfisca` crashed with `AttributeError: 'Namespace' object has no attribute 'vars'`
- the help option `openfisca serve -h` does not mention gunicorn's `--bind`

This PR fixes both shortcomings.