### PR TITLE
Cap PyTest version to avoid failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+### 24.8.1 [#772](https://github.com/openfisca/openfisca-core/pull/772)
+
+- Limits the range of PyTest versions to < 4.0 to avoid CI crashes caused by 4.0.
+
 ## 24.8.0 [#765](https://github.com/openfisca/openfisca-core/pull/765)
 
-- Add called parameters to Web API `/trace` endpoint
+- Adds called parameters to Web API `/trace` endpoint
   - For a calculated variable, add `parameters` item next to `dependencies` in `/trace` response
   - For example:
   ```JSON

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.8.0',
+    version = '24.8.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ dev_requirements = [
     'autopep8 == 1.4.0',
     'flake8 >= 3.5.0, < 3.6.0',
     'pycodestyle >= 2.3.0, < 2.4.0',  # To avoid incompatibility with flake8
-    'pytest',
+    'pytest < 4.0',
     'openfisca-country-template >= 3.4.0, < 4.0.0',
     'openfisca-extension-template >= 1.1.3, < 2.0.0',
     ] + api_requirements


### PR DESCRIPTION
PyTest 4 is currently breaking CI builds, this PR limits the range of PyTest versions to < 4.0 to avoid that.