### PR TITLE
Cap all dependency versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 24.8.2 [#773](https://github.com/openfisca/openfisca-core/pull/773)
+
+- Make sure to cap all dependency versions, in order to avoid unwanted functional and integration breaks caused by external code updates
+  - For example [#772](https://github.com/openfisca/openfisca-core/pull/772)
+
 ### 24.8.1 [#772](https://github.com/openfisca/openfisca-core/pull/772)
 
 - Limits the range of PyTest versions to < 4.0 to avoid CI crashes caused by 4.0.

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,15 @@
 from __future__ import unicode_literals, print_function, division, absolute_import
 from setuptools import setup, find_packages
 
+# Please make sure to cap all dependency versions, in order to avoid unwanted
+# functional and integration breaks caused by external code updates.
 
 general_requirements = [
     'Biryani[datetimeconv] >= 0.10.8',
     'dpath == 1.4.0',
     'enum34 >= 1.1.6',
-    'future',
-    'nose',  # For openfisca-run-test
+    'future < 1.0.0',
+    'nose < 2.0.0',  # For openfisca-run-test
     'numpy >= 1.11, < 1.16',
     'psutil == 5.4.6',
     'PyYAML >= 3.10',
@@ -28,7 +30,7 @@ dev_requirements = [
     'autopep8 == 1.4.0',
     'flake8 >= 3.5.0, < 3.6.0',
     'pycodestyle >= 2.3.0, < 2.4.0',  # To avoid incompatibility with flake8
-    'pytest < 4.0',
+    'pytest < 4.0.0',
     'openfisca-country-template >= 3.4.0, < 4.0.0',
     'openfisca-extension-template >= 1.1.3, < 2.0.0',
     ] + api_requirements

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.8.1',
+    version = '24.8.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
Applies learning from #772 

Make sure to cap all dependency versions, in order to avoid unwanted functional and integration breaks caused by external code updates.