### PR TITLE
Deal with OverflowError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 24.9.4 [#774](https://github.com/openfisca/openfisca-core/pull/774)
+
+- Clarify the error message when assigning a value larger than MaxInt32 to an 'int' variable
+
 ### 24.9.4 [#777](https://github.com/openfisca/openfisca-core/pull/777)
 
 - Allow OpenFisca-Core users to define their own level of log

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -104,7 +104,7 @@ class Entity(object):
                     try:
                         array[entity_index] = value
                     except (OverflowError):
-                        error_message = "Can't deal with value: '{}', it's too large for type {}.".format(value, holder.variable.value_type)
+                        error_message = "Can't deal with value: '{}', it's too large for type '{}'.".format(value, holder.variable.json_type)
                         raise SituationParsingError(path_in_json, error_message)
                     except (ValueError, TypeError):
                         if holder.variable.value_type == date:

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -79,7 +79,7 @@ class Entity(object):
 
             if not isinstance(variable_values, dict):
                 raise SituationParsingError(path_in_json,
-                    "Invalid type: must be of type object. Input variables must be set for specific periods. For instance: {'salary': {'2017-01': 2000, '2017-02': 2500}}, or {'birth_date': {'ETERNITY': '1980-01-01'}}.")
+                    "Can't deal with type: expected object. Input variables should be set for specific periods. For instance: {'salary': {'2017-01': 2000, '2017-02': 2500}}, or {'birth_date': {'ETERNITY': '1980-01-01'}}.")
 
             holder = self.get_holder(variable_name)
             for period_str, value in variable_values.items():
@@ -98,16 +98,19 @@ class Entity(object):
                         except KeyError:
                             possible_values = [item.name for item in holder.variable.possible_values]
                             raise SituationParsingError(path_in_json,
-                                "'{}' is not a valid value for '{}'. Possible values are ['{}'].".format(
+                                "'{}' is not a known value for '{}'. Possible values are ['{}'].".format(
                                     value, variable_name, "', '".join(possible_values))
                                 )
                     try:
                         array[entity_index] = value
+                    except (OverflowError):
+                        error_message = "Can't deal with value: '{}', it's too large for type {}.".format(value, holder.variable.value_type)
+                        raise SituationParsingError(path_in_json, error_message)
                     except (ValueError, TypeError):
                         if holder.variable.value_type == date:
-                            error_message = "Invalid date: '{}'.".format(value)
+                            error_message = "Can't deal with date: '{}'.".format(value)
                         else:
-                            error_message = "Invalid value: must be of type {}, received '{}'.".format(holder.variable.json_type, value)
+                            error_message = "Can't deal with value: expected type {}, received '{}'.".format(holder.variable.json_type, value)
                         raise SituationParsingError(path_in_json, error_message)
 
                     holder.buffer[period] = array

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.9.4',
+    version = '24.9.5',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/web_api/test_calculate.py
+++ b/tests/web_api/test_calculate.py
@@ -42,10 +42,10 @@ def test_responses():
         ('{"persons": {"bob": {"unknown_variable": {}}}}', NOT_FOUND, 'persons/bob/unknown_variable', 'You tried to calculate or to set',),
         ('{"persons": {"bob": {"housing_allowance": {}}}}', BAD_REQUEST, 'persons/bob/housing_allowance', "You tried to compute the variable 'housing_allowance' for the entity 'persons'",),
         ('{"persons": {"bob": {"salary": 4000 }}}', BAD_REQUEST, 'persons/bob/salary', 'period',),
-        ('{"persons": {"bob": {"salary": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/salary/2017-01', 'must be of type number',),
-        ('{"persons": {"bob": {"salary": {"2017-01": {}} }}}', BAD_REQUEST, 'persons/bob/salary/2017-01', 'must be of type number',),
-        ('{"persons": {"bob": {"age": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/age/2017-01', 'must be of type integer',),
-        ('{"persons": {"bob": {"birth": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/birth/2017-01', 'Invalid date',),
+        ('{"persons": {"bob": {"salary": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/salary/2017-01', 'expected type number',),
+        ('{"persons": {"bob": {"salary": {"2017-01": {}} }}}', BAD_REQUEST, 'persons/bob/salary/2017-01', 'expected type number',),
+        ('{"persons": {"bob": {"age": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/age/2017-01', 'expected type integer',),
+        ('{"persons": {"bob": {"birth": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/birth/2017-01', 'Can\'t deal with date',),
         ('{"persons": {"bob": {}}, "households": {"household": {"parents": ["unexpected_person_id"]}}}', BAD_REQUEST, 'households/household/parents', 'has not been declared in persons',),
         ('{"persons": {"bob": {}}, "households": {"household": {"parents": ["bob", "bob"]}}}', BAD_REQUEST, 'households/household/parents', 'has been declared more than once',),
         ('{"persons": {"bob": {}}, "households": {"household": {"parents": ["bob", {}]}}}', BAD_REQUEST, 'households/household/parents/1', 'Invalid type',),
@@ -211,7 +211,7 @@ def test_encoding_variable_value():
     assert_equal(response.status_code, BAD_REQUEST, response.data.decode('utf-8'))
     response_json = json.loads(response.data.decode('utf-8'))
     assert_in(
-        "'Locataire ou sous-locataire d‘un logement loué vide non-HLM' is not a valid value for 'housing_occupancy_status'. Possible values are ",
+        "'Locataire ou sous-locataire d‘un logement loué vide non-HLM' is not a known value for 'housing_occupancy_status'. Possible values are ",
         dpath.get(response_json, 'households/_/housing_occupancy_status/2017-07')
         )
 


### PR DESCRIPTION
Fixes https://github.com/openfisca/openfisca-france/issues/1197

#### Technical changes

- In `Entity.init_from_json/init_variable_values`, attempting to assign a value larger than MaxInt32 resulted in a somewhat cryptic OverflowError.
- This PR fixes that, and also nudges the language away from "Invalid X", which blames the user for a deficiency of the software, and towards "Can't handle X", which acknowledges the deficiency.

This PR does NOT as yet include a test. The presumed fix for the issue consists of catching OverflowError in `init_variable_values`. However:
- `init_variable_values` has no existing unit tests
- its caller, `init_from_json` has no existing unit tests
- it's not possible to instantiate the class Entity in isolation - it requires a Simulation, which in turns require a TaxBenefitSystem, which in turn requires one or more entities
- entities in general seem to be tested only indirectly through the country template

In summary, the design of Core in this area is (in my expert opinion) untestable at the unit test level. This is a serious but fixable flaw. It is better fixed as a pair or mob activity, so as to amplify the relevant design and TDD skills in the team. I'm happy to offer my help there; meanwhile my recommendation is to merge this PR as a strict improvement over the current state of the codebase.