### PR TITLE
Allow ParameterNode children to have a numeric keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 24.9.1 [#770](https://github.com/openfisca/openfisca-core/pull/770)
+### 24.9.2 [#776](https://github.com/openfisca/openfisca-core/pull/776)
+
+- Allow `ParameterNode` children to have a numeric keys
+  - Before, an incorrect id would be set for these children, resulting to inconsistencies in the Web API.
+
+### 24.9.1 [#770](https://github.com/openfisca/openfisca-core/pull/770)
 
 - Fix a bug that prevented amount scale parameters from being accessed in a formula
 

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -163,7 +163,7 @@ class Parameter(object):
             if instant_info == "expected" or isinstance(instant_info, dict) and instant_info.get("expected"):
                 continue
 
-            value_name = _compose_name(name, instant_str)
+            value_name = _compose_name(name, item_name = instant_str)
             value_at_instant = ParameterAtInstant(value_name, instant_str, data = instant_info, file_path = self.file_path, metadata = self.metadata)
             values_list.append(value_at_instant)
 
@@ -228,16 +228,16 @@ class Parameter(object):
             else:
                 if i < n:
                     overlapped_value = old_values[i].value
-                    value_name = _compose_name(self.name, stop_str)
+                    value_name = _compose_name(self.name, item_name = stop_str)
                     new_interval = ParameterAtInstant(value_name, stop_str, data = {'value': overlapped_value})
                     new_values.append(new_interval)
                 else:
-                    value_name = _compose_name(self.name, stop_str)
+                    value_name = _compose_name(self.name, item_name = stop_str)
                     new_interval = ParameterAtInstant(value_name, stop_str, data = {'value': None})
                     new_values.append(new_interval)
 
         # Insert new interval
-        value_name = _compose_name(self.name, start_str)
+        value_name = _compose_name(self.name, item_name = start_str)
         new_interval = ParameterAtInstant(value_name, start_str, data = {'value': value})
         new_values.append(new_interval)
 
@@ -485,7 +485,7 @@ class ParameterNodeAtInstant(object):
                 setattr(self, child_name, child_at_instant)
 
     def __getattr__(self, key):
-        param_name = _compose_name(self._name, key)
+        param_name = _compose_name(self._name, item_name = key)
         raise ParameterNotFound(param_name, self._instant_str)
 
     def __getitem__(self, key):
@@ -702,7 +702,7 @@ class Scale(object):
 
         brackets = []
         for i, bracket_data in enumerate(data['brackets']):
-            bracket_name = _compose_name(name, i)
+            bracket_name = _compose_name(name, item_name = i)
             bracket = Bracket(name = bracket_name, data = bracket_data, file_path = file_path)
             brackets.append(bracket)
         self.brackets = brackets
@@ -813,13 +813,13 @@ def _parse_child(child_name, child, child_path):
         return ParameterNode(child_name, data = child, file_path = child_path)
 
 
-def _compose_name(path, child_name):
-    if path:
-        if isinstance(child_name, int) or INSTANT_PATTERN.match(child_name):
-            return '{}[{}]'.format(path, child_name)
-        return '{}.{}'.format(path, child_name)
-    else:
+def _compose_name(path, child_name = None, item_name = None):
+    if not path:
         return child_name
+    if child_name is not None:
+        return '{}.{}'.format(path, child_name)
+    if item_name is not None:
+        return '{}[{}]'.format(path, item_name)
 
 
 def _validate_parameter(parameter, data, data_type = None, allowed_keys = None):

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.9.1',
+    version = '24.9.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_parameters.py
+++ b/tests/core/test_parameters.py
@@ -105,3 +105,16 @@ def test_parameter_documentation():
 def test_get_descendants():
     all_parameters = {parameter.name for parameter in tax_benefit_system.parameters.get_descendants()}
     assert all_parameters.issuperset({'taxes', 'taxes.housing_tax', 'taxes.housing_tax.minimal_amount'})
+
+
+def test_name():
+    parameter_data = {
+        "description": "Parameter indexed by a numeric key",
+        "2010": {
+            "values": {
+                '2006-01-01': 0.0075
+                }
+            }
+        }
+    parameter = ParameterNode('root', data = parameter_data)
+    assert parameter.children["2010"].name == "root.2010"


### PR DESCRIPTION
- Allow `ParameterNode` children to have a numeric keys
  - Before, an incorrect id would be set for these children, resulting to inconsistencies in the Web API.