### PR TITLE
Allow non-integral inputs to int variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 24.9.8 [#780](https://github.com/openfisca/openfisca-core/pull/780)
+
+- Allow non-integral inputs to int variables
+
 ### 24.9.7 [#769](https://github.com/openfisca/openfisca-core/pull/769)
 
 - Unify the protocol for appending sub-parameters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 24.9.7 [#769](https://github.com/openfisca/openfisca-core/pull/769)
 
-- Unify the protocol for appending sub-parameters
+- Ensure `path.to.parameter` syntax works consistently across country and extension
 
 ### 24.9.6 [#771](https://github.com/openfisca/openfisca-core/pull/771)
 

--- a/openfisca_core/columns.py
+++ b/openfisca_core/columns.py
@@ -259,7 +259,6 @@ class IntCol(Column):
     @property
     def json_to_dated_python(self):
         return conv.pipe(
-            conv.test_isinstance((int, basestring_type)),
             conv.make_anything_to_int(accept_expression = True),
             )
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.9.7',
+    version = '24.9.8',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -178,3 +178,11 @@ def test_set_not_chaged_variable():
     array = np.asarray([2000])
     holder.set_input('2015-01', array)
     assert_equal(simulation.calculate('salary', '2015-01'), array)
+
+
+def test_set_input_float_to_int():
+    simulation = get_simulation(couple)
+    age = np.asarray([50.6])
+    simulation.person.get_holder('age').set_input(period, age)
+    result = simulation.calculate('age', period)
+    assert_equal(result, np.asarray([50]))


### PR DESCRIPTION
Fixes #463

#### Technical changes

- Allow non-integral inputs to int variables

-----

The unit test included in this PR shows that a Holder will happily accept an array of float as an input to an `int` variable.

The underlying cause here is that parsing test cases still relies on `scenarios` which we would like to drop support for, per #716. Scenarios in turn rely on `columns`, of which [the code says they are "considered deprecated"](https://github.com/openfisca/openfisca-core/blob/56e31c6186e1e354d074ee1e6f4f760442b44981/openfisca_core/columns.py#L16). Columns and scenarios rely on `conv`, which I understand is our main remaining link with [Biryani](https://github.com/etalab/biryani). We have been saying for a while that we intend to drop Biryani, e.g. #691.

This looks like a textbook case for applying the [Mikado Method](http://mikadomethod.info/). ;)