### PR TITLE
 Don't force persons to belong to all entities

### DIFF
--- a/openfisca_core/errors.py
+++ b/openfisca_core/errors.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals, print_function, division, absolute_impo
 import os
 
 import dpath
+import numpy as np
 
 from openfisca_core.commons import to_unicode
 
@@ -66,3 +67,21 @@ class PeriodMismatchError(ValueError):
         self.definition_period = definition_period
         self.message = message
         ValueError.__init__(self, self.message)
+
+
+class UndefinedEntityError(ValueError):
+
+    def __init__(self, entity):
+        self.entity = entity
+        unallocated_persons = np.array(entity.members.ids)[
+            np.where(entity.members_entity_id == -1)
+            ].tolist()
+        message = "A calculation tried to access '{}.{}', but the {} {} do not belong to any {}.".format(
+            entity.members.key,
+            entity.key,
+            entity.members.plural,
+            unallocated_persons,
+            entity.key,
+            )
+
+        ValueError.__init__(self, message)

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -27,9 +27,10 @@ def main(parser = None):
         parser = argparse.ArgumentParser()
         parser = build_parser(parser)
 
-        warnings.warn("The 'openfisca-run-test' command has been deprecated in favor of 'openfisca test' since version 25.0, and will be removed in the future.",
-            Warning
-                      )
+        warnings.warn(
+            "The 'openfisca-run-test' command has been deprecated in favor of 'openfisca test' since version 25.0, and will be removed in the future.",
+            Warning,
+            )
 
     args = parser.parse_args()
     logging.basicConfig(level = logging.DEBUG if args.verbose else logging.WARNING, stream = sys.stdout)

--- a/openfisca_core/simulation_builder.py
+++ b/openfisca_core/simulation_builder.py
@@ -153,6 +153,8 @@ class SimulationBuilder(object):
         """
             Hydrate an entity from a JSON dictionnary ``entities_json``.
         """
+        if entities_json is None:
+            entities_json = {}
         check_type(entities_json, dict, [entity.plural])
         entities_json = OrderedDict((str(key), value) for key, value in entities_json.items())  # Stringify potential numeric keys, but keep the order
         entity.count = len(entities_json)
@@ -204,10 +206,11 @@ class SimulationBuilder(object):
             self.init_variable_values(entity, variables_json, entity_id, default_period = default_period)
 
         if not entity.is_person and persons_to_allocate:
-            raise SituationParsingError([entity.plural],
-                '{0} have been declared in {1}, but are not members of any {2}. All {1} must be allocated to a {2}.'.format(
-                    persons_to_allocate, entity.simulation.persons.plural, entity.key)
-                )
+            for person_id in persons_to_allocate:
+                person_index = persons.ids.index(person_id)
+                entity.members_entity_id[person_index] = -1
+                entity.members_role[person_index] = None
+                entity.members_legacy_role[person_index] = -1
 
         # Due to set_input mechanism, we must bufferize all inputs, then actually set them, so that the months are set first and the years last.
         self.finalize_variables_init(entity, entities_json)

--- a/openfisca_core/tools/__init__.py
+++ b/openfisca_core/tools/__init__.py
@@ -31,6 +31,9 @@ def assert_near(value, target_value, absolute_error_margin = None, message = '',
         value = np.array(value)
     if isinstance(value, EnumArray):
         return assert_enum_equals(value, target_value, message)
+    if value.dtype == np.object:
+        assert (value == target_value).all()
+        return
     if isinstance(target_value, basestring_type):
         target_value = eval_expression(target_value)
 

--- a/tests/core/test_simulation_builder.py
+++ b/tests/core/test_simulation_builder.py
@@ -29,7 +29,7 @@ def persons():
         definition_period = ETERNITY
         value_type = str
         dtype = 'O'
-        default_value = '0'
+        default_value = 0
         is_neutralized = False
         set_input = None
 

--- a/tests/core/tools/test_assert_near.py
+++ b/tests/core/tools/test_assert_near.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals, print_function, division, absolute_import
 
 import numpy as np
+from pytest import raises
 
 from openfisca_core.tools import assert_near
 
@@ -19,3 +20,13 @@ def test_enum_2():
     value = possible_values.encode(np.array(['tenant', 'owner']))
     expected_value = ['tenant', 'owner']
     assert_near(value, expected_value)
+
+
+def test_object():
+    assert_near(np.array([None]), None)
+    assert_near(np.array([{}]), {})
+
+
+def test_object_fail():
+    with raises(AssertionError):
+        assert_near(np.array([{'A'}]), {'B'})

--- a/tests/web_api/test_calculate.py
+++ b/tests/web_api/test_calculate.py
@@ -52,7 +52,6 @@ def test_responses():
         ('{"persons": {"bob": {"salary": {"invalid period": 2000 }}}}', BAD_REQUEST, 'persons/bob/salary/invalid period', 'Expected a period',),
         ('{"persons": {"bob": {"salary": {"invalid period": null }}}}', BAD_REQUEST, 'persons/bob/salary/invalid period', 'Expected a period',),
         ('{"persons": {"bob": {"basic_income": {"2017": 2000 }}}}', BAD_REQUEST, 'persons/bob/basic_income/2017', 'basic_income is only defined for months',),
-        ('{"persons": {"bob": {"birth": {"ETERNITY": "1980-01-01"} }}, "households": {}}', BAD_REQUEST, 'households', 'not members of any household',),
         ('{"persons": {"bob": {"salary": {"ETERNITY": 2000} }}}', BAD_REQUEST, 'persons/bob/salary/ETERNITY', 'salary is only defined for months',),
         ]
 


### PR DESCRIPTION
Connected to #667 
Depends on #781 

Following our discussions during the webinar about entities, I made a quick POC to check how we could stop enforcing persons to belong to all entities, as it's a common frustration among users.

The chosen behavior A in this PR here is:

- Allow a person to not be defined in any household
- If `person.household` is used and _at least one_ person doesn't have a household, an error is raised.

As a reminder, the alternative behavior B would be:

- Allow a person to not be defined in any household
- Still allow to call `person.household` in that case
- Make `person.household('variable', period)` return the `'variable'` default value for person who don't belong to any household.

I think there was a preference for behavior A during the webinar, let me know if you don't agree.

I tried to see how much we could use this to avoid boilerplate in France tests, and in some cases, [we can](https://github.com/openfisca/openfisca-france/compare/unif-tests-api...flexible-entities). In others though, we get an error, even if the test doesn't seem to be related to that specific entity (typically, we need the zipcode of a "famille", which is defined for a "menage").

I'd say that when trying to remove entity specifications that looked like boilerplate, I was successful in maybe 1/3 of the cases.  I'd expect this to work better in countries were the entities are not as coupled as the French ones.

Note:
- I'm opening against the `uniformize-tests-api` branch to avoid conflicts
- This is not ready to merge as is, see todo further down
- It could be interesting to merge this before https://github.com/openfisca/openfisca-france/pull/1224, as it would allow us to reduce the amount of boilerplate noise that we add to France tests (cc @Morendil)

I'm planning to keep working on this if contributors who expressed frustrations feel that this approach is the right one cc @jvalduvieco @jacob88.

Inputs from @guillett @benjello @sandcha @maukoquiroga @pblayo welcome as well :).

Todo if we keep going toward that direction:

- [ ] Make sure aggregators like `sum` still work when some people don't belong to an entity
- [ ] Intercept `UndefinedEntityError` when they happen during a Web API call to return a 400 instead of a 500, with information about which formula tried to access the undefined entity.
