### PR TITLE
Don't sort JSON keys in the Web API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-# 25.0 [#781](https://github.com/openfisca/openfisca-core/pull/781)
+## 25.1.0 [#787](https://github.com/openfisca/openfisca-core/pull/787)
+
+- Don't sort JSON keys in the Web API
+  - By default, `flask` sorts JSON _object_ keys alphabetically
+  - This is useful for reusing http caches for example, at the cost of some performance overhead
+  - But the [JSON specification](https://www.json.org/) doesn’t require to keep an order, as _objects_ are defined as "an unordered set of name/value pairs"
+
+# 25.0.0 [#781](https://github.com/openfisca/openfisca-core/pull/781)
 
 #### Breaking changes
 

--- a/openfisca_web_api/app.py
+++ b/openfisca_web_api/app.py
@@ -57,6 +57,7 @@ def create_app(tax_benefit_system,
 
     app.config['JSON_AS_ASCII'] = False  # When False, lets jsonify encode to utf-8
     app.url_map.strict_slashes = False  # Accept url like /parameters/
+    app.config['JSON_SORT_KEYS'] = False  # Don't sort JSON keys in the Web API
 
     data = build_data(tax_benefit_system)
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '25.0',
+    version = '25.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
By default, FLASK sorts the JSON keys of the API responses. This PR opts out of this behavior.

~~In some use-cases (merge with IPP parameters in France), having the same orders in API responses that in the parameter YAML files avoid extra work and boilerplate.~~

---

Edit by @maukoquiroga 2018-12-09:

I'm ok with the fact that we don't order an object defined as unordered by the JSON specification. However, as discussed in the comments, I omitted any mention of use-case from the motivation of this PR's introduced changes.