### PR TITLE
Deprecate subroles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 24.11.0 [#789](https://github.com/openfisca/openfisca-core/pull/789)
+
+- Deprecate subroles, and introduce a new syntax to replace them:
+  - For instance, if the role `parent` had two subroles `first_parent` and `second_parent`:
+    - `household.first_parent('salary', period)` can be replaced by `household.parents[0]('salary', period)`
+    - `person.has_role(Household.FIRST_PARENT)` can be replaced by `person.has_role(Household.PARENT, 0)`
+    - `family.sum(salary, role = Household.FIRST_PARENT)` can be replaced by `family.sum(salary, role = (Household.PARENT, 0))`
+
 ## 24.10.0 [#784](https://github.com/openfisca/openfisca-core/pull/784)
 
 - In Python, simplify simulation array deletion:

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -804,7 +804,7 @@ class Projector(object):
             return self.parent.transform_and_bubble_up(transformed_result)
 
     def transform(self, result):
-        return NotImplementedError()
+        raise NotImplementedError
 
 
 # For instance person.family
@@ -856,7 +856,12 @@ class MultipleRoleToEntityProjector(Projector):
         return RoleAndPositionProjector(self.target_entity, self.role, key, self.parent)
 
     def transform(self, result):
-        return result * self.reference_entity.has_role(self.role)
+        error_message = "You cannot use '{entity}.{role_plural}' to calculate a variable, as '{role_key}' is not a unique role. However, you can for instance calculate the variable for the 1st '{role_key}' with '{entity}.{role_plural}[0]'".format(
+            entity = self.target_entity.key,
+            role_key = self.role.key,
+            role_plural = self.role.plural
+            )
+        raise NotImplementedError(error_message)  # TODO: Add a nice error message
 
 
 # For instance household.parents[0]

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -923,6 +923,10 @@ def build_entity(key, plural, label, doc = "", roles = None, is_person = False):
             entity_class.roles.append(role)
             setattr(entity_class, role.key.upper(), role)
             if role_description.get('subroles'):
+                warnings.warn(
+                    "Entities subroles are deprecated since OpenFisca Core 24.11.0, and will be removed in the future. Check that version's Changelog for help migrating.",
+                    Warning
+                    )
                 role.subroles = []
                 for subrole_key in role_description['subroles']:
                     subrole = Role({'key': subrole_key, 'max': 1}, entity_class, parent_role = role)

--- a/openfisca_core/scenarios.py
+++ b/openfisca_core/scenarios.py
@@ -76,6 +76,9 @@ class AbstractScenario(object):
                 if entity.members_legacy_role is None:
                     entity.members_legacy_role = np.zeros(persons.count, dtype = np.int32)
 
+                if entity.members_position_by_role is None:
+                    entity.members_position_by_role = np.zeros(persons.count, dtype = np.int32)
+
                 if entity.count == 0:
                     entity.count = max(entity.members_entity_id) + 1
                     entity.ids = range(entity.count)
@@ -139,9 +142,13 @@ class AbstractScenario(object):
                         steps_count * persons_step_size,
                         dtype = np.int32
                         )
+                    entity.members_position_by_role = np.empty(
+                        steps_count * persons_step_size,
+                        dtype = np.int32
+                        )
 
                     for scenario_entity_index, scenario_entity in enumerate(test_case[entity.plural]):
-                        for person_role, person_legacy_role, person_id in iter_over_entity_members(entity, scenario_entity):
+                        for person_role, person_legacy_role, position_by_role, person_id in iter_over_entity_members(entity, scenario_entity):
                             person_index = person_index_by_id[person_id]
                             for step_index in range(steps_count):
                                 individu_index = step_index * persons_step_size + person_index
@@ -149,6 +156,7 @@ class AbstractScenario(object):
                                 entity.members_entity_id[individu_index] = step_index * entity_step_size + scenario_entity_index
                                 entity.members_role[individu_index] = person_role
                                 entity.members_legacy_role[individu_index] = person_legacy_role
+                                entity.members_position_by_role[individu_index] = position_by_role
 
                 for variable_name, column in tbs.variables.items():
                     if column.entity == entity.__class__ and variable_name in used_columns_name:
@@ -723,8 +731,8 @@ def iter_over_entity_members(entity_description, scenario_entity):
             legacy_role_j = 0
             for individu in individus:
                 if role.subroles:
-                    yield role.subroles[legacy_role_j], legacy_role_i + legacy_role_j, individu
+                    yield role.subroles[legacy_role_j], legacy_role_i + legacy_role_j, legacy_role_j, individu
                 else:
-                    yield role, legacy_role_i + legacy_role_j, individu
+                    yield role, legacy_role_i + legacy_role_j, legacy_role_j, individu
                 legacy_role_j += 1
         legacy_role_i += (role.max or 1)

--- a/openfisca_core/tools/simulation_dumper.py
+++ b/openfisca_core/tools/simulation_dumper.py
@@ -79,6 +79,7 @@ def _dump_entity(entity, directory):
     np.save(os.path.join(path, "members_position.npy"), entity.members_position)
     np.save(os.path.join(path, "members_entity_id.npy"), entity.members_entity_id)
     np.save(os.path.join(path, "members_legacy_role.npy"), entity.members_legacy_role)
+    np.save(os.path.join(path, "members_position_by_role.npy"), entity.members_position_by_role)
     encoded_roles = np.select(
         [entity.members_role == role for role in entity.flattened_roles],
         [role.key for role in entity.flattened_roles],
@@ -97,6 +98,7 @@ def _restore_entity(entity, directory):
     entity.members_position = np.load(os.path.join(path, "members_position.npy"))
     entity.members_entity_id = np.load(os.path.join(path, "members_entity_id.npy"))
     entity.members_legacy_role = np.load(os.path.join(path, "members_legacy_role.npy"))
+    entity.members_position_by_role = np.load(os.path.join(path, "members_position_by_role.npy"))
     encoded_roles = np.load(os.path.join(path, "members_role.npy"))
     entity.members_role = np.select(
         [encoded_roles == role.key for role in entity.flattened_roles],

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.10.0',
+    version = '24.11.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_dump_restore.py
+++ b/tests/core/test_dump_restore.py
@@ -31,6 +31,7 @@ def test_dump():
     assert_array_equal(simulation.household.members_position, simulation_2.household.members_position)
     assert_array_equal(simulation.household.members_entity_id, simulation_2.household.members_entity_id)
     assert_array_equal(simulation.household.members_legacy_role, simulation_2.household.members_legacy_role)
+    assert_array_equal(simulation.household.members_position_by_role, simulation_2.household.members_position_by_role)
     assert_array_equal(simulation.household.members_role, simulation_2.household.members_role)
 
     # Check calculated values are in cache

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -425,6 +425,19 @@ def test_value_from_first_person():
     assert_near(salary_first_person, [1000, 3000])
 
 
+def test_multiple_role_projector():
+    test_case = deepcopy(TEST_CASE)
+    test_case['persons'][0]['salary'] = 1000
+    test_case['persons'][1]['salary'] = 1500
+    test_case['persons'][4]['salary'] = 3000
+    test_case['persons'][5]['salary'] = 500
+
+    simulation = new_simulation(test_case)
+    household = simulation.household
+
+    salaries_parents = household.parents('salary', period = MONTH)
+    assert_near(salaries_parents, [1000, 1500, 0, 0, 3000, 0])
+
 def test_projectors_methods():
     simulation = Simulation(tax_benefit_system = tax_benefit_system, simulation_json = couple)
     household = simulation.household

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -203,6 +203,16 @@ def test_has_role_with_subrole():
     assert_near(individu.has_role(SECOND_PARENT), [False, True, False, False, False, False])
 
 
+def test_has_role_with_position():
+
+    simulation = new_simulation(TEST_CASE)
+    individu = simulation.persons
+    assert_near(individu.has_role(PARENT, 0), [True, False, False, False, True, False])
+    assert_near(individu.has_role(PARENT, 1), [False, True, False, False, False, False])
+    assert_near(individu.has_role(CHILD, 0), [False, False, True, False, False, True])
+    assert_near(individu.has_role(CHILD, 1), [False, False, False, True, False, False])
+
+
 def test_project():
     test_case = deepcopy(TEST_CASE)
     test_case['households'][0]['housing_tax'] = 20000
@@ -277,6 +287,9 @@ def test_sum():
     total_salary_parents_by_household = household.sum(salary, role = PARENT)
 
     assert_near(total_salary_parents_by_household, [2500, 3000])
+
+    total_salary_first_parent = household.sum(salary, role = (PARENT, 0))
+    assert_near(total_salary_first_parent, [1000, 3000])
 
 
 def test_any():

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -269,7 +269,7 @@ def test_sum():
     simulation = new_simulation(test_case, MONTH)
     household = simulation.household
 
-    salary = household.members('salary', "2016-01")
+    salary = household.members('salary', MONTH)
     total_salary_by_household = household.sum(salary)
 
     assert_near(total_salary_by_household, [2500, 3500])
@@ -435,8 +435,18 @@ def test_multiple_role_projector():
     simulation = new_simulation(test_case)
     household = simulation.household
 
-    salaries_parents = household.parents('salary', period = MONTH)
-    assert_near(salaries_parents, [1000, 1500, 0, 0, 3000, 0])
+    assert_near(
+        household.parents('salary', period = MONTH),
+        [1000, 1500, 0, 0, 3000, 0])
+
+    assert_near(
+        household.parents[0]('salary', period = MONTH),
+        [1000, 3000])
+
+    assert_near(
+        household.parents[1]('salary', period = MONTH),
+        [1500, 0])
+
 
 def test_projectors_methods():
     simulation = Simulation(tax_benefit_system = tax_benefit_system, simulation_json = couple)
@@ -532,8 +542,8 @@ def test_undoredered_persons():
     household = simulation.household
     person = simulation.person
 
-    salary = household.members('salary', "2016-01")  # [ 3000, 0, 1500, 20, 500, 1000 ]
-    accommodation_size = household('accommodation_size', "2016-01")  # [ 160, 60 ]
+    salary = household.members('salary', MONTH)  # [ 3000, 0, 1500, 20, 500, 1000 ]
+    accommodation_size = household('accommodation_size', MONTH)  # [ 160, 60 ]
 
     # Aggregation/Projection persons -> entity
 
@@ -546,6 +556,7 @@ def test_undoredered_persons():
     assert_near(household.first_parent('salary', "2016-01"), [1000, 3000])
     assert_near(household.second_parent('salary', "2016-01"), [1500, 0])
     assert_near(person.value_from_partner(salary, person.household, household.PARENT), [0, 0, 1000, 0, 0, 1500])
+    assert_near(household.first_person('salary', MONTH), [0, 3000])
     assert_near(household.value_nth_person(1, salary), [1500, 500])
 
     assert_near(household.sum(salary, role = PARENT), [2500, 3000])
@@ -574,3 +585,4 @@ def test_undoredered_persons():
     assert_near(household.share_between_members(accommodation_size), [30, 40, 40, 40, 30, 40])
     assert_near(household.share_between_members(accommodation_size, role = PARENT), [60, 0, 80, 0, 0, 80])
     assert_near(household.value_nth_person(0, salary, role = CHILD), [20, 500])
+    assert_near(household.children[0]('salary', MONTH), [20, 500])

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -51,6 +51,14 @@ def test_role_index_and_positions():
     assert(simulation.household.ids == [0, 1])
 
 
+def test_infer_positions():
+    household = Simulation(tax_benefit_system).household
+    household.members_entity_id = [1, 1, 0, 0, 1, 0, 0]
+    household.members_role = [PARENT, CHILD, PARENT, CHILD, PARENT, CHILD, CHILD]
+    assert_near(household.members_position, [0, 1, 0, 1, 2, 2, 3])
+    assert_near(household.members_position_by_role, [0, 0, 0, 0, 1, 1, 2])
+
+
 def test_entity_structure_with_constructor():
     simulation_json = {
         "persons": {
@@ -527,7 +535,7 @@ def test_get_memory_usage():
     assert(len(memory_usage['by_variable']) == 1)
 
 
-def test_undoredered_persons():
+def test_unordedered_persons():
     test_case = {
         'persons': [{'id': 'ind4'}, {'id': 'ind3'}, {'id': 'ind1'}, {'id': 'ind2'}, {'id': 'ind5'}, {'id': 'ind0'}],
         'households': [

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals, print_function, division, absolute_import
 from copy import deepcopy
+from pytest import raises
 
 from openfisca_core.tools import assert_near
 from openfisca_core.simulations import Simulation
@@ -449,10 +450,6 @@ def test_multiple_role_projector():
     household = simulation.household
 
     assert_near(
-        household.parents('salary', period = MONTH),
-        [1000, 1500, 0, 0, 3000, 0])
-
-    assert_near(
         household.parents[0]('salary', period = MONTH),
         [1000, 3000])
 
@@ -599,3 +596,11 @@ def test_undoredered_persons():
     assert_near(household.share_between_members(accommodation_size, role = PARENT), [60, 0, 80, 0, 0, 80])
     assert_near(household.value_nth_person(0, salary, role = CHILD), [20, 500])
     assert_near(household.children[0]('salary', MONTH), [20, 500])
+
+
+def test_use_multiple_role_for_calc():
+    simulation = Simulation(tax_benefit_system = tax_benefit_system, simulation_json = couple)
+
+    with raises(NotImplementedError) as error:
+        simulation.household.parents('salary', '2017-01')
+    assert 'not a unique role' in error.value.args[0]

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -45,6 +45,7 @@ def test_role_index_and_positions():
     assert((simulation.household.members_role == [FIRST_PARENT, SECOND_PARENT, CHILD, CHILD, FIRST_PARENT, CHILD]).all())
     assert_near(simulation.household.members_legacy_role, [0, 1, 2, 3, 0, 2])
     assert_near(simulation.household.members_position, [0, 1, 2, 3, 0, 1])
+    assert_near(simulation.household.members_position_by_role, [0, 1, 0, 1, 0, 0])
     assert(simulation.person.ids == ["ind0", "ind1", "ind2", "ind3", "ind4", "ind5"])
     assert(simulation.household.ids == [0, 1])
 
@@ -76,6 +77,7 @@ def test_entity_structure_with_constructor():
     assert((household.members_role == [FIRST_PARENT, SECOND_PARENT, FIRST_PARENT, CHILD, CHILD]).all())
     assert_near(household.members_legacy_role, [0, 1, 0, 2, 3])
     assert_near(household.members_position, [0, 1, 0, 2, 3])
+    assert_near(household.members_position_by_role, [0, 1, 0, 0, 1])
 
 
 def test_entity_variables_with_constructor():
@@ -354,6 +356,29 @@ def test_value_nth_person():
     assert_near(result3, [9, -1])
 
 
+def test_value_nth_person_with_role():
+    test_case = deepcopy(TEST_CASE_AGES)
+    simulation = new_simulation(test_case)
+    household = simulation.household
+    array = household.members('age', MONTH)
+
+    assert_near(
+        household.value_nth_person(0, array, role = PARENT, default = -1),
+        [40, 54])
+
+    assert_near(
+        household.value_nth_person(1, array, role = PARENT, default = -1),
+        [37, -1])
+
+    assert_near(
+        household.value_nth_person(0, array, role = CHILD, default = -1),
+        [7, 20])
+
+    assert_near(
+        household.value_nth_person(1, array, role = CHILD, default = -1),
+        [9, -1])
+
+
 def test_rank():
     test_case = deepcopy(TEST_CASE_AGES)
     simulation = new_simulation(test_case)
@@ -508,6 +533,7 @@ def test_undoredered_persons():
     assert_near(household.first_parent('salary', "2016-01"), [1000, 3000])
     assert_near(household.second_parent('salary', "2016-01"), [1500, 0])
     assert_near(person.value_from_partner(salary, person.household, household.PARENT), [0, 0, 1000, 0, 0, 1500])
+    assert_near(household.value_nth_person(1, salary), [1500, 500])
 
     assert_near(household.sum(salary, role = PARENT), [2500, 3000])
     assert_near(household.sum(salary, role = CHILD), [20, 500])
@@ -534,3 +560,4 @@ def test_undoredered_persons():
     assert_near(household.project_on_first_person(accommodation_size), [60, 160, 0, 0, 0, 0])
     assert_near(household.share_between_members(accommodation_size), [30, 40, 40, 40, 30, 40])
     assert_near(household.share_between_members(accommodation_size, role = PARENT), [60, 0, 80, 0, 0, 80])
+    assert_near(household.value_nth_person(0, salary, role = CHILD), [20, 500])


### PR DESCRIPTION
Connected to #560 

- Deprecate subroles, and introduce a new syntax to replace them:
  - For instance, if the role `parent` had two subroles `first_parent` and `second_parent`:
    - `household.first_parent('salary', period)` can be replaced by `household.parents[0]('salary', period)`
    - `person.has_role(Household.FIRST_PARENT)` can be replaced by `person.has_role(Household.PARENT, 0)`
    - `family.sum(salary, role = Household.FIRST_PARENT)` can be replaced by `family.sum(salary, role = (Household.PARENT, 0))`