### PR TITLE
Simulation get known periods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 24.10.0 [#791](https://github.com/openfisca/openfisca-core/pull/791)
+
+- In Python, simplify getting known periods for variable in a simulation:
+
+Before:
+
+```py
+simulation = ...
+holder = simulation.persons.get_holder('salary')
+holder.get_known_periods()
+```
+
+After:
+
+```py
+simulation = ...
+simulation.get_known_periods('salary')
+```
+
 ## 24.10.0 [#784](https://github.com/openfisca/openfisca-core/pull/784)
 
 - In Python, simplify simulation array deletion:

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -452,6 +452,28 @@ class Simulation(object):
         """
         self.get_holder(variable).delete_arrays(period)
 
+
+    def get_known_periods(self, variable):
+        """
+            Get a list variable's known period, i.e. the periods where a value has been initialized and
+
+            :param variable: the variable to be set
+
+            Example:
+
+            >>> from openfisca_country_template import CountryTaxBenefitSystem
+            >>> simulation = Simulation(CountryTaxBenefitSystem())
+            >>> simulation.set_input('age', '2018-04', [12, 14])
+            >>> simulation.set_input('age', '2018-05', [13, 14])
+            >>> simulation.s summarize
+            >>> print(simulation.get_known_periods('age'))
+            True
+
+        """
+        self.get_holder(variable).get_known_periods()
+
+
+
     def set_input(self, variable, period, value):
         """
             Set a variable's value for a given period

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -452,7 +452,6 @@ class Simulation(object):
         """
         self.get_holder(variable).delete_arrays(period)
 
-
     def get_known_periods(self, variable):
         """
             Get a list variable's known period, i.e. the periods where a value has been initialized and
@@ -470,8 +469,6 @@ class Simulation(object):
 
         """
         return self.get_holder(variable).get_known_periods()
-
-
 
     def set_input(self, variable, period, value):
         """

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -465,12 +465,11 @@ class Simulation(object):
             >>> simulation = Simulation(CountryTaxBenefitSystem())
             >>> simulation.set_input('age', '2018-04', [12, 14])
             >>> simulation.set_input('age', '2018-05', [13, 14])
-            >>> simulation.s summarize
-            >>> print(simulation.get_known_periods('age'))
-            True
+            >>> simulation.get_known_periods('age')
+            [Period((u'month', Instant((2018, 5, 1)), 1)), Period((u'month', Instant((2018, 4, 1)), 1))]
 
         """
-        self.get_holder(variable).get_known_periods()
+        return self.get_holder(variable).get_known_periods()
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '24.10.0',
+    version = '24.11.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
#### New features

- Introduce `simulation.get_known_periods(variable)`
  - Allows for to know the periods a variable is known from a simulation (already exist for the holder). 

Fix #788 