### PR TITLE
Explicit test runner dependencies in Python 2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 25.1.1 [#...](https://github.com/openfisca/openfisca-core/pull/...)
+
+- Explicit test runner dependencies in Python 2.7
+  - Using an older version of `ruamel` caused a `'CommentedSeq' object has no attribute 'get'` error.
+
 ## 25.1.0 [#787](https://github.com/openfisca/openfisca-core/pull/787)
 
 - Don't sort JSON keys in the Web API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 25.1.1 [#...](https://github.com/openfisca/openfisca-core/pull/...)
+### 25.1.1 [#794](https://github.com/openfisca/openfisca-core/pull/794)
 
 - Explicit test runner dependencies in Python 2.7
   - Using an older version of `ruamel` caused a `'CommentedSeq' object has no attribute 'get'` error.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ general_requirements = [
     'numpy >= 1.11, < 1.16',
     'psutil == 5.4.6',
     'PyYAML >= 3.10',
-    'ruamel.yaml <= 0.16',
+    'ruamel.yaml >= 0.15.80, < 0.16',
     'sortedcontainers == 1.5.9',
     'numexpr == 2.6.8',
     ]
@@ -39,7 +39,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '25.1.0',
+    version = '25.1.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
- Explicit test runner dependencies in Python 2.7
  - Using an older version of `ruamel` caused a `'CommentedSeq' object has no attribute 'get'` error.