### PR TITLE
Add test for tracer log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 25.2.6 [#797](https://github.com/openfisca/openfisca-core/pull/797)
+
+- Improve `print_computation_log` and make it a tested, thus supported call
+
 ### 25.2.5 [#802](https://github.com/openfisca/openfisca-core/pull/802)
 
 - Load extensions more reliably, by removing dead code in load_extension

--- a/openfisca_core/tracers.py
+++ b/openfisca_core/tracers.py
@@ -198,7 +198,7 @@ class Tracer(object):
     def _print_node(self, key, depth, aggregate):
 
         def print_line(depth, node, value):
-            print("{}{} >> {}".format('  ' * depth, node, value))
+            return "{}{} >> {}".format('  ' * depth, node, value)
 
         if not self.trace.get(key):
             return print_line(depth, key, "Calculation aborted due to a circular dependency")
@@ -224,14 +224,14 @@ class Tracer(object):
         def _print_details(key, depth):
             if depth > 0 and ignore_zero and np.all(self.trace[key]['value'] == 0):
                 return
-            self._print_node(key, depth, aggregate)
+            yield self._print_node(key, depth, aggregate)
             if depth < max_depth:
                 for dependency in self.trace[key]['dependencies']:
-                    _print_details(dependency, depth + 1)
+                    return _print_details(dependency, depth + 1)
 
-        _print_details(key, 0)
+        return _print_details(key, 0)
 
-    def print_computation_log(self, aggregate = False):
+    def computation_log(self, aggregate = False):
         """
             Print the computation log of a simulation.
 
@@ -240,8 +240,11 @@ class Tracer(object):
             If ``aggregate`` is ``True``, only print the minimum, maximum, and average value of each computed vector.
             This mode is more suited for simulations on a large population.
         """
-        for node, depth in self._computation_log:
-            self._print_node(node, depth, aggregate)
+        return [self._print_node(node, depth, aggregate) for node, depth in self._computation_log]
+
+    def print_computation_log(self, aggregate = False):
+        for line in self.computation_log(aggregate):
+            print(line)
 
 
 class TracingParameterNodeAtInstant(object):

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '25.2.5',
+    version = '25.2.6',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_tracer.py
+++ b/tests/core/test_tracer.py
@@ -29,6 +29,25 @@ def test_variable_stats():
     assert_equals(tracer.usage_stats['C']['nb_requests'], 0)
 
 
+def test_log_format():
+    tracer = Tracer()
+    tracer.record_calculation_start("A", 2017)
+    tracer.record_calculation_start("B", 2017)
+    tracer.record_calculation_end("B", 2017, 1)
+    tracer.record_calculation_end("A", 2017, 2)
+
+    from io import StringIO
+    import contextlib
+
+    log = StringIO()
+    with contextlib.redirect_stdout(log):
+        tracer.print_computation_log()
+
+    lines = log.getvalue().split('\n')
+    assert_equals(lines[0], '  A<2017> >> 2')
+    assert_equals(lines[1], '    B<2017> >> 1')
+
+
 #  Tests on tracing with fancy indexing
 zone = np.asarray(['z1', 'z2', 'z2', 'z1'])
 housing_occupancy_status = np.asarray(['owner', 'owner', 'tenant', 'tenant'])

--- a/tests/core/test_tracer.py
+++ b/tests/core/test_tracer.py
@@ -36,14 +36,7 @@ def test_log_format():
     tracer.record_calculation_end("B", 2017, 1)
     tracer.record_calculation_end("A", 2017, 2)
 
-    from io import StringIO
-    import contextlib
-
-    log = StringIO()
-    with contextlib.redirect_stdout(log):
-        tracer.print_computation_log()
-
-    lines = log.getvalue().split('\n')
+    lines = tracer.computation_log()
     assert_equals(lines[0], '  A<2017> >> 2')
     assert_equals(lines[1], '    B<2017> >> 1')
 


### PR DESCRIPTION
### 25.2.2

- Add tracer format log test to ensure no regression occur



As an intense user of the tracer log I would like to make sure that this feature is kept as is or at least to be notified when changed.

Sublime text allows OK navigation:

![sans titre](https://user-images.githubusercontent.com/1410356/49885629-0dec1700-fe38-11e8-837e-c50db026564c.png)
