### PR TITLE
Fix test runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 25.2.2 [#798](https://github.com/openfisca/openfisca-core/pull/798)
+
+- Fixes a regression in the YAML test runner. If you have changed any YAML tests since 25.0.0, please rerun them.
+
 ### 25.2.1 [#796](https://github.com/openfisca/openfisca-core/pull/796)
 
 - Update documentation URL in the API welcome message

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -242,16 +242,16 @@ def _run_test(simulation, test):
         return
     for key, expected_value in output.items():
         if simulation.tax_benefit_system.variables.get(key):  # If key is a variable
-            return _check_variable(simulation, key, expected_value, test.get('period'), test)
-        if simulation.entities.get(key):  # If key is an entity singular
+            _check_variable(simulation, key, expected_value, test.get('period'), test)
+        elif simulation.entities.get(key):  # If key is an entity singular
             for variable_name, value in expected_value.items():
                 _check_variable(simulation, variable_name, value, test.get('period'), test)
-            return
-        entity_array = simulation.get_entity(plural = key)  # If key is an entity plural
-        for entity_id, value_by_entity in expected_value.items():
-            for variable_name, value in value_by_entity.items():
-                entity_index = entity_array.ids.index(entity_id)
-                _check_variable(simulation, variable_name, value, test.get('period'), test, entity_index)
+        else:
+            entity_array = simulation.get_entity(plural = key)  # If key is an entity plural
+            for entity_id, value_by_entity in expected_value.items():
+                for variable_name, value in value_by_entity.items():
+                    entity_index = entity_array.ids.index(entity_id)
+                    _check_variable(simulation, variable_name, value, test.get('period'), test, entity_index)
 
 
 def _should_ignore_variable(variable_name, test):

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '25.2.1',
+    version = '25.2.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/yaml_tests/test_failure.yaml
+++ b/tests/core/yaml_tests/test_failure.yaml
@@ -3,4 +3,5 @@
   input:
     salary: 2000
   output:
+    pension: 0
     income_tax: 0


### PR DESCRIPTION
#781 caused the test runner to check only the first variable in a YAML test:

https://github.com/openfisca/openfisca-core/blob/61db5102bcce7fb973ae5c98df0042550dfc6b94/openfisca_core/tools/test_runner.py#L238-L255

On L245, the "return" exits the `_run_test` function after the first checked variable.

This PR fixes that, and changes `tests/core/yaml_test/test_failure.yaml` to cover this regression.