### PR TITLE
Fix 2nd exception while warning about missing libyaml

### DIFF
--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -45,9 +45,9 @@ def import_yaml():
 
 TEST_KEYWORDS = {'absolute_error_margin', 'description', 'extensions', 'ignore_variables', 'input', 'keywords', 'name', 'only_variables', 'output', 'period', 'reforms', 'relative_error_margin'}
 
-yaml, Loader = import_yaml()
-
 log = logging.getLogger(__name__)
+
+yaml, Loader = import_yaml()
 
 _tax_benefit_system_cache = {}
 


### PR DESCRIPTION
#### Minor change

- Initialize logger earlier to avoid error

Cf. #799 