### PR TITLE
Load extensions more reliably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,20 @@
 # Changelog
 
+### 25.2.5 [#802](https://github.com/openfisca/openfisca-core/pull/802)
+
+- Load extensions more reliably, by removing dead code in load_extension
+
 ### 25.2.4 [#806](https://github.com/openfisca/openfisca-core/pull/806)
 
-- Fixes a missing default parameter in `Simulation.delete_arrays` method.
+- Supply a missing default parameter in `Simulation.delete_arrays` method.
 
 ### 25.2.3 [#800](https://github.com/openfisca/openfisca-core/pull/800)
 
-- Fixes an exception on yaml import in test runner
+- Fix an exception on yaml import in test runner
 
 ### 25.2.2 [#798](https://github.com/openfisca/openfisca-core/pull/798)
 
-- Fixes a regression in the YAML test runner. If you have changed any YAML tests since 25.0.0, please rerun them.
+- Fix a regression in the YAML test runner. If you have changed any YAML tests since 25.0.0, please rerun them.
 
 ### 25.2.1 [#796](https://github.com/openfisca/openfisca-core/pull/796)
 

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -11,7 +11,6 @@ import logging
 import inspect
 import pkg_resources
 import traceback
-from setuptools import find_packages
 
 from openfisca_core import conv
 from openfisca_core import periods
@@ -206,24 +205,16 @@ class TaxBenefitSystem(object):
         :param string extension: The extension to load. Can be an absolute path pointing to an extension directory, or the name of an OpenFisca extension installed as a pip package.
 
         """
-        if path.isdir(extension):
-            if find_packages(extension):
-                # Load extension from a package directory
-                extension_directory = path.join(extension, find_packages(extension)[0])
-            else:
-                # Load extension from a simple directory
-                extension_directory = extension
-        else:
-            # Load extension from installed pip package
-            try:
-                package = importlib.import_module(extension)
-                extension_directory = package.__path__[0]
-            except ImportError:
-                message = linesep.join([traceback.format_exc(),
-                                        'Error loading extension: `{}` is neither a directory, nor a package.'.format(extension),
-                                        'Are you sure it is installed in your environment? If so, look at the stack trace above to determine the origin of this error.',
-                                        'See more at <https://github.com/openfisca/openfisca-extension-template#installing>.'])
-                raise ValueError(message)
+        # Load extension from installed pip package
+        try:
+            package = importlib.import_module(extension)
+            extension_directory = package.__path__[0]
+        except ImportError:
+            message = linesep.join([traceback.format_exc(),
+                                    'Error loading extension: `{}` is neither a directory, nor a package.'.format(extension),
+                                    'Are you sure it is installed in your environment? If so, look at the stack trace above to determine the origin of this error.',
+                                    'See more at <https://github.com/openfisca/openfisca-extension-template#installing>.'])
+            raise ValueError(message)
 
         self.add_variables_from_directory(extension_directory)
         param_dir = path.join(extension_directory, 'parameters')

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '25.2.4',
+    version = '25.2.5',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
#### Technical changes

- Load extensions more reliably, by removing dead code in load_extension

Partial solution to, connected to #801

When @guillett was trying to run a test that invoked an extension, this would fail when invoking `openfisca-run-test` (and would likely have failed with `openfisca test` as well) from the root directory of the extension's repo. This was because `load_extension` looked at directories, found a directory of the same name as the extension, and then went on to enumerate all packages installed under that directory with setuptool's `find_package`. `load_extension` would in that case consider the *first* such package to be the requested extension, which was an incorrect assumption; the extension would thus silently fail to load, leading to the unexpected error.