### PR TITLE
Failing test for N/A management

### DIFF
--- a/tests/core/yaml_tests/test_success_2.yaml
+++ b/tests/core/yaml_tests/test_success_2.yaml
@@ -1,0 +1,14 @@
+- name: "Basic test - N/A management"
+  description:  Alicia basic_income should not be null
+  period: 2017-01
+  input:
+    persons:
+      Alicia:
+        salary: 4000
+      Javier:
+        basic_income: 0
+    household:
+      parents: [Alicia, Javier]
+  output:
+    household:
+      total_benefits: 600


### PR DESCRIPTION
This PR contains a failing test that exhibit an unexpected behavior.

Heterogeneous inputs are acceptable in JSON input but they are not managed as I would expect.

In the following test, Javier basic income in known to be null, so it is specified but Alicia's isn't. Only her salary is known and set to 4000.
With this salary she is eligible to a basic income of 600.

Those 600 are set to 0 because Javier's basic_income is known.
When creating the input dataset, this 0 should be replaced by a NA value and that variable should not be considered as fully known.