### PR TITLE
Introduce LookupTaxScale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 25.3.0 [#811](https://github.com/openfisca/openfisca-core/pull/811)
+
+#### Technical changes
+
+- Allow France to model "Chèque Energie" in a cleaner way:
+  - Introduce SingleAmountTaxScale (SATS), a simpler form of MarginalAmountTaxScale (MATS)
+    - whereas MATS sums the values in brackets, up to the amount subject to the scale, SATS only "looks up" the appropriate value for the amount subject to the scale, and is thus the simpler mechanism
+    - use `numpy.digitize`, allowing callers to specify right or left intervals
+    - introduce a `type` tag in `brackets` object, thus far with only `single_amount` allowed
+  - Rename AmountTaxScale to MarginalAmountTaxScale and make it inherit from SATS
+
+This is non-breaking, as there are no direct clients of these classes outside of Core.
+
 ### 25.2.9 [#814](https://github.com/openfisca/openfisca-core/pull/814)
 
 - When a YAML test fails, display the correct period for wrong output variable

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -729,8 +729,8 @@ class Scale(object):
     def _get_at_instant(self, instant):
         brackets = [bracket.get_at_instant(instant) for bracket in self.brackets]
 
-        if self.metadata.get('type') == 'lookup':
-            scale = taxscales.LookupTaxScale()
+        if self.metadata.get('type') == 'single_amount':
+            scale = taxscales.SingleAmountTaxScale()
             for bracket in brackets:
                 if 'amount' in bracket._children and 'threshold' in bracket._children:
                     amount = bracket.amount
@@ -738,7 +738,7 @@ class Scale(object):
                     scale.add_bracket(threshold, amount)
             return scale
         elif any('amount' in bracket._children for bracket in brackets):
-            scale = taxscales.AmountTaxScale()
+            scale = taxscales.MarginalAmountTaxScale()
             for bracket in brackets:
                 if 'amount' in bracket._children and 'threshold' in bracket._children:
                     amount = bracket.amount

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -729,7 +729,15 @@ class Scale(object):
     def _get_at_instant(self, instant):
         brackets = [bracket.get_at_instant(instant) for bracket in self.brackets]
 
-        if any('amount' in bracket._children for bracket in brackets):
+        if self.metadata.get('type') == 'lookup':
+            scale = taxscales.LookupTaxScale()
+            for bracket in brackets:
+                if 'amount' in bracket._children and 'threshold' in bracket._children:
+                    amount = bracket.amount
+                    threshold = bracket.threshold
+                    scale.add_bracket(threshold, amount)
+            return scale
+        elif any('amount' in bracket._children for bracket in brackets):
             scale = taxscales.AmountTaxScale()
             for bracket in brackets:
                 if 'amount' in bracket._children and 'threshold' in bracket._children:

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -705,7 +705,7 @@ class Scale(object):
         _set_backward_compatibility_metadata(self, data)
         self.metadata.update(data.get('metadata', {}))
 
-        if not isinstance(data['brackets'], list):
+        if not isinstance(data.get('brackets', []), list):
             raise ParameterParsingError(
                 "Property 'brackets' of scale '{}' must be of type array."
                 .format(self.name),
@@ -713,7 +713,7 @@ class Scale(object):
                 )
 
         brackets = []
-        for i, bracket_data in enumerate(data['brackets']):
+        for i, bracket_data in enumerate(data.get('brackets', [])):
             bracket_name = _compose_name(name, item_name = i)
             bracket = Bracket(name = bracket_name, data = bracket_data, file_path = file_path)
             brackets.append(bracket)

--- a/openfisca_core/taxscales.py
+++ b/openfisca_core/taxscales.py
@@ -124,6 +124,10 @@ class AbstractRateTaxScale(AbstractTaxScale):
 
 
 class SingleAmountTaxScale(AbstractTaxScale):
+    '''
+    A SingleAmountTaxScale's calc() method matches the input amount to a set of brackets
+    and returns the single cell value that fits within that bracket.
+    '''
     amounts = None
 
     def __init__(self, name = None, option = None, unit = None):
@@ -154,6 +158,10 @@ class SingleAmountTaxScale(AbstractTaxScale):
 
 
 class MarginalAmountTaxScale(SingleAmountTaxScale):
+    '''
+    A MarginalAmountTaxScale's calc() method matches the input amount to a set of brackets
+    and returns the sum of cell values from the lowest bracket to the one containing the input.
+    '''
     def calc(self, base):
         base1 = np.tile(base, (len(self.thresholds), 1)).T
         thresholds1 = np.tile(np.hstack((self.thresholds, np.inf)), (len(base), 1))

--- a/openfisca_core/taxscales.py
+++ b/openfisca_core/taxscales.py
@@ -146,11 +146,9 @@ class AmountTaxScale(AbstractTaxScale):
             self.thresholds.insert(i, threshold)
             self.amounts.insert(i, amount)
 
-    def calc(self, base):
-        base1 = np.tile(base, (len(self.thresholds), 1)).T
-        thresholds1 = np.tile(np.hstack((self.thresholds, np.inf)), (len(base), 1))
-        a = max_(min_(base1, thresholds1[:, 1:]) - thresholds1[:, :-1], 0)
-        return np.dot(self.amounts, a.T > 0)
+    def calc(self, base, right=False):
+        bracket_indices = np.digitize(base, self.thresholds, right=right)
+        return np.array(self.amounts)[bracket_indices - 1]
 
 
 class LinearAverageRateTaxScale(AbstractRateTaxScale):

--- a/openfisca_core/taxscales.py
+++ b/openfisca_core/taxscales.py
@@ -154,7 +154,7 @@ class AmountTaxScale(AbstractTaxScale):
 
 
 class LookupTaxScale(AmountTaxScale):
-    def calc(self, base, right=True):
+    def calc(self, base, right=False):
         guarded_thresholds = np.array([-np.inf] + self.thresholds + [np.inf])
         bracket_indices = np.digitize(base, guarded_thresholds, right=right)
         guarded_amounts = np.array([0] + self.amounts + [0])

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '25.2.9',
+    version = '25.3.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_tax_scales.py
+++ b/tests/core/test_tax_scales.py
@@ -12,16 +12,16 @@ from openfisca_core.periods import Instant
 
 def test_amount_tax_scale():
     base = np.array([1, 8, 10])
-    amount_tax_scale = AmountTaxScale()
+    amount_tax_scale = MarginalAmountTaxScale()
     amount_tax_scale.add_bracket(6, 0.23)
     amount_tax_scale.add_bracket(9, 0.29)
 
     assert_near(amount_tax_scale.calc(base), [0, 0.23, 0.52])
 
 
-def test_lookup_tax_scale():
+def test_single_amount_tax_scale():
     base = np.array([1, 8, 10, 12])
-    tax_scale = LookupTaxScale()
+    tax_scale = SingleAmountTaxScale()
     tax_scale.add_bracket(6, 0.23)
     tax_scale.add_bracket(9, 0.29)
     tax_scale.add_bracket(11, 0)
@@ -47,29 +47,19 @@ def test_amount_in_scale():
     first_jan = Instant((2017, 11, 1))
     scale_at_instant = scale.get_at_instant(first_jan)
 
-    assert type(scale_at_instant) == AmountTaxScale
+    assert type(scale_at_instant) == MarginalAmountTaxScale
     assert scale_at_instant.amounts[0] == 6
 
 
 def test_dispatch_scale_creation_on_type():
     data = {'description': 'Social security contribution tax scale',
-            'metadata': {'type': 'lookup', 'threshold_unit': 'currency-EUR', 'rate_unit': '/1'},
-            'brackets': [
-                {
-                    'amount': {
-                        '2017-10-01': {'value': 6},
-                        },
-                    'threshold': {
-                        '2017-10-01': {'value': 0.23}
-                        }
-                    }
-                ]
+            'metadata': {'type': 'single_amount', 'threshold_unit': 'currency-EUR', 'rate_unit': '/1'},
             }
     scale = Scale('amount_scale', data, '')
     first_jan = Instant((2017, 11, 1))
     scale_at_instant = scale.get_at_instant(first_jan)
 
-    assert type(scale_at_instant) == LookupTaxScale
+    assert type(scale_at_instant) == SingleAmountTaxScale
 
 
 def test_simple_linear_average_rate_tax_scale():

--- a/tests/core/test_tax_scales.py
+++ b/tests/core/test_tax_scales.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals, print_function, division, absolute_import
 import numpy as np
 
-from openfisca_core.taxscales import MarginalRateTaxScale, AmountTaxScale, combine_tax_scales
+from openfisca_core.taxscales import *
 from openfisca_core.tools import assert_near
 from openfisca_core.parameters import Scale
 from openfisca_core.periods import Instant
@@ -17,6 +17,16 @@ def test_amount_tax_scale():
     amount_tax_scale.add_bracket(9, 0.29)
 
     assert_near(amount_tax_scale.calc(base), [0, 0.23, 0.52])
+
+
+def test_lookup_tax_scale():
+    base = np.array([1, 8, 10, 12])
+    tax_scale = LookupTaxScale()
+    tax_scale.add_bracket(6, 0.23)
+    tax_scale.add_bracket(9, 0.29)
+    tax_scale.add_bracket(11, 0)
+
+    assert_near(tax_scale.calc(base), [0, 0.23, 0.29, 0])
 
 
 def test_amount_in_scale():

--- a/tests/core/test_tax_scales.py
+++ b/tests/core/test_tax_scales.py
@@ -51,6 +51,27 @@ def test_amount_in_scale():
     assert scale_at_instant.amounts[0] == 6
 
 
+def test_dispatch_scale_creation_on_type():
+    data = {'description': 'Social security contribution tax scale',
+            'metadata': {'type': 'lookup', 'threshold_unit': 'currency-EUR', 'rate_unit': '/1'},
+            'brackets': [
+                {
+                    'amount': {
+                        '2017-10-01': {'value': 6},
+                        },
+                    'threshold': {
+                        '2017-10-01': {'value': 0.23}
+                        }
+                    }
+                ]
+            }
+    scale = Scale('amount_scale', data, '')
+    first_jan = Instant((2017, 11, 1))
+    scale_at_instant = scale.get_at_instant(first_jan)
+
+    assert type(scale_at_instant) == LookupTaxScale
+
+
 def test_simple_linear_average_rate_tax_scale():
     base = np.array([1, 1.5, 2, 2.5, 3.0, 4.0])
 


### PR DESCRIPTION
#### Technical changes

- Allow France to model "Chèque Energie" in a cleaner way:
  - Introduce SingleAmountTaxScale (SATS), a simpler form of MarginalAmountTaxScale (MATS)
    - whereas MATS sums the values in brackets, up to the amount subject to the scale, SATS only "looks up" the appropriate value for the amount subject to the scale, and is thus the simpler mechanism
    - use `numpy.digitize`, allowing callers to specify right or left intervals
    - introduce a `type` tag in `brackets` object, thus far with only `single_amount` allowed
  - Rename AmountTaxScale to MarginalAmountTaxScale and make it inherit from SATS

This is non-breaking, as there are no direct clients of these classes outside of Core.