### PR TITLE
Ensure consistent results in the presence of "spirals"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+# 30.0.0 [#817](https://github.com/openfisca/openfisca-core/pull/817)
+
+#### Breaking changes
+
+- Improve cycle and spiral detection, giving consistent results more systematically
+
+#### Migration notes
+
+- Remove all optional parameters `max_nb_cycles`
+- Avoid relying on cached values of a computation
+
+For additional details, see the PR's [description](https://github.com/openfisca/openfisca-core/pull/817).
+
 ### 29.0.2 [#858](https://github.com/openfisca/openfisca-core/pull/858)
 
 #### Bug fix

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -320,12 +320,11 @@ class Simulation(object):
         a heuristic, against "quasicircles", where the evaluation of a variable at a period involves
         the same variable at a different period.
         """
-        previous = [(_name, _period) for (_name, _period) in self.computation_stack if _name == variable.name]
+        previous_periods = [_period for (_name, _period) in self.computation_stack if _name == variable.name]
         self.computation_stack.append((variable.name, str(period)))
-        for pair in previous:
-            if pair == (variable.name, str(period)):
-                raise CycleError("Circular definition detected on formula {}@{}".format(variable.name, period))
-        spiral = len(previous) >= self.max_spiral_loops
+        if str(period) in previous_periods:
+            raise CycleError("Circular definition detected on formula {}@{}".format(variable.name, period))
+        spiral = len(previous_periods) >= self.max_spiral_loops
         if spiral:
             self.invalidate_spiral_variables(variable)
             message = "Quasicircular definition detected on formula {}@{} involving {}".format(variable.name, period, self.computation_stack)

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -139,7 +139,7 @@ class Simulation(object):
             if array is None and variable.base_function:
                 array = variable.base_function(holder, period)
 
-                # If no result, use the default value and cache it
+            # If no result, use the default value and cache it
             if array is None:
                 array = holder.default_array()
 

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -332,7 +332,7 @@ class Simulation(object):
 
     def invalidate_spiral_variables(self, variable):
         count = 0
-        for frame in self.computation_stack[::-1]:
+        for frame in reversed(self.computation_stack):
             self.invalidated_caches.add(frame)
             if frame[0] == variable.name:
                 count += 1

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -331,6 +331,10 @@ class Simulation(object):
             raise SpiralError(message, variable.name)
 
     def invalidate_spiral_variables(self, variable):
+        # Visit the stack, from the bottom (most recent) up; we know that we'll find
+        # the variable implicated in the spiral (max_spiral_loops+1) times; we keep the
+        # intermediate values computed (to avoid impacting performance) but we mark them
+        # for deletion from the cache once the calculation ends.
         count = 0
         for frame in reversed(self.computation_stack):
             self.invalidated_caches.add(frame)

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -156,10 +156,12 @@ class Simulation(object):
         return array
 
     def purge_cache_of_invalid_values(self):
-        if len(self.computation_stack) == 0:
-            for (_name, _period) in self.invalidated_caches:
-                holder = self.get_holder(_name)
-                holder.delete_arrays(_period)
+        # We wait for the end of calculate(), signalled by an empty stack, before purging the cache
+        if self.computation_stack:
+            return
+        for (_name, _period) in self.invalidated_caches:
+            holder = self.get_holder(_name)
+            holder.delete_arrays(_period)
 
     def calculate_add(self, variable_name, period, **parameters):
         variable = self.tax_benefit_system.get_variable(variable_name)

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -149,7 +149,7 @@ class Simulation(object):
                 self.tracer._computation_log.append(["spiral_" + variable.name + ":" + str(period), 1])
         finally:
             if self.trace:
-                self.tracer.record_calculation_end(variable.name, period, array, **parameters)
+                self.tracer.record_calculation_end(variable.name, period, np.array(["SpiralError"]), **parameters)
             self._clean_cycle_detection_data(variable.name)
 
         # If no result, use the default value

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -151,11 +151,11 @@ class Simulation(object):
                 self.tracer.record_calculation_end(variable.name, period, array, **parameters)
             self._clean_cycle_detection_data(variable.name)
 
-        self._check_end_of_calculate()
+        self.purge_cache_of_invalid_values()
 
         return array
 
-    def _check_end_of_calculate(self):
+    def purge_cache_of_invalid_values(self):
         if len(self.computation_stack) == 0:
             for (_name, _period) in self.invalidated_caches:
                 holder = self.get_holder(_name)

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -326,8 +326,6 @@ class Simulation(object):
             message = "Quasicircular definition detected on formula {}@{} involving {}".format(variable.name, period, self.computation_stack)
             raise SpiralError(message, variable.name)
 
-
-
     def _clean_cycle_detection_data(self, variable_name):
         """
         When the value of a formula have been computed, remove the period from

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -318,15 +318,21 @@ class Simulation(object):
         a heuristic, against "quasicircles", where the evaluation of a variable at a period involves
         the same variable at a different period.
         """
+        max_spiral_loops = 2
         previous = [(name, period) for (name, period, status) in self.computation_stack if name == variable.name]
-        spiral = len(previous) > 1
+        spiral = len(previous) >= max_spiral_loops
         self.computation_stack.append([variable.name, str(period), True])
         for pair in previous:
             if pair == (variable.name, str(period)):
                 raise CycleError("Circular definition detected on formula {}@{}".format(variable.name, period))
         if spiral:
+            count = 0
             for frame in self.computation_stack[::-1]:
                 frame[2] = False
+                if frame[0] == variable.name:
+                    count += 1
+                    if count > max_spiral_loops:
+                        break
             message = "Quasicircular definition detected on formula {}@{} involving {}".format(variable.name, period, self.computation_stack)
             raise SpiralError(message, variable.name)
 

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -64,6 +64,8 @@ class Simulation(object):
         self.trace = False
         self.opt_out_cache = False
 
+        # controls the spirals detection; check for performance impact if > 1
+        self.max_spiral_loops = 1
         self.memory_config = None
         self._data_storage_dir = None
 

--- a/openfisca_core/tracers.py
+++ b/openfisca_core/tracers.py
@@ -147,28 +147,6 @@ class Tracer(object):
                 )
         self.trace[key]['value'] = result
 
-    def record_calculation_abortion(self, variable_name, period, **parameters):
-        """
-            Record that OpenFisca aborted computing a variable. This removes all trace of this computation.
-
-            :param str variable_name: Name of the variable starting to be computed
-            :param Period period: Period for which the variable is being computed
-            :param list parameters: Parameter with which the variable is being computed
-        """
-        key = self._get_key(variable_name, period, **parameters)
-        expected_key = self.stack.pop()
-
-        if not key == expected_key:
-            raise ValueError(
-                "Something went wrong with the simulation tracer: calculation of '{1}' was aborted, whereas the last variable we started computing was '{0}'."
-                .format(expected_key, key).encode('utf-8')
-                )
-
-        if self.stack:
-            parent = self.stack[-1]
-            self.trace[parent]['dependencies'].remove(key)
-        del self.trace[key]
-
     def _get_aggregate(self, key):
         if self._aggregates.get(key):
             return self._aggregates.get(key)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '29.0.2',
+    version = '30.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_cycles.py
+++ b/tests/core/test_cycles.py
@@ -151,17 +151,9 @@ def test_spiral_heuristic(simulation, reference_period):
     assert_near(variable6_last_month, [11])
 
 
-def test_allowed_cycle_different_order(simulation, reference_period):
-    variable5 = simulation.calculate('variable5', period = reference_period)
-    variable6 = simulation.calculate('variable6', period = reference_period)
-    variable6_last_month = simulation.calculate('variable6', reference_period.last_month)
-    assert_near(variable5, [5])
-    assert_near(variable6, [11])
-    assert_near(variable6_last_month, [0])
-
-
 def test_cotisation_1_level(simulation, reference_period):
-    cotisation = simulation.calculate('cotisation', period = reference_period.last_month)
+    month = reference_period.last_month
+    cotisation = simulation.calculate('cotisation', period = month)
     assert_near(cotisation, [2])
 
 

--- a/tests/core/test_cycles.py
+++ b/tests/core/test_cycles.py
@@ -114,7 +114,6 @@ def test_spirals_result_in_default_value(simulation, reference_period):
     assert_near(variable3, [0])
 
 
-@pytest.mark.xfail
 def test_spiral_heuristic(simulation, reference_period):
     """
     Calculate variable5 then variable6 then in the other order, to verify that the first calculated variable
@@ -125,8 +124,8 @@ def test_spiral_heuristic(simulation, reference_period):
     variable6_last_month = simulation.calculate('variable6', reference_period.last_month)
     simulation.tracer.print_computation_log()
     assert_near(variable5, [5])
-    assert_near(variable6, [11])
-    assert_near(variable6_last_month, [11])
+    assert_near(variable6, [6])
+    assert_near(variable6_last_month, [6])
 
 
 def test_cotisation_1_level(simulation, reference_period):

--- a/tests/core/test_cycles.py
+++ b/tests/core/test_cycles.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import pytest
 
 from openfisca_core import periods
 from openfisca_core.periods import MONTH
@@ -135,18 +136,19 @@ def test_spirals_result_in_default_value(simulation, reference_period):
     assert_near(variable3, [0])
 
 
+@pytest.mark.xfail
 def test_spiral_heuristic(simulation, reference_period):
     """
     Calculate variable5 then variable6 then in the other order, to verify that the first calculated variable
     has no effect on the result.
     """
-    variable5 = simulation.calculate('variable5', period = reference_period, trace=True)
-    variable6 = simulation.calculate('variable6', period = reference_period, trace=True)
-    variable6_last_month = simulation.calculate('variable6', reference_period.last_month, trace=True)
+    variable5 = simulation.calculate('variable5', period = reference_period)
+    variable6 = simulation.calculate('variable6', period = reference_period)
+    variable6_last_month = simulation.calculate('variable6', reference_period.last_month)
     simulation.tracer.print_computation_log()
-    assert_near(variable5, [16])
-    assert_near(variable6, [22])
-    assert_near(variable6_last_month, [22])
+    assert_near(variable5, [5])
+    assert_near(variable6, [11])
+    assert_near(variable6_last_month, [11])
 
 
 def test_allowed_cycle_different_order(simulation, reference_period):

--- a/tests/core/test_cycles.py
+++ b/tests/core/test_cycles.py
@@ -137,7 +137,7 @@ def test_spirals_result_in_default_value(simulation, reference_period):
 
 def test_spiral_heuristic(simulation, reference_period):
     """
-    Calculate variable5 then variable6 then in the order order, to verify that the first calculated variable
+    Calculate variable5 then variable6 then in the other order, to verify that the first calculated variable
     has no effect on the result.
     """
     variable5 = simulation.calculate('variable5', period = reference_period, trace=True)

--- a/tests/core/test_cycles.py
+++ b/tests/core/test_cycles.py
@@ -98,32 +98,10 @@ class cotisation(Variable):
             return person.empty_array() + 1
 
 
-# 7 -f-> 8 with a period offset, with explicit cycle allowed (1 level)
-#   <---
-class variable7(Variable):
-    value_type = int
-    entity = Person
-    definition_period = MONTH
-
-    def formula(person, period):
-        variable8 = person('variable8', period.last_month, max_nb_cycles = 1)
-        return 7 + variable8
-
-
-class variable8(Variable):
-    value_type = int
-    entity = Person
-    definition_period = MONTH
-
-    def formula(person, period):
-        variable7 = person('variable7', period)
-        return 8 + variable7
-
-
 # TaxBenefitSystem instance declared after formulas
 tax_benefit_system = CountryTaxBenefitSystem()
 tax_benefit_system.add_variables(variable1, variable2, variable3, variable4,
-    variable5, variable6, cotisation, variable7, variable8)
+    variable5, variable6, cotisation)
 
 
 def test_pure_cycle(simulation, reference_period):
@@ -155,9 +133,3 @@ def test_cotisation_1_level(simulation, reference_period):
     month = reference_period.last_month
     cotisation = simulation.calculate('cotisation', period = month)
     assert_near(cotisation, [2])
-
-
-def test_cycle_1_level(simulation, reference_period):
-    variable7 = simulation.calculate('variable7', period = reference_period)
-    # variable8 = simulation.calculate('variable8')
-    assert_near(variable7, [22])

--- a/tests/core/test_cycles.py
+++ b/tests/core/test_cycles.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import pytest
-
 from openfisca_core import periods
 from openfisca_core.periods import MONTH
 from openfisca_core.simulation_builder import SimulationBuilder

--- a/tests/core/test_cycles.py
+++ b/tests/core/test_cycles.py
@@ -113,7 +113,7 @@ tax_benefit_system.add_variables(variable1, variable2, variable3, variable4,
 
 
 def test_pure_cycle(simulation, reference_period):
-    with raises(AssertionError):
+    with raises(CycleError):
         simulation.calculate('variable1', period = reference_period)
 
 

--- a/tests/core/test_cycles.py
+++ b/tests/core/test_cycles.py
@@ -42,7 +42,7 @@ class variable2(Variable):
         return person('variable1', period)
 
 
-# 3 <--> 4 with a period offset, but without explicit cycle allowed
+# 3 <--> 4 with a period offset
 class variable3(Variable):
     value_type = int
     entity = Person
@@ -61,7 +61,7 @@ class variable4(Variable):
         return person('variable3', period)
 
 
-# 5 -f-> 6 with a period offset, with cycle flagged but not allowed
+# 5 -f-> 6 with a period offset
 #   <---
 class variable5(Variable):
     value_type = int

--- a/tests/core/test_cycles.py
+++ b/tests/core/test_cycles.py
@@ -85,6 +85,16 @@ class variable6(Variable):
         return 6 + variable5
 
 
+class variable7(Variable):
+    value_type = int
+    entity = Person
+    definition_period = MONTH
+
+    def formula(person, period):
+        variable5 = person('variable5', period)
+        return 7 + variable5
+
+
 # december cotisation depending on november value
 class cotisation(Variable):
     value_type = int
@@ -101,7 +111,7 @@ class cotisation(Variable):
 # TaxBenefitSystem instance declared after formulas
 tax_benefit_system = CountryTaxBenefitSystem()
 tax_benefit_system.add_variables(variable1, variable2, variable3, variable4,
-    variable5, variable6, cotisation)
+    variable5, variable6, variable7, cotisation)
 
 
 def test_pure_cycle(simulation, reference_period):
@@ -122,10 +132,15 @@ def test_spiral_heuristic(simulation, reference_period):
     variable5 = simulation.calculate('variable5', period = reference_period)
     variable6 = simulation.calculate('variable6', period = reference_period)
     variable6_last_month = simulation.calculate('variable6', reference_period.last_month)
-    simulation.tracer.print_computation_log()
     assert_near(variable5, [5])
     assert_near(variable6, [6])
     assert_near(variable6_last_month, [6])
+
+
+def test_spiral_cache(simulation, reference_period):
+    simulation.calculate('variable7', period = reference_period)
+    cached_variable7 = simulation.get_holder('variable7').get_array(reference_period)
+    assert cached_variable7 is not None
 
 
 def test_cotisation_1_level(simulation, reference_period):

--- a/tests/core/test_cycles.py
+++ b/tests/core/test_cycles.py
@@ -4,7 +4,7 @@
 from openfisca_core import periods
 from openfisca_core.periods import MONTH
 from openfisca_core.simulation_builder import SimulationBuilder
-from openfisca_core.simulations import CycleError, SpiralError
+from openfisca_core.simulations import CycleError
 from openfisca_core.variables import Variable
 
 from openfisca_country_template import CountryTaxBenefitSystem

--- a/tests/core/test_cycles.py
+++ b/tests/core/test_cycles.py
@@ -101,7 +101,7 @@ class cotisation(Variable):
 
     def formula(person, period):
         if period.start.month == 12:
-            return 2 * person('cotisation', period.last_month, max_nb_cycles = 1)
+            return 2 * person('cotisation', period.last_month)
         else:
             return person.empty_array() + 1
 

--- a/tests/core/test_cycles.py
+++ b/tests/core/test_cycles.py
@@ -3,8 +3,8 @@
 
 from openfisca_core import periods
 from openfisca_core.periods import MONTH
-from openfisca_core.simulations import CycleError
 from openfisca_core.simulation_builder import SimulationBuilder
+from openfisca_core.simulations import CycleError, SpiralError
 from openfisca_core.variables import Variable
 
 from openfisca_country_template import CountryTaxBenefitSystem
@@ -70,7 +70,7 @@ class variable5(Variable):
     definition_period = MONTH
 
     def formula(person, period):
-        variable6 = person('variable6', period.last_month, max_nb_cycles = 0)
+        variable6 = person('variable6', period.last_month)
         return 5 + variable6
 
 
@@ -130,22 +130,23 @@ def test_pure_cycle(simulation, reference_period):
         simulation.calculate('variable1', period = reference_period)
 
 
-def test_cycle_time_offset(simulation, reference_period):
-    with raises(CycleError):
-        simulation.calculate('variable3', period = reference_period)
+def test_spirals_result_in_default_value(simulation, reference_period):
+    variable3 = simulation.calculate('variable3', period = reference_period)
+    assert_near(variable3, [0])
 
 
-def test_allowed_cycle(simulation, reference_period):
+def test_spiral_heuristic(simulation, reference_period):
     """
     Calculate variable5 then variable6 then in the order order, to verify that the first calculated variable
     has no effect on the result.
     """
-    variable6 = simulation.calculate('variable6', period = reference_period)
-    variable5 = simulation.calculate('variable5', period = reference_period)
-    variable6_last_month = simulation.calculate('variable6', reference_period.last_month)
-    assert_near(variable5, [5])
-    assert_near(variable6, [11])
-    assert_near(variable6_last_month, [0])
+    variable5 = simulation.calculate('variable5', period = reference_period, trace=True)
+    variable6 = simulation.calculate('variable6', period = reference_period, trace=True)
+    variable6_last_month = simulation.calculate('variable6', reference_period.last_month, trace=True)
+    simulation.tracer.print_computation_log()
+    assert_near(variable5, [16])
+    assert_near(variable6, [22])
+    assert_near(variable6_last_month, [22])
 
 
 def test_allowed_cycle_different_order(simulation, reference_period):

--- a/tests/core/test_cycles.py
+++ b/tests/core/test_cycles.py
@@ -123,16 +123,12 @@ def test_spirals_result_in_default_value(simulation, reference_period):
 
 
 def test_spiral_heuristic(simulation, reference_period):
-    """
-    Calculate variable5 then variable6 then in the other order, to verify that the first calculated variable
-    has no effect on the result.
-    """
     variable5 = simulation.calculate('variable5', period = reference_period)
     variable6 = simulation.calculate('variable6', period = reference_period)
     variable6_last_month = simulation.calculate('variable6', reference_period.last_month)
-    assert_near(variable5, [5])
-    assert_near(variable6, [6])
-    assert_near(variable6_last_month, [6])
+    assert_near(variable5, [11])
+    assert_near(variable6, [11])
+    assert_near(variable6_last_month, [11])
 
 
 def test_spiral_cache(simulation, reference_period):
@@ -144,4 +140,4 @@ def test_spiral_cache(simulation, reference_period):
 def test_cotisation_1_level(simulation, reference_period):
     month = reference_period.last_month
     cotisation = simulation.calculate('cotisation', period = month)
-    assert_near(cotisation, [2])
+    assert_near(cotisation, [0])


### PR DESCRIPTION
* Breaking change
* Improve cycle and spiral detection, giving consistent results more systematically
* Migration instructions:
  - remove all optional parameters `max_nb_cycles`
  - avoid relying on cached values of a computation (especially wrong values)

--------
## Detailed explanation of the changes

Terminology:
- a "cycle" describes the situation where computing an OpenFisca variable for a given period eventually triggers the computation of the same variable for the same period; this cannot be resolved, so an exception is raised and the computation is aborted;
- a "spiral" is a related situation where computing a variable for a given period requires computing the same variable for a different period.

This PR makes that distinction more explicit by the type of exception raised.

Previously it was the responsibility of callers (country package authors and other reusers) to control the behaviour in the presence of spirals, by setting a limit on the number of "loops" a computation can go through. In such cases, the computation is not aborted with an error but allowed to proceed after returning a default value (usually 0). **This resulted in inconsistent computations in interaction with caching of computed values.**

This PR removes this responsibility from the caller, and Core now "goes the extra mile" to detect this condition, and to behave more reliably - returning consistent results that do not depend on the order in which computations are performed.

Spirals are more complex to analyse in the absence of static determination of the dependency between variables, so a heuristic is applied in this PR: limit the number of loops to 1. In addition, values computed in a "spiral" configuration **should not be cached**. We have verified empirically that with these changes, the result of computations no longer depends on their ordering.

This PR effects the following changes:
- maintain a separate stack structure that mimics the actual Python stack
- upon exceeding the loop limit, propagate the error up that parallel stack
- but propagate it only up to the variable for which a spiral exists, not above
- raise an exception to exit the formula in which the error was detected
- return the default value from this computation
- on completion of the original computation, invalidate the cached values of all variables marked as involved in the spiral

Connected to openfisca/openfisca-france#1211