### PR TITLE
Fix message output by test runner when a variable is unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 25.3.1 [#820](https://github.com/openfisca/openfisca-core/pull/820)
+
+- Outputs a more helpful message when a variable checked in a test doesn't exist
+- Introduces unit tests for the test runner
+
 ## 25.3.0 [#811](https://github.com/openfisca/openfisca-core/pull/811)
 
 #### Technical changes

--- a/openfisca_core/errors.py
+++ b/openfisca_core/errors.py
@@ -34,6 +34,7 @@ class VariableNotFound(Exception):
             "it is probably available on <https://github.com/openfisca/{0}/blob/master/CHANGELOG.md>.".format(country_package_name)
             ])
         self.message = message
+        self.variable_name = variable_name
         Exception.__init__(self, self.message.encode('utf-8'))
 
 

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -483,7 +483,7 @@ class Simulation(object):
         if entity_type:
             return self.entities[entity_type.key]
         if plural:
-            return next((entity for entity in self.entities.values() if entity.plural == plural))
+            return next((entity for entity in self.entities.values() if entity.plural == plural), None)
 
     def clone(self, debug = False, trace = False):
         """

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -248,11 +248,15 @@ def _run_test(simulation, test):
             for variable_name, value in expected_value.items():
                 _check_variable(simulation, variable_name, value, test.get('period'), test)
         else:
-            entity_array = simulation.get_entity(plural = key)  # If key is an entity plural
-            for entity_id, value_by_entity in expected_value.items():
-                for variable_name, value in value_by_entity.items():
-                    entity_index = entity_array.ids.index(entity_id)
-                    _check_variable(simulation, variable_name, value, test.get('period'), test, entity_index)
+            entity_array = simulation.get_entity(plural = key)
+            if entity_array is not None:  # If key is an entity plural
+                for entity_id, value_by_entity in expected_value.items():
+                    for variable_name, value in value_by_entity.items():
+                        entity_index = entity_array.ids.index(entity_id)
+                        _check_variable(simulation, variable_name, value, test.get('period'), test, entity_index)
+            else:
+                message = "In test '{}', in file '{}', you wanted to check the value of {}, but we don't know a variable with this name."
+                raise ValueError(message.format(test.get('name'), test.get('file_path'), key))
 
 
 def _should_ignore_variable(variable_name, test):

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '25.3.0',
+    version = '25.3.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_runner/test_yaml_runner.py
+++ b/tests/core/test_runner/test_yaml_runner.py
@@ -1,0 +1,19 @@
+from openfisca_core.tools.test_runner import _run_test
+
+import pytest
+
+class TaxBenefitSystem:
+	def __init__(self):
+		self.variables = {}
+
+class Simulation:
+	def __init__(self):
+		self.tax_benefit_system = TaxBenefitSystem()
+		self.entities = {}
+	def get_entity(self, plural = None):
+		return None
+
+def test_variable_not_found():
+	test = {"output": {"unknown_variable": 0}}	
+	with pytest.raises(ValueError):
+		_run_test(Simulation(), test)

--- a/tests/core/test_runner/test_yaml_runner.py
+++ b/tests/core/test_runner/test_yaml_runner.py
@@ -1,4 +1,5 @@
 from openfisca_core.tools.test_runner import _run_test
+from openfisca_core.errors import VariableNotFound
 
 
 import pytest
@@ -7,6 +8,9 @@ import pytest
 class TaxBenefitSystem:
     def __init__(self):
         self.variables = {}
+
+    def get_package_metadata(self):
+        return {"name": "Test", "version": "Test"}
 
 
 class Simulation:
@@ -20,5 +24,6 @@ class Simulation:
 
 def test_variable_not_found():
     test = {"output": {"unknown_variable": 0}}
-    with pytest.raises(ValueError):
+    with pytest.raises(VariableNotFound) as excinfo:
         _run_test(Simulation(), test)
+    assert excinfo.value.variable_name == "unknown_variable"

--- a/tests/core/test_runner/test_yaml_runner.py
+++ b/tests/core/test_runner/test_yaml_runner.py
@@ -1,19 +1,24 @@
 from openfisca_core.tools.test_runner import _run_test
 
+
 import pytest
 
+
 class TaxBenefitSystem:
-	def __init__(self):
-		self.variables = {}
+    def __init__(self):
+        self.variables = {}
+
 
 class Simulation:
-	def __init__(self):
-		self.tax_benefit_system = TaxBenefitSystem()
-		self.entities = {}
-	def get_entity(self, plural = None):
-		return None
+    def __init__(self):
+        self.tax_benefit_system = TaxBenefitSystem()
+        self.entities = {}
+
+    def get_entity(self, plural = None):
+        return None
+
 
 def test_variable_not_found():
-	test = {"output": {"unknown_variable": 0}}	
-	with pytest.raises(ValueError):
-		_run_test(Simulation(), test)
+    test = {"output": {"unknown_variable": 0}}
+    with pytest.raises(ValueError):
+        _run_test(Simulation(), test)

--- a/tests/core/test_simulations.py
+++ b/tests/core/test_simulations.py
@@ -30,6 +30,11 @@ def test_calculate_with_trace():
     assert housing_tax_trace['parameters']['taxes.housing_tax.minimal_amount<2017-01-01>'] == 200
 
 
+def test_get_entity_not_found():
+    simulation = scenario.new_simulation(trace = True)
+    assert simulation.get_entity(plural = "no_such_entities") is None
+
+
 def test_clone():
     simulation = Simulation(
         tax_benefit_system = tax_benefit_system,


### PR DESCRIPTION
Fixes #801

- Outputs a more helpful message when a variable checked in a test doesn't exist
- Introduces unit tests for the test runners