### PR TITLE
Add debugger option to openfisca test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 25.3.3 [821](https://github.com/openfisca/openfisca-core/pull/821)
+
+- Bring up the debugger on integration test failures with `openfisca test --pdb` optional argument
+
 ### 25.3.2 [824](https://github.com/openfisca/openfisca-core/pull/824)
 
 - Rename LICENSE.AGPL.txt to LICENSE to let github recognize it

--- a/openfisca_core/scripts/openfisca_command.py
+++ b/openfisca_core/scripts/openfisca_command.py
@@ -36,6 +36,7 @@ def get_parser():
         parser.add_argument('path', help = "paths (files or directories) of tests to execute", nargs = '+')
         parser = add_tax_benefit_system_arguments(parser)
         parser.add_argument('-n', '--name_filter', default = None, help = "partial name of tests to execute. Only tests with the given name_filter in their name, file name, or keywords will be run.")
+        parser.add_argument('-p', '--pdb', action = 'store_true', default = False, help = "drop into debugger on failures or errors")
         parser.add_argument('-v', '--verbose', action = 'store_true', default = False, help = "increase output verbosity")
         parser.add_argument('-o', '--only-variables', nargs = '*', default = None, help = "variables to test. If specified, only test the given variables.")
         parser.add_argument('-i', '--ignore-variables', nargs = '*', default = None, help = "variables to ignore. If specified, do not test the given variables.")

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -16,6 +16,7 @@ def main(parser):
     tax_benefit_system = build_tax_benefit_system(args.country_package, args.extensions, args.reforms)
 
     options = {
+        'pdb': args.pdb,
         'verbose': args.verbose,
         'name_filter': args.name_filter,
         'only_variables': args.only_variables,

--- a/openfisca_core/taxscales.py
+++ b/openfisca_core/taxscales.py
@@ -162,6 +162,7 @@ class MarginalAmountTaxScale(SingleAmountTaxScale):
     A MarginalAmountTaxScale's calc() method matches the input amount to a set of brackets
     and returns the sum of cell values from the lowest bracket to the one containing the input.
     '''
+
     def calc(self, base):
         base1 = np.tile(base, (len(self.thresholds), 1)).T
         thresholds1 = np.tile(np.hstack((self.thresholds, np.inf)), (len(base), 1))

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -103,9 +103,15 @@ def run_tests(tax_benefit_system, paths, options = {}):
 
     """
     argv = sys.argv[:1]  # Nose crashes if it gets any unexpected argument.
+
+    if options.get('pdb'):
+        argv.append('--pdb')
+
     if options.get('verbose'):
         argv.append('--nocapture')  # Do not capture output when verbose mode is activated
+
     argv.append('--nologcapture')  # Do not capture logs so that the user can define a log level
+
     return nose.run(
         # The suite argument must be a lambda for nose to run the tests lazily
         suite = lambda: generate_tests(tax_benefit_system, paths, options),

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '25.3.2',
+    version = '25.3.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
#### New features

- Introduce `openfisca test --pdb`
  - Allows for dropping into debugger on failures or errors
  - Example : 
    
```
test --pdb --country-package openfisca_country_template path/to/country/template/tests
..........................ERROR:openfisca_core.tools.test_runner:age.yaml
> /path/to/openfisca-core/openfisca-core/openfisca_core/tools/__init__.py(44)assert_near()
-> diff, absolute_error_margin)
(Pdb)
```