### PR TITLE
Fix end date application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 #### Migration guide
 
-This change is not expected to actually break any reusing code, as it seems inconsistent to specify an end date for a variable and use it in computations for periods past that date. However, nothing has previously ruled out relying on that behaviour.
+This change is not expected to actually break much reusing code (if any), as it is unlikely that one would deliberately specify an end date for a variable and use it in computations for periods past that date. However, nothing has previously ruled out relying on that behaviour and it may have been introduced by accident. In particular, it can happen that a variable with a formula and an end date is also, in some applications, used as an input.
 
 ## 26.2.0 [#833](https://github.com/openfisca/openfisca-core/pull/833)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+# 27.0.0 [#826](https://github.com/openfisca/openfisca-core/pull/826)
+
+#### Breaking changes
+
+- No longer honor calls to set_input for variables which have an end date and for periods after that date.
+
+#### Migration guide
+
+This change is not expected to actually break any reusing code, as it seems inconsistent to specify an end date for a variable and use it in computations for periods past that date. However, nothing has previously ruled out relying on that behaviour.
+
 ## 26.2.0 [#833](https://github.com/openfisca/openfisca-core/pull/833)
 
 - Introduce a way to build a simulation for tabular inputs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Breaking changes
 
-- No longer honor calls to set_input for variables which have an end date and for periods after that date.
+- No longer honor calls to `set_input` for variables which have an end date and for periods after that date.
 
 #### Migration guide
 

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -7,7 +7,6 @@ import warnings
 
 import numpy as np
 import psutil
-from datetime import date
 
 from openfisca_core import periods
 from openfisca_core.commons import empty_clone

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -172,7 +172,7 @@ class Holder(object):
                 self.variable.definition_period,
                 error_message
                 )
-        if self.variable.is_neutralized or ((self.variable.end is not None) and (period.start.date > self.variable.end)):
+        if self.variable.is_neutralized:
             warning_message = "You cannot set a value for the variable {}, as it has been neutralized. The value you provided ({}) will be ignored.".format(self.variable.name, array)
             if sys.version_info < (3, 0):
                 warning_message = warning_message.encode('utf-8')

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -7,6 +7,7 @@ import warnings
 
 import numpy as np
 import psutil
+from datetime import date
 
 from openfisca_core import periods
 from openfisca_core.commons import empty_clone
@@ -87,7 +88,7 @@ class Holder(object):
 
             If the value is not known, return ``None``.
         """
-        if self.variable.is_neutralized:
+        if self.variable.is_neutralized or ((self.variable.end is not None) and (period.startd.date > self.variable.end)):
             return self.default_array()
         value = self._memory_storage.get(period, extra_params)
         if value is not None:

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -172,7 +172,7 @@ class Holder(object):
                 self.variable.definition_period,
                 error_message
                 )
-        if self.variable.is_neutralized or ((self.variable.end is not None) and (period.startd.date > self.variable.end)):
+        if self.variable.is_neutralized or ((self.variable.end is not None) and (period.start.date > self.variable.end)):
             warning_message = "You cannot set a value for the variable {}, as it has been neutralized. The value you provided ({}) will be ignored.".format(self.variable.name, array)
             if sys.version_info < (3, 0):
                 warning_message = warning_message.encode('utf-8')

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -88,7 +88,7 @@ class Holder(object):
 
             If the value is not known, return ``None``.
         """
-        if self.variable.is_neutralized or ((self.variable.end is not None) and (period.startd.date > self.variable.end)):
+        if self.variable.is_neutralized or ((self.variable.end is not None) and (period.start.date > self.variable.end)):
             return self.default_array()
         value = self._memory_storage.get(period, extra_params)
         if value is not None:

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -173,7 +173,7 @@ class Holder(object):
                 self.variable.definition_period,
                 error_message
                 )
-        if self.variable.is_neutralized:
+        if self.variable.is_neutralized or ((self.variable.end is not None) and (period.startd.date > self.variable.end)):
             warning_message = "You cannot set a value for the variable {}, as it has been neutralized. The value you provided ({}) will be ignored.".format(self.variable.name, array)
             if sys.version_info < (3, 0):
                 warning_message = warning_message.encode('utf-8')

--- a/openfisca_core/simulation_builder.py
+++ b/openfisca_core/simulation_builder.py
@@ -404,7 +404,11 @@ class SimulationBuilder(object):
                 # Hack to replicate the values in the persons entity
                 # when we have an axis along a group entity but not persons
                 array = np.tile(values, entity.count // len(values))
-                holder.set_input(period_value, array)
+                variable = holder.variable
+                # TODO - this duplicates the check in Simulation.set_input, but
+                # fixing that requires improving Simulation's handling of entities
+                if (variable.end is None) or (period_value.start.date > variable.end):
+                    holder.set_input(period_value, array)
 
     def raise_period_mismatch(self, entity, json, e):
         # This error happens when we try to set a variable value for a period that doesn't match its definition period

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -478,7 +478,7 @@ class Simulation(object):
 
             If a ``set_input`` property has been set for the variable, this method may accept inputs for periods not matching the ``definition_period`` of the variable. To read more about this, check the `documentation <https://openfisca.org/doc/coding-the-legislation/35_periods.html#automatically-process-variable-inputs-defined-for-periods-not-matching-the-definitionperiod>`_.
         """
-        variable = self.tax_benefit_system.variables[variable_name]
+        variable = self.tax_benefit_system.get_variable(variable_name)
         period = periods.period(period)
         if ((variable.end is not None) and (period.start.date > variable.end)):
             return

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -461,7 +461,7 @@ class Simulation(object):
         """
         return self.get_holder(variable).get_known_periods()
 
-    def set_input(self, variable, period, value):
+    def set_input(self, variable_name, period, value):
         """
             Set a variable's value for a given period
 
@@ -478,7 +478,11 @@ class Simulation(object):
 
             If a ``set_input`` property has been set for the variable, this method may accept inputs for periods not matching the ``definition_period`` of the variable. To read more about this, check the `documentation <https://openfisca.org/doc/coding-the-legislation/35_periods.html#automatically-process-variable-inputs-defined-for-periods-not-matching-the-definitionperiod>`_.
         """
-        self.get_holder(variable).set_input(period, value)
+        variable = self.tax_benefit_system.variables[variable_name]
+        period = periods.period(period)
+        if ((variable.end is not None) and (period.start.date > variable.end)):
+            return
+        self.get_holder(variable_name).set_input(period, value)
 
     def get_variable_entity(self, variable_name):
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ from setuptools import setup, find_packages
 general_requirements = [
     'dpath == 1.4.0',
     'enum34 >= 1.1.6',
-    'future < 1.0.0',
     'nose < 2.0.0',  # For openfisca test
     'numpy >= 1.11, < 1.16',
     'psutil == 5.4.6',
@@ -37,7 +36,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '26.2.0',
+    version = '27.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_variables.py
+++ b/tests/core/test_variables.py
@@ -111,6 +111,16 @@ def test_variable__end_attribute():
     assert variable.end == datetime.date(1989, 12, 31)
 
 
+def test_variable__end_attribute_set_input():
+    month_before_end = '1989-01'
+    month_after_end = '1990-01'
+    simulation = new_simulation(tax_benefit_system, month_before_end)
+    simulation.set_input('variable__end_attribute', month_before_end, 10)
+    simulation.set_input('variable__end_attribute', month_after_end, 10)
+    assert simulation.calculate('variable__end_attribute', month_before_end) == 10
+    assert simulation.calculate('variable__end_attribute', month_after_end) == 0
+
+
 # end, one formula without date
 
 class end_attribute__one_simple_formula(Variable):


### PR DESCRIPTION
Hi everyone,

I want to design a reform where all non-contributive taxes and benefits (e.g. income tax, housing benefits, family benefits, social benefits etc.) are neutralized. I want this reform to apply only from a given date.

What I tried to do : 

- The `neutralize_variable` function and the related attribute `is_neutralized` cannot help me with that. They apply for all periods (either a variable is always neutralized either it is never).
- So I tried a solution with the `end` attribute from `Variable`. But it turns out that it does not work for "input" variables. 
Example : *I provide a value for a variable for period `"2019"` and then I code a reform that create an end date for this variable which is equal to `"2018-12-31"`. If I ask OpenFisca to calculate this variable for period `"2019"`, it will return the value I provided. I would like it to return the default value (like if it were neutralized).*

What I propose as a solution : 

- Prevent the computation of a variable after its end date and prevent values to be set for variable after its  end date.

Note that this solution works only because I'm interested in neutralizing variables after a certain date. But if want to neutralize variables between date T and T+1 it won't work for example...

#### Breaking changes

- In `holders.py`: 
  - Treat the variable as if it was neutralized for periods after its end date
