### PR TITLE
Remove __future__ statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 26.0.3 [828](https://github.com/openfisca/openfisca-core/pull/828)
+
+- Remove `__future__` statements
+  - As Python 2 support has been dropped, they are not needed anymore.
+
 ### 26.0.2 [830](https://github.com/openfisca/openfisca-core/pull/830)
 
 - Collect and publish measurements of which lines of codes are exercised (or not) by our tests

--- a/openfisca_core/base_functions.py
+++ b/openfisca_core/base_functions.py
@@ -7,8 +7,6 @@
     If a variable is calculated at a period for which it does not have a formulas, its base_function will be called to try to infere a value based on past or future values of the variable.
 """
 
-from __future__ import unicode_literals, print_function, division, absolute_import
-
 
 def requested_period_default_value(holder, period, *extra_params):
     """

--- a/openfisca_core/commons.py
+++ b/openfisca_core/commons.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 from builtins import str
 
 

--- a/openfisca_core/data_storage.py
+++ b/openfisca_core/data_storage.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import shutil
 import os
 

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import traceback
 import warnings
 import textwrap

--- a/openfisca_core/errors.py
+++ b/openfisca_core/errors.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 
 import os
 

--- a/openfisca_core/formula_helpers.py
+++ b/openfisca_core/formula_helpers.py
@@ -2,7 +2,6 @@
 
 
 """Helpers to write formulas."""
-from __future__ import unicode_literals, print_function, division, absolute_import
 
 
 import numpy as np

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import logging
 import os
 import sys

--- a/openfisca_core/indexed_enums.py
+++ b/openfisca_core/indexed_enums.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 
 import numpy as np
 from enum import Enum as BaseEnum

--- a/openfisca_core/memory_config.py
+++ b/openfisca_core/memory_config.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import logging
 
 log = logging.getLogger(__name__)

--- a/openfisca_core/model_api.py
+++ b/openfisca_core/model_api.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 from datetime import date  # noqa analysis:ignore
 
 from numpy import (   # noqa analysis:ignore

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -2,7 +2,6 @@
 
 
 """Handle legislative parameters."""
-from __future__ import unicode_literals, print_function, division, absolute_import
 
 
 import os

--- a/openfisca_core/periods.py
+++ b/openfisca_core/periods.py
@@ -8,7 +8,6 @@ A period is a triple (unit, start, size), where unit is either "month" or "year"
 
 Since a period is a triple it can be used as a dictionary key.
 """
-
 import calendar
 import datetime
 import re

--- a/openfisca_core/rates.py
+++ b/openfisca_core/rates.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 
 import numpy
 

--- a/openfisca_core/reforms.py
+++ b/openfisca_core/reforms.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import copy
 
 from openfisca_core.parameters import ParameterNode

--- a/openfisca_core/scripts/__init__.py
+++ b/openfisca_core/scripts/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import traceback
 import importlib
 import logging

--- a/openfisca_core/scripts/find_placeholders.py
+++ b/openfisca_core/scripts/find_placeholders.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import os
 import fnmatch
 import sys

--- a/openfisca_core/scripts/measure_numpy_condition_notations.py
+++ b/openfisca_core/scripts/measure_numpy_condition_notations.py
@@ -10,7 +10,6 @@ Measure and compare different vectorial condition notations:
 
 The aim of this script is to compare the time taken by the calculation of the values
 """
-from __future__ import unicode_literals, print_function, division, absolute_import
 from contextlib import contextmanager
 import argparse
 import sys

--- a/openfisca_core/scripts/measure_performances.py
+++ b/openfisca_core/scripts/measure_performances.py
@@ -3,7 +3,6 @@
 
 
 """Measure performances of a basic tax-benefit system to compare to other OpenFisca implementations."""
-from __future__ import unicode_literals, print_function, division, absolute_import
 import argparse
 import logging
 import sys

--- a/openfisca_core/scripts/measure_performances_fancy_indexing.py
+++ b/openfisca_core/scripts/measure_performances_fancy_indexing.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals, print_function, division, absolute_import
 
 import numpy as np
 import timeit

--- a/openfisca_core/scripts/migrations/v16_2_to_v17/xml_to_yaml.py
+++ b/openfisca_core/scripts/migrations/v16_2_to_v17/xml_to_yaml.py
@@ -5,7 +5,6 @@
 
 Comments are NOT converted.
 '''
-from __future__ import unicode_literals, print_function, division, absolute_import
 
 
 import os

--- a/openfisca_core/scripts/migrations/v16_2_to_v17/xml_to_yaml_country_template.py
+++ b/openfisca_core/scripts/migrations/v16_2_to_v17/xml_to_yaml_country_template.py
@@ -7,7 +7,6 @@ Usage :
 or just (output is written in a directory called `yaml_parameters`):
   `python xml_to_yaml_country_template.py`
 '''
-from __future__ import unicode_literals, print_function, division, absolute_import
 import sys
 import os
 

--- a/openfisca_core/scripts/migrations/v16_2_to_v17/xml_to_yaml_extension_template.py
+++ b/openfisca_core/scripts/migrations/v16_2_to_v17/xml_to_yaml_extension_template.py
@@ -7,7 +7,6 @@ Usage :
 or just (output is written in a directory called `yaml_parameters`):
   `python xml_to_yaml_extension_template.py`
 '''
-from __future__ import unicode_literals, print_function, division, absolute_import
 
 import sys
 import os

--- a/openfisca_core/scripts/migrations/v24_to_25.py
+++ b/openfisca_core/scripts/migrations/v24_to_25.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 
 import argparse
 import os

--- a/openfisca_core/scripts/openfisca_command.py
+++ b/openfisca_core/scripts/openfisca_command.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals, print_function, division, absolute_import
 import argparse
 import warnings
 import sys

--- a/openfisca_core/scripts/remove_fuzzy.py
+++ b/openfisca_core/scripts/remove_fuzzy.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals, print_function, division, absolute_import
 # remove_fuzzy.py : Remove the fuzzy attribute in xml files and add END tags.
 # See https://github.com/openfisca/openfisca-core/issues/437
 

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import logging
 import sys
 import os

--- a/openfisca_core/scripts/simulation_generator.py
+++ b/openfisca_core/scripts/simulation_generator.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals, print_function, division, absolute_import
 import numpy as np
 
 import random

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 from os import linesep
 import tempfile
 import logging

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import glob
 from inspect import isclass
 from os import path, linesep

--- a/openfisca_core/taxscales.py
+++ b/openfisca_core/taxscales.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import unicode_literals, print_function, division, absolute_import
-
 from bisect import bisect_left, bisect_right
 import copy
 import logging

--- a/openfisca_core/tools/__init__.py
+++ b/openfisca_core/tools/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 
 import os
 

--- a/openfisca_core/tools/simulation_dumper.py
+++ b/openfisca_core/tools/simulation_dumper.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 
 import os
 

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -4,7 +4,6 @@
 A module to run openfisca yaml tests
 """
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 from builtins import str
 
 import glob

--- a/openfisca_core/tracers.py
+++ b/openfisca_core/tracers.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 
 import numpy as np
 

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import datetime
 import inspect
 import re

--- a/openfisca_web_api/app.py
+++ b/openfisca_web_api/app.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import logging
 import os
 import traceback

--- a/openfisca_web_api/errors.py
+++ b/openfisca_web_api/errors.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import logging
 
 log = logging.getLogger('gunicorn.error')

--- a/openfisca_web_api/handlers.py
+++ b/openfisca_web_api/handlers.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 
 from copy import deepcopy
 

--- a/openfisca_web_api/loader/__init__.py
+++ b/openfisca_web_api/loader/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 
 from openfisca_web_api.loader.parameters import build_parameters
 from openfisca_web_api.loader.variables import build_variables

--- a/openfisca_web_api/loader/entities.py
+++ b/openfisca_web_api/loader/entities.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 from openfisca_core.commons import to_unicode
 
 

--- a/openfisca_web_api/loader/parameters.py
+++ b/openfisca_web_api/loader/parameters.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 from openfisca_core.parameters import Parameter, ParameterNode, Scale
 
 

--- a/openfisca_web_api/loader/spec.py
+++ b/openfisca_web_api/loader/spec.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import os
 import yaml
 from copy import deepcopy

--- a/openfisca_web_api/loader/tax_benefit_system.py
+++ b/openfisca_web_api/loader/tax_benefit_system.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import importlib
 import traceback
 import logging

--- a/openfisca_web_api/loader/variables.py
+++ b/openfisca_web_api/loader/variables.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import datetime
 import inspect
 import textwrap

--- a/openfisca_web_api/scripts/serve.py
+++ b/openfisca_web_api/scripts/serve.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import sys
 import logging
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '26.0.2',
+    version = '26.0.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 from setuptools import setup, find_packages
 
 # Please make sure to cap all dependency versions, in order to avoid unwanted

--- a/tests/core/parameter_validation/test_parameter_validation.py
+++ b/tests/core/parameter_validation/test_parameter_validation.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import os
 
 from nose.tools import assert_in, raises

--- a/tests/core/parameters_fancy_indexing/test_fancy_indexing.py
+++ b/tests/core/parameters_fancy_indexing/test_fancy_indexing.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import os
 
 import numpy as np

--- a/tests/core/test_base_functions.py
+++ b/tests/core/test_base_functions.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals, print_function, division, absolute_import
 import numpy as np
 from openfisca_core.tools import assert_near
 

--- a/tests/core/test_calculate_output.py
+++ b/tests/core/test_calculate_output.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals, print_function, division, absolute_import
 from nose.tools import raises
 
 from openfisca_core.model_api import *  # noqa analysis:ignore

--- a/tests/core/test_countries.py
+++ b/tests/core/test_countries.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 from nose.tools import raises, assert_raises
 
 from openfisca_core.variables import Variable

--- a/tests/core/test_cycles.py
+++ b/tests/core/test_cycles.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 from nose.tools import raises
 
 from openfisca_core import periods

--- a/tests/core/test_dump_restore.py
+++ b/tests/core/test_dump_restore.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 
 import shutil
 import tempfile

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 from copy import deepcopy
 
 from openfisca_core.simulation_builder import SimulationBuilder

--- a/tests/core/test_extensions.py
+++ b/tests/core/test_extensions.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals, print_function, division, absolute_import
 from nose.tools import raises
 
 from openfisca_country_template import CountryTaxBenefitSystem

--- a/tests/core/test_extra_params.py
+++ b/tests/core/test_extra_params.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 
 from openfisca_core import periods
 from openfisca_core.periods import MONTH

--- a/tests/core/test_formula_helpers.py
+++ b/tests/core/test_formula_helpers.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import numpy
 from nose.tools import raises
 

--- a/tests/core/test_formulas.py
+++ b/tests/core/test_formulas.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import numpy as np
 
 from openfisca_core.periods import MONTH

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import numpy as np
 
 from nose.tools import assert_equal, assert_is_none

--- a/tests/core/test_opt_out_cache.py
+++ b/tests/core/test_opt_out_cache.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 from openfisca_country_template import CountryTaxBenefitSystem
 from openfisca_country_template.entities import Person
 from openfisca_core.variables import Variable

--- a/tests/core/test_parameters.py
+++ b/tests/core/test_parameters.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 from nose.tools import assert_equal, raises
 import tempfile
 

--- a/tests/core/test_periods.py
+++ b/tests/core/test_periods.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 
 import pytest
 

--- a/tests/core/test_reforms.py
+++ b/tests/core/test_reforms.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import warnings
 
 

--- a/tests/core/test_simulations.py
+++ b/tests/core/test_simulations.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 
 from openfisca_core.simulations import Simulation
 

--- a/tests/core/test_tax_scales.py
+++ b/tests/core/test_tax_scales.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import numpy as np
 
 from openfisca_core.taxscales import *

--- a/tests/core/test_tracer.py
+++ b/tests/core/test_tracer.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 from nose.tools import raises, assert_equals
 import numpy as np
 

--- a/tests/core/test_variables.py
+++ b/tests/core/test_variables.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import datetime
 from nose.tools import raises
 

--- a/tests/core/test_yaml.py
+++ b/tests/core/test_yaml.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import pkg_resources
 import os
 import sys

--- a/tests/core/tools/test_assert_near.py
+++ b/tests/core/tools/test_assert_near.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals, print_function, division, absolute_import
 
 import numpy as np
 

--- a/tests/web_api/__init__.py
+++ b/tests/web_api/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import pkg_resources
 from openfisca_web_api.app import create_app
 from openfisca_core.scripts import build_tax_benefit_system

--- a/tests/web_api/basic_case/__init__.py
+++ b/tests/web_api/basic_case/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals, print_function, division, absolute_import
 import pkg_resources
 from openfisca_web_api.app import create_app
 from openfisca_core.scripts import build_tax_benefit_system

--- a/tests/web_api/case_with_extension/test_extensions.py
+++ b/tests/web_api/case_with_extension/test_extensions.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 from http.client import OK
 from nose.tools import assert_equal
 from openfisca_core.scripts import build_tax_benefit_system

--- a/tests/web_api/test_calculate.py
+++ b/tests/web_api/test_calculate.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import os
 import json
 from http.client import BAD_REQUEST, OK, NOT_FOUND

--- a/tests/web_api/test_entities.py
+++ b/tests/web_api/test_entities.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 from http.client import OK
 from nose.tools import assert_equal
 import json

--- a/tests/web_api/test_headers.py
+++ b/tests/web_api/test_headers.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 from nose.tools import assert_equal
 from . import distribution, subject
 

--- a/tests/web_api/test_helpers.py
+++ b/tests/web_api/test_helpers.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals, print_function, division, absolute_import
 import os
 
 from nose.tools import assert_equal

--- a/tests/web_api/test_parameters.py
+++ b/tests/web_api/test_parameters.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 from http.client import OK, NOT_FOUND
 import json
 from nose.tools import assert_equal, assert_regexp_matches, assert_in

--- a/tests/web_api/test_spec.py
+++ b/tests/web_api/test_spec.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import json
 from http.client import OK
 

--- a/tests/web_api/test_trace.py
+++ b/tests/web_api/test_trace.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 import json
 from copy import deepcopy
 

--- a/tests/web_api/test_variables.py
+++ b/tests/web_api/test_variables.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function, division, absolute_import
 from http.client import OK, NOT_FOUND
 import json
 from nose.tools import assert_equal, assert_regexp_matches, assert_in, assert_is_none, assert_not_in


### PR DESCRIPTION
#### Technical changes

- Remove `__future__` statements
  - As Python 2 support has been dropped, they are not needed anymore.