### PR TITLE
Update autopep8 and flake8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 26.0.4 [#825](https://github.com/openfisca/openfisca-core/pull/825)
+### 26.0.5 [#829](https://github.com/openfisca/openfisca-core/pull/829)
+
+- Update autopep8 and flake8, which in particular now enforce rules W504 and W605
+  - W504 goes against house style, so we add it to ignored rules
+  - W605 may seem like an [overreach](https://github.com/PyCQA/pycodestyle/issues/755) but does make sense (additional details in PR description), so we upgrade a few regexes to raw strings
+
+### 26.0.4 [#825](https://github.com/openfisca/openfisca-core/pull/825)
 
 - Fixes regression introduced by Core v25 when running YAML tests with reforms or extensions
 

--- a/openfisca_core/periods.py
+++ b/openfisca_core/periods.py
@@ -21,7 +21,7 @@ MONTH = 'month'
 YEAR = 'year'
 ETERNITY = 'eternity'
 
-INSTANT_PATTERN = re.compile('^\d{4}(?:-\d{1,2}){0,2}$')  # matches '2015', '2015-01', '2015-01-01'
+INSTANT_PATTERN = re.compile(r'^\d{4}(?:-\d{1,2}){0,2}$')  # matches '2015', '2015-01', '2015-01-01'
 
 
 def N_(message):

--- a/openfisca_core/scripts/remove_fuzzy.py
+++ b/openfisca_core/scripts/remove_fuzzy.py
@@ -20,9 +20,9 @@ lines_2 = [
     for line in lines
     ]
 
-regex_indent = '^(\s*)<VALUE '
-regex_fin = ' fin="([0-9\-]+)"'
-regex_iso8601 = '([0-9]+)-([0-9]+)-([0-9]+)'
+regex_indent = r'^(\s*)<VALUE '
+regex_fin = r' fin="([0-9\-]+)"'
+regex_iso8601 = r'([0-9]+)-([0-9]+)-([0-9]+)'
 one_day = datetime.timedelta(days=1)
 
 lines_3 = []
@@ -84,7 +84,7 @@ position_code = list(zip(index_code, index_code_end))
 
 
 end_to_remove = []
-regex_deb = ' deb="([0-9\-]+)"'
+regex_deb = r' deb="([0-9\-]+)"'
 
 for code_begining, code_end in position_code:
     deb_list = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,11 +6,11 @@
 
 [flake8]
 hang-closing = true
-ignore       = E128,E251,F403,F405,E501,W503
+ignore       = E128,E251,F403,F405,E501,W503,W504
 
 [pep8]
 hang-closing = true
-ignore       = E128,E251,F403,F405,E501,W503
+ignore       = E128,E251,F403,F405,E501,W503,W504
 in-place     = true
 
 [nosetests]

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,8 @@ api_requirements = [
     ]
 
 dev_requirements = [
-    'autopep8 == 1.4.0',
-    'flake8 >= 3.5.0, < 3.6.0',
-    'pycodestyle >= 2.3.0, < 2.4.0',  # To avoid incompatibility with flake8
+    'autopep8 >= 1.4.0, < 1.5.0',
+    'flake8 >= 3.7.0, < 3.8.0',
     'pytest >= 4.0.0, < 5.0.0',
     'pytest-cov >= 2.0.0, < 3.0.0',
     'openfisca-country-template >= 3.6.0rc0, < 4.0.0',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '26.0.4',
+    version = '26.0.5',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/parameters_fancy_indexing/test_fancy_indexing.py
+++ b/tests/core/parameters_fancy_indexing/test_fancy_indexing.py
@@ -146,7 +146,7 @@ def test_with_bareme():
     try:
         P_3[city_code], [100, 300, 200]
     except NotImplementedError as e:
-        assert_regexp_matches(get_message(e), "'bareme.7501\d' is a 'MarginalRateTaxScale'")
+        assert_regexp_matches(get_message(e), r"'bareme.7501\d' is a 'MarginalRateTaxScale'")
         assert_in("has not been implemented", get_message(e))
         raise
 

--- a/tests/web_api/test_parameters.py
+++ b/tests/web_api/test_parameters.py
@@ -8,7 +8,7 @@ from . import subject
 # /parameters
 
 parameters_response = subject.get('/parameters')
-GITHUB_URL_REGEX = '^https://github\.com/openfisca/country-template/blob/\d+\.\d+\.\d+((.dev|rc)\d+)?/openfisca_country_template/parameters/(.)+\.yaml$'
+GITHUB_URL_REGEX = r'^https://github\.com/openfisca/country-template/blob/\d+\.\d+\.\d+((.dev|rc)\d+)?/openfisca_country_template/parameters/(.)+\.yaml$'
 
 
 def test_return_code():

--- a/tests/web_api/test_variables.py
+++ b/tests/web_api/test_variables.py
@@ -13,7 +13,7 @@ def assert_items_equal(x, y):
 # /variables
 
 variables_response = subject.get('/variables')
-GITHUB_URL_REGEX = '^https://github\.com/openfisca/country-template/blob/\d+\.\d+\.\d+((.dev|rc)\d+)?/openfisca_country_template/variables/(.)+\.py#L\d+-L\d+$'
+GITHUB_URL_REGEX = r'^https://github\.com/openfisca/country-template/blob/\d+\.\d+\.\d+((.dev|rc)\d+)?/openfisca_country_template/variables/(.)+\.py#L\d+-L\d+$'
 
 
 def test_return_code():


### PR DESCRIPTION
#### Technical changes

- Update autopep8 and flake8, which in particular now enforce rules W504 and W605
  - W504 goes against house style, so we add it to ignored rules
  - W605 may seem like an [overreach](https://github.com/PyCQA/pycodestyle/issues/755) but does make sense (additional details in PR description), so we upgrade a few regexes to raw strings

#### Detailed explanation (W605)

in Python strings the character "\" normally introduces an escape sequence, and should be followed by only a few select characters (\n is newline, \t is tab, and there are a few more esoteric ones) - anything else, for instance "\d", is an "illegal escape sequence" and should normally require a double escape (i.e. "\\d").

However, in regular expressions (where "\d" is a common way to say "any digit from 0 to 9") this would be quite burdensome, and Python in fact "looks the other way" when you use an illegal escape sequence, it interprets the characters literally. So you *don't* have to use a double escape in regular expressions, but that's a bit of a hack.

So W605 is in fact the right thing, and preserves the "principle of least surprise", at the cost of an extra syntax: that of "[raw strings](https://stackoverflow.com/questions/2081640/what-exactly-do-u-and-r-string-flags-do-and-what-are-raw-string-literals)" denoted by the string prefix `r`. Like so: `r"\d"` - this is a string containing the characters "\" and "\d". It is exactly the same string as `"\d"`, but that is _explainable_, unlike `"\d"` which should generate an error if the Python parser applied its own specification strictly.