### PR TITLE
Relax rules on allocation to group entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 26.1.0 [#835](https://github.com/openfisca/openfisca-core/pull/835)
+
+- No longer raise an error when a group entity is not specified in a test case, or partially specified.
+  - Instead, each person is by default allocated to a group of which they are the sole member, with the default role in that group.
+
 ### 26.0.6 [#836](https://github.com/openfisca/openfisca-core/pull/836)
 
 - Convert tests that were incompatible with Pytest 4.0+ and reported "xfail" when run with that version

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '26.0.6',
+    version = '26.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_simulation_builder.py
+++ b/tests/core/test_simulation_builder.py
@@ -340,13 +340,21 @@ def test_allocate_person_twice(simulation_builder):
     assert exception.value.error == {'familles': {'famille1': {'parents': 'Alicia has been declared more than once in familles'}}}
 
 
-def test_unallocated_person(simulation_builder, group_entity):
-    with raises(SituationParsingError) as exception:
-        simulation_builder.add_group_entity('persons', ['Alicia', 'Javier', 'Sarah', 'Tom'], group_entity, {
-            'Household_1': {'parents': ['Alicia', 'Javier']},
-            'Household_2': {'parents': ['Tom']},
-            })
-    assert exception.value.error == {'households': "{'Sarah'} have been declared in persons, but are not members of any household. All persons must be allocated to a household."}
+def test_one_person_without_household(simulation_builder):
+    simulation_dict = {'persons': {'Alicia': {}}}
+    simulation = simulation_builder.build_from_dict(tax_benefit_system, simulation_dict)
+    assert simulation.household.count == 1
+
+
+def test_some_person_without_household(simulation_builder):
+    input_yaml = """
+        persons: {'Alicia': {}, 'Bob': {}}
+        household: {'parents': ['Alicia']}
+    """
+    simulation = simulation_builder.build_from_dict(tax_benefit_system, yaml.load(input_yaml))
+    assert simulation.household.count == 2
+    parents_in_households = simulation.household.nb_persons(role = simulation.household.PARENT)
+    assert parents_in_households.tolist() == [1, 1]  # household member default role is first_parent
 
 
 # Test Intégration

--- a/tests/web_api/test_calculate.py
+++ b/tests/web_api/test_calculate.py
@@ -50,8 +50,7 @@ def check_response(data, expected_error_code, path_to_check, content_to_check):
     ('{"persons": {"bob": {"salary": {"invalid period": 2000 }}}}', BAD_REQUEST, 'persons/bob/salary', 'Expected a period',),
     ('{"persons": {"bob": {"salary": {"invalid period": null }}}}', BAD_REQUEST, 'persons/bob/salary', 'Expected a period',),
     ('{"persons": {"bob": {"basic_income": {"2017": 2000 }}}, "households": {"household": {"parents": ["bob"]}}}', BAD_REQUEST, 'persons/bob/basic_income/2017', 'basic_income is only defined for months',),
-    ('{"persons": {"bob": {"salary": {"ETERNITY": 2000 }}}, "households": {"household": {"parents": ["bob"]}}}', BAD_REQUEST, 'persons/bob/salary/ETERNITY', 'salary is only defined for months',),
-    ('{"persons": {"bob": {"birth": {"ETERNITY": "1980-01-01"} }}, "households": {}}', BAD_REQUEST, 'households', 'not members of any household',),
+    ('{"persons": {"bob": {"salary": {"ETERNITY": 2000 }}}, "households": {"household": {"parents": ["bob"]}}}', BAD_REQUEST, 'persons/bob/salary/ETERNITY', 'salary is only defined for months',)
     ])
 def test_responses(test):
     check_response(*test)


### PR DESCRIPTION
Fixes #667 
Supersedes #785 

No longer raise an error when a group entity is not specified in a test case, or partially specified (only a subset of all persons is allocated to a group). Instead, each person is by default allocated to a group of which they are the sole member, with the default role in that group.