### PR TITLE
Convert tests that were incompatible with Pytest 4.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 26.0.6 [#836](https://github.com/openfisca/openfisca-core/pull/836)
+
+- Convert tests that were incompatible with Pytest 4.0+ and reported "xfail" when run with that version
+
 ### 26.0.5 [#829](https://github.com/openfisca/openfisca-core/pull/829)
 
 - Update autopep8 and flake8, which in particular now enforce rules W504 and W605

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '26.0.5',
+    version = '26.0.6',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/parameter_validation/test_parameter_validation.py
+++ b/tests/core/parameter_validation/test_parameter_validation.py
@@ -1,15 +1,12 @@
 # -*- coding: utf-8 -*-
 
 import os
-
 import pytest
-
 from openfisca_core.parameters import load_parameter_file, ParameterNode, ParameterParsingError
 
-
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-
 year = 2016
+
 
 def check(file_name, keywords):
     path = os.path.join(BASE_DIR, file_name) + '.yaml'
@@ -23,23 +20,24 @@ def check(file_name, keywords):
 
 
 @pytest.mark.parametrize("test", [
-        ('indentation', {'Invalid YAML', 'indentation.yaml', 'line 2', 'mapping values are not allowed'}),
-        ('wrong_scale', {'Unexpected property', 'scale[1]', 'treshold'}),
-        ('wrong_value', {'Invalid value', 'wrong_value[2015-12-01]', '1A'}),
-        ('unexpected_key_in_parameter', {'Unexpected property', 'unexpected_key'}),
-        ('wrong_type_in_parameter', {'must be of type object'}),
-        ('wrong_type_in_value_history', {'must be of type object'}),
-        ('unexpected_key_in_value_history', {'must be valid YYYY-MM-DD instants'}),
-        ('unexpected_key_in_value_at_instant', {'Unexpected property', 'unexpected_key'}),
-        ('unexpected_key_in_scale', {'Unexpected property', 'unexpected_key'}),
-        ('wrong_type_in_scale', {'must be of type object'}),
-        ('wrong_type_in_brackets', {'must be of type array'}),
-        ('wrong_type_in_bracket', {'must be of type object'}),
-        ('missing_value', {'missing', 'value'}),
-        ])
+    ('indentation', {'Invalid YAML', 'indentation.yaml', 'line 2', 'mapping values are not allowed'}),
+    ('wrong_scale', {'Unexpected property', 'scale[1]', 'treshold'}),
+    ('wrong_value', {'Invalid value', 'wrong_value[2015-12-01]', '1A'}),
+    ('unexpected_key_in_parameter', {'Unexpected property', 'unexpected_key'}),
+    ('wrong_type_in_parameter', {'must be of type object'}),
+    ('wrong_type_in_value_history', {'must be of type object'}),
+    ('unexpected_key_in_value_history', {'must be valid YYYY-MM-DD instants'}),
+    ('unexpected_key_in_value_at_instant', {'Unexpected property', 'unexpected_key'}),
+    ('unexpected_key_in_scale', {'Unexpected property', 'unexpected_key'}),
+    ('wrong_type_in_scale', {'must be of type object'}),
+    ('wrong_type_in_brackets', {'must be of type array'}),
+    ('wrong_type_in_bracket', {'must be of type object'}),
+    ('missing_value', {'missing', 'value'}),
+    ])
 def test_parsing_errors(test):
     with pytest.raises(ParameterParsingError):
         check(*test)
+
 
 def test_filesystem_hierarchy():
     path = os.path.join(BASE_DIR, 'filesystem_hierarchy')

--- a/tests/core/parameter_validation/test_parameter_validation.py
+++ b/tests/core/parameter_validation/test_parameter_validation.py
@@ -2,7 +2,7 @@
 
 import os
 
-from nose.tools import assert_in, raises
+import pytest
 
 from openfisca_core.parameters import load_parameter_file, ParameterNode, ParameterParsingError
 
@@ -11,8 +11,6 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 year = 2016
 
-
-@raises(ParameterParsingError)
 def check(file_name, keywords):
     path = os.path.join(BASE_DIR, file_name) + '.yaml'
     try:
@@ -20,12 +18,11 @@ def check(file_name, keywords):
     except ParameterParsingError as e:
         content = str(e)
         for keyword in keywords:
-            assert_in(keyword, content)
+            assert keyword in content
         raise
 
 
-def test_parsing_errors():
-    tests = [
+@pytest.mark.parametrize("test", [
         ('indentation', {'Invalid YAML', 'indentation.yaml', 'line 2', 'mapping values are not allowed'}),
         ('wrong_scale', {'Unexpected property', 'scale[1]', 'treshold'}),
         ('wrong_value', {'Invalid value', 'wrong_value[2015-12-01]', '1A'}),
@@ -39,11 +36,10 @@ def test_parsing_errors():
         ('wrong_type_in_brackets', {'must be of type array'}),
         ('wrong_type_in_bracket', {'must be of type object'}),
         ('missing_value', {'missing', 'value'}),
-        ]
-
-    for test in tests:
-        yield (check,) + test
-
+        ])
+def test_parsing_errors(test):
+    with pytest.raises(ParameterParsingError):
+        check(*test)
 
 def test_filesystem_hierarchy():
     path = os.path.join(BASE_DIR, 'filesystem_hierarchy')

--- a/tests/core/test_periods.py
+++ b/tests/core/test_periods.py
@@ -179,15 +179,7 @@ def test_empty_string():
         period('')
 
 
-def test_subperiods():
-
-    def check_subperiods(period, unit, length, first, last):
-        subperiods = period.get_subperiods(unit)
-        assert len(subperiods) == length
-        assert subperiods[0] == first
-        assert subperiods[-1] == last
-
-    tests = [
+@pytest.mark.parametrize("test", [
         (period('year:2014:2'), YEAR, 2, period('2014'), period('2015')),
         (period(2017), MONTH, 12, period('2017-01'), period('2017-12')),
         (period('year:2014:2'), MONTH, 24, period('2014-01'), period('2015-12')),
@@ -195,7 +187,13 @@ def test_subperiods():
         (period(2017), DAY, 365, period('2017-01-01'), period('2017-12-31')),
         (period('year:2014:2'), DAY, 730, period('2014-01-01'), period('2015-12-31')),
         (period('month:2014-03:3'), DAY, 92, period('2014-03-01'), period('2014-05-31')),
-        ]
+        ])
+def test_subperiods(test):
 
-    for test in tests:
-        yield (check_subperiods,) + test
+    def check_subperiods(period, unit, length, first, last):
+        subperiods = period.get_subperiods(unit)
+        assert len(subperiods) == length
+        assert subperiods[0] == first
+        assert subperiods[-1] == last
+
+        check_subperiods(*test)

--- a/tests/core/test_periods.py
+++ b/tests/core/test_periods.py
@@ -180,14 +180,14 @@ def test_empty_string():
 
 
 @pytest.mark.parametrize("test", [
-        (period('year:2014:2'), YEAR, 2, period('2014'), period('2015')),
-        (period(2017), MONTH, 12, period('2017-01'), period('2017-12')),
-        (period('year:2014:2'), MONTH, 24, period('2014-01'), period('2015-12')),
-        (period('month:2014-03:3'), MONTH, 3, period('2014-03'), period('2014-05')),
-        (period(2017), DAY, 365, period('2017-01-01'), period('2017-12-31')),
-        (period('year:2014:2'), DAY, 730, period('2014-01-01'), period('2015-12-31')),
-        (period('month:2014-03:3'), DAY, 92, period('2014-03-01'), period('2014-05-31')),
-        ])
+    (period('year:2014:2'), YEAR, 2, period('2014'), period('2015')),
+    (period(2017), MONTH, 12, period('2017-01'), period('2017-12')),
+    (period('year:2014:2'), MONTH, 24, period('2014-01'), period('2015-12')),
+    (period('month:2014-03:3'), MONTH, 3, period('2014-03'), period('2014-05')),
+    (period(2017), DAY, 365, period('2017-01-01'), period('2017-12-31')),
+    (period('year:2014:2'), DAY, 730, period('2014-01-01'), period('2015-12-31')),
+    (period('month:2014-03:3'), DAY, 92, period('2014-03-01'), period('2014-05-31')),
+    ])
 def test_subperiods(test):
 
     def check_subperiods(period, unit, length, first, last):

--- a/tests/core/test_reforms.py
+++ b/tests/core/test_reforms.py
@@ -137,8 +137,7 @@ def test_update_items():
         value_history.update(period=None, start=start_instant, stop=stop_instant, value=value)
         assert_equal(value_history, expected_items)
 
-    yield (
-        check_update_items,
+    check_update_items (
         'Replace an item by a new item',
         ValuesHistory('dummy_name', {"2013-01-01": {'value': 0.0}, "2014-01-01": {'value': None}}),
         periods.period(2013).start,
@@ -146,8 +145,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2013-01-01": {'value': 1.0}, "2014-01-01": {'value': None}}),
         )
-    yield (
-        check_update_items,
+    check_update_items (
         'Replace an item by a new item in a list of items, the last being open',
         ValuesHistory('dummy_name', {"2014-01-01": {'value': 9.53}, "2015-01-01": {'value': 9.61}, "2016-01-01": {'value': 9.67}}),
         periods.period(2015).start,
@@ -155,8 +153,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2014-01-01": {'value': 9.53}, "2015-01-01": {'value': 1.0}, "2016-01-01": {'value': 9.67}}),
         )
-    yield (
-        check_update_items,
+    check_update_items (
         'Open the stop instant to the future',
         ValuesHistory('dummy_name', {"2013-01-01": {'value': 0.0}, "2014-01-01": {'value': None}}),
         periods.period(2013).start,
@@ -164,8 +161,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2013-01-01": {'value': 1.0}}),
         )
-    yield (
-        check_update_items,
+    check_update_items (
         'Insert a new item in the middle of an existing item',
         ValuesHistory('dummy_name', {"2010-01-01": {'value': 0.0}, "2014-01-01": {'value': None}}),
         periods.period(2011).start,
@@ -173,8 +169,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2010-01-01": {'value': 0.0}, "2011-01-01": {'value': 1.0}, "2012-01-01": {'value': 0.0}, "2014-01-01": {'value': None}}),
         )
-    yield (
-        check_update_items,
+    check_update_items (
         'Insert a new open item coming after the last open item',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2015).start,
@@ -182,8 +177,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}, "2015-01-01": {'value': 1.0}}),
         )
-    yield (
-        check_update_items,
+    check_update_items (
         'Insert a new item starting at the same date than the last open item',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2014).start,
@@ -191,8 +185,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 1.0}, "2015-01-01": {'value': 0.14}}),
         )
-    yield (
-        check_update_items,
+    check_update_items (
         'Insert a new open item starting at the same date than the last open item',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2014).start,
@@ -200,8 +193,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 1.0}}),
         )
-    yield (
-        check_update_items,
+    check_update_items (
         'Insert a new item coming before the first item',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2005).start,
@@ -209,8 +201,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2005-01-01": {'value': 1.0}, "2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         )
-    yield (
-        check_update_items,
+    check_update_items (
         'Insert a new item coming before the first item with a hole',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2003).start,
@@ -218,8 +209,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2003-01-01": {'value': 1.0}, "2004-01-01": {'value': None}, "2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         )
-    yield (
-        check_update_items,
+    check_update_items (
         'Insert a new open item starting before the start date of the first item',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2005).start,
@@ -227,8 +217,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2005-01-01": {'value': 1.0}}),
         )
-    yield (
-        check_update_items,
+    check_update_items (
         'Insert a new open item starting at the same date than the first item',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2006).start,
@@ -239,7 +228,6 @@ def test_update_items():
 
 
 def test_add_variable():
-
     class new_variable(Variable):
         value_type = int
         label = "Nouvelle variable introduite par la réforme"

--- a/tests/core/test_reforms.py
+++ b/tests/core/test_reforms.py
@@ -137,7 +137,7 @@ def test_update_items():
         value_history.update(period=None, start=start_instant, stop=stop_instant, value=value)
         assert_equal(value_history, expected_items)
 
-    check_update_items (
+    check_update_items(
         'Replace an item by a new item',
         ValuesHistory('dummy_name', {"2013-01-01": {'value': 0.0}, "2014-01-01": {'value': None}}),
         periods.period(2013).start,
@@ -145,7 +145,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2013-01-01": {'value': 1.0}, "2014-01-01": {'value': None}}),
         )
-    check_update_items (
+    check_update_items(
         'Replace an item by a new item in a list of items, the last being open',
         ValuesHistory('dummy_name', {"2014-01-01": {'value': 9.53}, "2015-01-01": {'value': 9.61}, "2016-01-01": {'value': 9.67}}),
         periods.period(2015).start,
@@ -153,7 +153,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2014-01-01": {'value': 9.53}, "2015-01-01": {'value': 1.0}, "2016-01-01": {'value': 9.67}}),
         )
-    check_update_items (
+    check_update_items(
         'Open the stop instant to the future',
         ValuesHistory('dummy_name', {"2013-01-01": {'value': 0.0}, "2014-01-01": {'value': None}}),
         periods.period(2013).start,
@@ -161,7 +161,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2013-01-01": {'value': 1.0}}),
         )
-    check_update_items (
+    check_update_items(
         'Insert a new item in the middle of an existing item',
         ValuesHistory('dummy_name', {"2010-01-01": {'value': 0.0}, "2014-01-01": {'value': None}}),
         periods.period(2011).start,
@@ -169,7 +169,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2010-01-01": {'value': 0.0}, "2011-01-01": {'value': 1.0}, "2012-01-01": {'value': 0.0}, "2014-01-01": {'value': None}}),
         )
-    check_update_items (
+    check_update_items(
         'Insert a new open item coming after the last open item',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2015).start,
@@ -177,7 +177,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}, "2015-01-01": {'value': 1.0}}),
         )
-    check_update_items (
+    check_update_items(
         'Insert a new item starting at the same date than the last open item',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2014).start,
@@ -185,7 +185,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 1.0}, "2015-01-01": {'value': 0.14}}),
         )
-    check_update_items (
+    check_update_items(
         'Insert a new open item starting at the same date than the last open item',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2014).start,
@@ -193,7 +193,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 1.0}}),
         )
-    check_update_items (
+    check_update_items(
         'Insert a new item coming before the first item',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2005).start,
@@ -201,7 +201,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2005-01-01": {'value': 1.0}, "2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         )
-    check_update_items (
+    check_update_items(
         'Insert a new item coming before the first item with a hole',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2003).start,
@@ -209,7 +209,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2003-01-01": {'value': 1.0}, "2004-01-01": {'value': None}, "2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         )
-    check_update_items (
+    check_update_items(
         'Insert a new open item starting before the start date of the first item',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2005).start,
@@ -217,7 +217,7 @@ def test_update_items():
         1.0,
         ValuesHistory('dummy_name', {"2005-01-01": {'value': 1.0}}),
         )
-    check_update_items (
+    check_update_items(
         'Insert a new open item starting at the same date than the first item',
         ValuesHistory('dummy_name', {"2006-01-01": {'value': 0.055}, "2014-01-01": {'value': 0.14}}),
         periods.period(2006).start,

--- a/tests/core/test_tracer.py
+++ b/tests/core/test_tracer.py
@@ -53,13 +53,14 @@ def check_tracing_params(accessor, param_key):
     param = accessor(tracingParams)
     assert_near(tracer.trace['A<2015-01>']['parameters'][param_key], param)
 
+
 @pytest.mark.parametrize("test", [
-        (lambda P: P.rate.single.owner.z1, 'rate.single.owner.z1<2015-01-01>'),  # basic case
-        (lambda P: P.rate.single.owner[zone], 'rate.single.owner<2015-01-01>'),  # fancy indexing on leaf
-        (lambda P: P.rate.single[housing_occupancy_status].z1, 'rate.single<2015-01-01>'),  # on a node
-        (lambda P: P.rate.single[housing_occupancy_status][zone], 'rate.single<2015-01-01>'),  # double fancy indexing
-        (lambda P: P.rate[family_status][housing_occupancy_status].z2, 'rate<2015-01-01>'),  # double + node
-        (lambda P: P.rate[family_status][housing_occupancy_status][zone], 'rate<2015-01-01>'),  # triple
-        ])
+    (lambda P: P.rate.single.owner.z1, 'rate.single.owner.z1<2015-01-01>'),  # basic case
+    (lambda P: P.rate.single.owner[zone], 'rate.single.owner<2015-01-01>'),  # fancy indexing on leaf
+    (lambda P: P.rate.single[housing_occupancy_status].z1, 'rate.single<2015-01-01>'),  # on a node
+    (lambda P: P.rate.single[housing_occupancy_status][zone], 'rate.single<2015-01-01>'),  # double fancy indexing
+    (lambda P: P.rate[family_status][housing_occupancy_status].z2, 'rate<2015-01-01>'),  # double + node
+    (lambda P: P.rate[family_status][housing_occupancy_status][zone], 'rate<2015-01-01>'),  # triple
+    ])
 def test_parameters(test):
     check_tracing_params(*test)

--- a/tests/web_api/test_calculate.py
+++ b/tests/web_api/test_calculate.py
@@ -32,27 +32,27 @@ def check_response(data, expected_error_code, path_to_check, content_to_check):
 
 
 @pytest.mark.parametrize("test", [
-        ('{"a" : "x", "b"}', BAD_REQUEST, 'error', 'Invalid JSON'),
-        ('["An", "array"]', BAD_REQUEST, 'error', 'Invalid type'),
-        ('{"persons": {}}', BAD_REQUEST, 'persons', 'At least one person'),
-        ('{"persons": {"bob": {}}, "unknown_entity": {}}', BAD_REQUEST, 'unknown_entity', 'entities are not found',),
-        ('{"persons": {"bob": {}}, "households": {"dupont": {"parents": {}}}}', BAD_REQUEST, 'households/dupont/parents', 'type',),
-        ('{"persons": {"bob": {"unknown_variable": {}}}}', NOT_FOUND, 'persons/bob/unknown_variable', 'You tried to calculate or to set',),
-        ('{"persons": {"bob": {"housing_allowance": {}}}}', BAD_REQUEST, 'persons/bob/housing_allowance', "You tried to compute the variable 'housing_allowance' for the entity 'persons'",),
-        ('{"persons": {"bob": {"salary": 4000 }}}', BAD_REQUEST, 'persons/bob/salary', 'period',),
-        ('{"persons": {"bob": {"salary": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/salary/2017-01', 'expected type number',),
-        ('{"persons": {"bob": {"salary": {"2017-01": {}} }}}', BAD_REQUEST, 'persons/bob/salary/2017-01', 'expected type number',),
-        ('{"persons": {"bob": {"age": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/age/2017-01', 'expected type integer',),
-        ('{"persons": {"bob": {"birth": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/birth/2017-01', 'Can\'t deal with date',),
-        ('{"persons": {"bob": {}}, "households": {"household": {"parents": ["unexpected_person_id"]}}}', BAD_REQUEST, 'households/household/parents', 'has not been declared in persons',),
-        ('{"persons": {"bob": {}}, "households": {"household": {"parents": ["bob", "bob"]}}}', BAD_REQUEST, 'households/household/parents', 'has been declared more than once',),
-        ('{"persons": {"bob": {}}, "households": {"household": {"parents": ["bob", {}]}}}', BAD_REQUEST, 'households/household/parents/1', 'Invalid type',),
-        ('{"persons": {"bob": {"salary": {"invalid period": 2000 }}}}', BAD_REQUEST, 'persons/bob/salary', 'Expected a period',),
-        ('{"persons": {"bob": {"salary": {"invalid period": null }}}}', BAD_REQUEST, 'persons/bob/salary', 'Expected a period',),
-        ('{"persons": {"bob": {"basic_income": {"2017": 2000 }}}, "households": {"household": {"parents": ["bob"]}}}', BAD_REQUEST, 'persons/bob/basic_income/2017', 'basic_income is only defined for months',),
-        ('{"persons": {"bob": {"salary": {"ETERNITY": 2000 }}}, "households": {"household": {"parents": ["bob"]}}}', BAD_REQUEST, 'persons/bob/salary/ETERNITY', 'salary is only defined for months',),
-        ('{"persons": {"bob": {"birth": {"ETERNITY": "1980-01-01"} }}, "households": {}}', BAD_REQUEST, 'households', 'not members of any household',),
-        ])
+    ('{"a" : "x", "b"}', BAD_REQUEST, 'error', 'Invalid JSON'),
+    ('["An", "array"]', BAD_REQUEST, 'error', 'Invalid type'),
+    ('{"persons": {}}', BAD_REQUEST, 'persons', 'At least one person'),
+    ('{"persons": {"bob": {}}, "unknown_entity": {}}', BAD_REQUEST, 'unknown_entity', 'entities are not found',),
+    ('{"persons": {"bob": {}}, "households": {"dupont": {"parents": {}}}}', BAD_REQUEST, 'households/dupont/parents', 'type',),
+    ('{"persons": {"bob": {"unknown_variable": {}}}}', NOT_FOUND, 'persons/bob/unknown_variable', 'You tried to calculate or to set',),
+    ('{"persons": {"bob": {"housing_allowance": {}}}}', BAD_REQUEST, 'persons/bob/housing_allowance', "You tried to compute the variable 'housing_allowance' for the entity 'persons'",),
+    ('{"persons": {"bob": {"salary": 4000 }}}', BAD_REQUEST, 'persons/bob/salary', 'period',),
+    ('{"persons": {"bob": {"salary": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/salary/2017-01', 'expected type number',),
+    ('{"persons": {"bob": {"salary": {"2017-01": {}} }}}', BAD_REQUEST, 'persons/bob/salary/2017-01', 'expected type number',),
+    ('{"persons": {"bob": {"age": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/age/2017-01', 'expected type integer',),
+    ('{"persons": {"bob": {"birth": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/birth/2017-01', 'Can\'t deal with date',),
+    ('{"persons": {"bob": {}}, "households": {"household": {"parents": ["unexpected_person_id"]}}}', BAD_REQUEST, 'households/household/parents', 'has not been declared in persons',),
+    ('{"persons": {"bob": {}}, "households": {"household": {"parents": ["bob", "bob"]}}}', BAD_REQUEST, 'households/household/parents', 'has been declared more than once',),
+    ('{"persons": {"bob": {}}, "households": {"household": {"parents": ["bob", {}]}}}', BAD_REQUEST, 'households/household/parents/1', 'Invalid type',),
+    ('{"persons": {"bob": {"salary": {"invalid period": 2000 }}}}', BAD_REQUEST, 'persons/bob/salary', 'Expected a period',),
+    ('{"persons": {"bob": {"salary": {"invalid period": null }}}}', BAD_REQUEST, 'persons/bob/salary', 'Expected a period',),
+    ('{"persons": {"bob": {"basic_income": {"2017": 2000 }}}, "households": {"household": {"parents": ["bob"]}}}', BAD_REQUEST, 'persons/bob/basic_income/2017', 'basic_income is only defined for months',),
+    ('{"persons": {"bob": {"salary": {"ETERNITY": 2000 }}}, "households": {"household": {"parents": ["bob"]}}}', BAD_REQUEST, 'persons/bob/salary/ETERNITY', 'salary is only defined for months',),
+    ('{"persons": {"bob": {"birth": {"ETERNITY": "1980-01-01"} }}, "households": {}}', BAD_REQUEST, 'households', 'not members of any household',),
+    ])
 def test_responses(test):
     check_response(*test)
 
@@ -181,7 +181,7 @@ def test_enum_wrong_value():
     response_json = json.loads(response.data.decode('utf-8'))
     message = "Possible values are ['owner', 'tenant', 'free_lodger', 'homeless']"
     text = dpath.get(response_json, "households/_/housing_occupancy_status/2017-01")
-    assert message in text        
+    assert message in text
 
 
 def test_encoding_variable_value():
@@ -208,7 +208,7 @@ def test_encoding_variable_value():
     response_json = json.loads(response.data.decode('utf-8'))
     message = "'Locataire ou sous-locataire d‘un logement loué vide non-HLM' is not a known value for 'housing_occupancy_status'. Possible values are "
     text = dpath.get(response_json, 'households/_/housing_occupancy_status/2017-07')
-    assert message in text        
+    assert message in text
 
 
 def test_encoding_entity_name():
@@ -235,7 +235,7 @@ def test_encoding_entity_name():
     if response.status_code != OK:
         message = "'O‘Ryan' is not a valid ASCII value."
         text = response_json['error']
-        assert message in text        
+        assert message in text
 
 
 def test_encoding_period_id():
@@ -277,7 +277,7 @@ def test_encoding_period_id():
     if "Expected a period" not in to_unicode(response.data):
         message = "'à' is not a valid ASCII value."
         text = response_json['error']
-        assert message in text        
+        assert message in text
 
 
 def test_str_variable():

--- a/tests/web_api/test_parameters.py
+++ b/tests/web_api/test_parameters.py
@@ -2,6 +2,7 @@
 
 from http.client import OK, NOT_FOUND
 import json
+import pytest
 from nose.tools import assert_equal, assert_regexp_matches, assert_in
 from . import subject
 
@@ -108,20 +109,18 @@ def check_code(route, code):
     assert_equal(response.status_code, code)
 
 
-def test_routes_robustness():
-    expected_codes = {
-        '/parameters/': OK,
-        '/parameter': NOT_FOUND,
-        '/parameter/': NOT_FOUND,
-        '/parameter/with-ÜNı©ød€': NOT_FOUND,
-        '/parameter/with%20url%20encoding': NOT_FOUND,
-        '/parameter/taxes/income_tax_rate/': OK,
-        '/parameter/taxes/income_tax_rate/too-much-nesting': NOT_FOUND,
-        '/parameter//taxes/income_tax_rate/': NOT_FOUND,
-        }
-
-    for route, code in expected_codes.items():
-        yield check_code, route, code
+@pytest.mark.parametrize("expected_code", [
+    ('/parameters/', OK),
+    ('/parameter', NOT_FOUND),
+    ('/parameter/', NOT_FOUND),
+    ('/parameter/with-ÜNı©ød€', NOT_FOUND),
+    ('/parameter/with%20url%20encoding', NOT_FOUND),
+    ('/parameter/taxes/income_tax_rate/', OK),
+    ('/parameter/taxes/income_tax_rate/too-much-nesting', NOT_FOUND),
+    ('/parameter//taxes/income_tax_rate/', NOT_FOUND),
+    ])
+def test_routes_robustness(expected_code):
+    check_code(*expected_code)
 
 
 def test_parameter_encoding():

--- a/tests/web_api/test_variables.py
+++ b/tests/web_api/test_variables.py
@@ -2,6 +2,7 @@
 
 from http.client import OK, NOT_FOUND
 import json
+import pytest
 from nose.tools import assert_equal, assert_regexp_matches, assert_in, assert_is_none, assert_not_in
 from . import subject
 
@@ -51,18 +52,16 @@ def check_input_variable_value(key, expected_value):
     assert_equal(input_variable[key], expected_value)
 
 
-def test_input_variable_value():
-    expected_values = {
-        'description': 'Birth date',
-        'valueType': 'Date',
-        'defaultValue': '1970-01-01',
-        'definitionPeriod': 'ETERNITY',
-        'entity': 'person',
-        'references': ['https://en.wiktionary.org/wiki/birthdate'],
-        }
-
-    for key, expected_value in expected_values.items():
-        yield check_input_variable_value, key, expected_value
+@pytest.mark.parametrize("expected_values", [
+    ('description', 'Birth date'),
+    ('valueType', 'Date'),
+    ('defaultValue', '1970-01-01'),
+    ('definitionPeriod', 'ETERNITY'),
+    ('entity', 'person'),
+    ('references', ['https://en.wiktionary.org/wiki/birthdate']),
+    ])
+def test_input_variable_value(expected_values):
+    check_input_variable_value(*expected_values)
 
 
 def test_input_variable_github_url():
@@ -81,17 +80,15 @@ def check_variable_value(key, expected_value):
     assert_equal(variable[key], expected_value)
 
 
-def test_variable_value():
-    expected_values = {
-        'description': 'Income tax',
-        'valueType': 'Float',
-        'defaultValue': 0,
-        'definitionPeriod': 'MONTH',
-        'entity': 'person',
-        }
-
-    for key, expected_value in expected_values.items():
-        yield check_variable_value, key, expected_value
+@pytest.mark.parametrize("expected_values", [
+    ('description', 'Income tax'),
+    ('valueType', 'Float'),
+    ('defaultValue', 0),
+    ('definitionPeriod', 'MONTH'),
+    ('entity', 'person'),
+    ])
+def test_variable_value(expected_values):
+    check_variable_value(*expected_values)
 
 
 def test_variable_formula_github_link():


### PR DESCRIPTION
Fixes #834 

### Technical changes

- Convert tests that were incompatible with Pytest 4.0+ and reported "xfail" when run with that version