### PR TITLE
Improve usability of Enum values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# 31.0.1 [#840](https://github.com/openfisca/openfisca-core/pull/840)
+
+- Improve usability of Enum values:
+- Details:
+  - Allow the use of Enum values in comparisons: instead of using `<Enum class>.possible_values` you can simply `import` the Enum class
+  - Accept Enum values via set_input (same result as the previous point)
+
 # 31.0.0 [#813](https://github.com/openfisca/openfisca-core/pull/813)
 
 #### Breaking changes

--- a/openfisca_core/indexed_enums.py
+++ b/openfisca_core/indexed_enums.py
@@ -75,7 +75,7 @@ class EnumArray(np.ndarray):
 
     def __eq__(self, other):
         # When comparing to an item of self.possible_values, use the item index to speed up the comparison
-        if other.__class__ is self.possible_values:
+        if str(other.__class__) == str(self.possible_values):
             return self.view(np.ndarray) == other.index  # use view(np.ndarray) so that the result is a classic ndarray, not an EnumArray
         return self.view(np.ndarray) == other
 

--- a/openfisca_core/indexed_enums.py
+++ b/openfisca_core/indexed_enums.py
@@ -75,7 +75,7 @@ class EnumArray(np.ndarray):
 
     def __eq__(self, other):
         # When comparing to an item of self.possible_values, use the item index to speed up the comparison
-        if str(other.__class__) == str(self.possible_values):
+        if other.__class__.__name__ is self.possible_values.__name__:
             return self.view(np.ndarray) == other.index  # use view(np.ndarray) so that the result is a classic ndarray, not an EnumArray
         return self.view(np.ndarray) == other
 

--- a/openfisca_core/indexed_enums.py
+++ b/openfisca_core/indexed_enums.py
@@ -51,7 +51,7 @@ class Enum(BaseEnum):
             array = np.select([array == item.name for item in cls], [item.index for item in cls]).astype(ENUM_ARRAY_DTYPE)
         elif array.dtype.kind == 'O':  # Enum items arrays
             # Ensure we are comparing the comparable. The problem this fixes:
-            #  On entering "cls" this method will generally come from variable.possible_values,
+            #  On entering this method "cls" will generally come from variable.possible_values,
             #  while the array values may come from directly importing a module containing an Enum class.
             #  However, variables (and hence their possible_values) are loaded by a call to load_module,
             #  which gives them a different identity from the ones imported in the usual way.

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -141,6 +141,8 @@ class Simulation(object):
             if array is None:
                 array = holder.default_array()
 
+            array = self._cast_formula_result(array, variable)
+
             holder.put_in_cache(array, period)
         except SpiralError:
             array = holder.default_array()
@@ -248,7 +250,7 @@ class Simulation(object):
             array = formula(entity, period, parameters_at)
 
         self._check_formula_result(array, variable, entity, period)
-        return self._cast_formula_result(array, variable)
+        return array
 
     def _check_period_consistency(self, period, variable):
         """

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '31.0.0',
+    version = '31.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -5,6 +5,7 @@ import pytest
 
 import openfisca_country_template.situation_examples
 from openfisca_core.simulation_builder import SimulationBuilder
+from openfisca_country_template.variables.housing import HousingOccupancyStatus
 from openfisca_core.periods import period as make_period, ETERNITY
 from openfisca_core.tools import assert_near
 from openfisca_core.memory_config import MemoryConfig
@@ -26,7 +27,6 @@ def couple():
 
 
 period = make_period('2017-12')
-HousingOccupancyStatus = tax_benefit_system.get_variable('housing_occupancy_status').possible_values
 
 
 def test_set_input_enum_string(couple):


### PR DESCRIPTION
Allow the use of Enum values in comparisons, working around our abuse of the Python module system for TaxBenefitSystem loading.

Tested by updating `test_holders.py` to import HousingOccupancyStatus instead of getting `possible_values`. (Also tested, outside of CI, against the YAML test in [this branch](https://github.com/openfisca/openfisca-france/compare/double-import-error) of France.)