### PR TITLE
Remove simulation_json argument to Simulation constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+# 29.0.0 [#843](https://github.com/openfisca/openfisca-core/pull/843)
+
+#### Breaking changes
+
+- Remove argument `simulation_json` of `Simulation` constructor, which was deprecated as of Core 25
+- Remove keyword arguments from Simulation constructor, which should be called only from SimulationBuilder; introduce a property for `trace`
+- Remove `period` attribute of Simulation
+
+#### Migration notes
+
+- As of Core 25, the preferred way of constructing new Simulation instances is via SimulationBuilder, any remaining uses of scenarios should be migrated to that API first.
+- Any period attribute of the Simulation was coming from the simulation data (test case or JSON structure), use that instead of the attribute in the Simulation instance.
+- Any keyword arguments of Simulation that you were using (or passing to Simulation-constructing methods) can now be accessed directly or as properties, `trace` being the most widely used. Example below:
+
+**Before**
+
+```Python
+simulation = SimulationBuilder().build_from_entities(tax_benefit_system, input_data, trace = True)
+```
+
+**After**
+
+```Python
+simulation = SimulationBuilder().build_from_entities(tax_benefit_system, input_data)
+simulation.trace = True
+```
+
 ### 28.0.1 [#845](https://github.com/openfisca/openfisca-core/pull/845)
 
 - Consistently use the safe approach to YAML loading, fixing [this deprecation warning](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation) introduced in PyYAML 5.1

--- a/openfisca_core/simulation_builder.py
+++ b/openfisca_core/simulation_builder.py
@@ -70,9 +70,7 @@ class SimulationBuilder(object):
         """
         input_dict = deepcopy(input_dict)
 
-        simulation = kwargs.pop('simulation', None)  # Only for backward compatibility with previous Simulation constructor
-        if simulation is None:
-            simulation = Simulation(tax_benefit_system, **kwargs)
+        simulation = Simulation(tax_benefit_system, **kwargs)
 
         # Register variables so get_variable_entity can find them
         for (variable_name, variable) in tax_benefit_system.variables.items():

--- a/openfisca_core/simulation_builder.py
+++ b/openfisca_core/simulation_builder.py
@@ -69,7 +69,7 @@ class SimulationBuilder(object):
         """
         input_dict = deepcopy(input_dict)
 
-        simulation = Simulation(tax_benefit_system)
+        simulation = Simulation(tax_benefit_system, tax_benefit_system.instantiate_entities())
 
         # Register variables so get_variable_entity can find them
         for (variable_name, variable) in tax_benefit_system.variables.items():
@@ -159,7 +159,7 @@ class SimulationBuilder(object):
                 - Every person has, in each entity, the first role
         """
 
-        simulation = Simulation(tax_benefit_system)
+        simulation = Simulation(tax_benefit_system, tax_benefit_system.instantiate_entities())
         for entity in simulation.entities.values():
             entity.count = count
             entity.ids = np.array(range(count))

--- a/openfisca_core/simulation_builder.py
+++ b/openfisca_core/simulation_builder.py
@@ -40,24 +40,23 @@ class SimulationBuilder(object):
         self.axes_memberships: Dict[Entity.plural, List[int]] = {}
         self.axes_roles: Dict[Entity.plural, List[int]] = {}
 
-    def build_from_dict(self, tax_benefit_system, input_dict, **kwargs):
+    def build_from_dict(self, tax_benefit_system, input_dict):
         """
             Build a simulation from ``input_dict``
 
             This method uses :any:`build_from_entities` if entities are fully specified, or :any:`build_from_variables` if not.
 
             :param dict input_dict: A dict represeting the input of the simulation
-            :param kwargs: Same keywords argument than the :any:`Simulation` constructor
             :return: A :any:`Simulation`
         """
 
         input_dict = self.explicit_singular_entities(tax_benefit_system, input_dict)
         if any(key in tax_benefit_system.entities_plural() for key in input_dict.keys()):
-            return self.build_from_entities(tax_benefit_system, input_dict, **kwargs)
+            return self.build_from_entities(tax_benefit_system, input_dict)
         else:
-            return self.build_from_variables(tax_benefit_system, input_dict, **kwargs)
+            return self.build_from_variables(tax_benefit_system, input_dict)
 
-    def build_from_entities(self, tax_benefit_system, input_dict, **kwargs):
+    def build_from_entities(self, tax_benefit_system, input_dict):
         """
             Build a simulation from a Python dict ``input_dict`` fully specifying entities.
 
@@ -70,7 +69,7 @@ class SimulationBuilder(object):
         """
         input_dict = deepcopy(input_dict)
 
-        simulation = Simulation(tax_benefit_system, **kwargs)
+        simulation = Simulation(tax_benefit_system)
 
         # Register variables so get_variable_entity can find them
         for (variable_name, variable) in tax_benefit_system.variables.items():
@@ -127,7 +126,7 @@ class SimulationBuilder(object):
 
         return simulation
 
-    def build_from_variables(self, tax_benefit_system, input_dict, **kwargs):
+    def build_from_variables(self, tax_benefit_system, input_dict):
         """
             Build a simulation from a Python dict ``input_dict`` describing variables values without expliciting entities.
 
@@ -140,7 +139,7 @@ class SimulationBuilder(object):
                 )
         """
         count = _get_person_count(input_dict)
-        simulation = self.build_default_simulation(tax_benefit_system, count, **kwargs)
+        simulation = self.build_default_simulation(tax_benefit_system, count)
         for variable, value in input_dict.items():
             if not isinstance(value, dict):
                 if self.default_period is None:
@@ -152,7 +151,7 @@ class SimulationBuilder(object):
                     simulation.set_input(variable, period_str, dated_value)
         return simulation
 
-    def build_default_simulation(self, tax_benefit_system, count = 1, **kwargs):
+    def build_default_simulation(self, tax_benefit_system, count = 1):
         """
             Build a simulation where:
                 - There are ``count`` persons
@@ -160,7 +159,7 @@ class SimulationBuilder(object):
                 - Every person has, in each entity, the first role
         """
 
-        simulation = Simulation(tax_benefit_system, **kwargs)
+        simulation = Simulation(tax_benefit_system)
         for entity in simulation.entities.values():
             entity.count = count
             entity.ids = np.array(range(count))

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -118,6 +118,7 @@ class Simulation(object):
 
         # First look for a value already cached
         cached_array = holder.get_array(period)
+        print("cached", variable_name, period, cached_array)
         if cached_array is not None:
             if self.trace:
                 self.tracer.record_calculation_end(variable.name, period, cached_array, **parameters)
@@ -221,6 +222,7 @@ class Simulation(object):
         """
 
         formula = variable.get_formula(period)
+        print("formula", variable.name, period, formula)
         if formula is None:
             return None
 

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -31,22 +31,10 @@ class Simulation(object):
     """
         Represents a simulation, and handles the calculation logic
     """
-    debug = False
-    period = None
-    tax_benefit_system = None
-
-    # ----- Simulation construction ----- #
-
     def __init__(
             self,
             tax_benefit_system,
-            entities_instances = None,
-            simulation_json = None,
-            debug = False,
-            period = None,
-            trace = False,
-            opt_out_cache = False,
-            memory_config = None,
+            entities_instances = None
             ):
         """
             Create an empty simulation
@@ -64,21 +52,17 @@ class Simulation(object):
         self.link_to_entities_instances()
         self.create_shortcuts()
 
-        if period:
-            assert isinstance(period, periods.Period)
-        self.period = period
-
         # To keep track of the values (formulas and periods) being calculated to detect circular definitions.
         # See use in formulas.py.
         # The data structure of requested_periods_by_variable_name is: {variable_name: [period1, period2]}
         self.requested_periods_by_variable_name = {}
         self.max_nb_cycles = None
 
-        self.debug = debug
-        self.trace = trace or self.debug
-        self.opt_out_cache = opt_out_cache
+        self.debug = False
+        self.trace = False
+        self.opt_out_cache = False
 
-        self.memory_config = memory_config
+        self.memory_config = None
         self._data_storage_dir = None
 
     @property

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -4,7 +4,6 @@
 from os import linesep
 import tempfile
 import logging
-import warnings
 
 import numpy as np
 
@@ -35,7 +34,6 @@ class Simulation(object):
     debug = False
     period = None
     tax_benefit_system = None
-    trace = False
 
     # ----- Simulation construction ----- #
 
@@ -78,24 +76,22 @@ class Simulation(object):
 
         self.debug = debug
         self.trace = trace or self.debug
-        if self.trace:
-            self.tracer = Tracer()
-        else:
-            self.tracer = None
         self.opt_out_cache = opt_out_cache
 
         self.memory_config = memory_config
         self._data_storage_dir = None
 
-        if simulation_json is not None:
-            warnings.warn(' '.join([
-                "The 'simulation_json' argument of the Simulation is deprecated since version 25.0, and will be removed in the future.",
-                "The proper way to init a simulation from a JSON-like dict is to use SimulationBuilder.build_from_entities. See <https://openfisca.org/doc/openfisca-python-api/simulation_builder.html#openfisca_core.simulation_builder.SimulationBuilder.build_from_dict>"
-                ]),
-                Warning
-                )
-            from openfisca_core.simulation_builder import SimulationBuilder
-            SimulationBuilder().build_from_entities(self.tax_benefit_system, simulation_json, simulation = self)
+    @property
+    def trace(self):
+        return self._trace
+
+    @trace.setter
+    def trace(self, trace):
+        self._trace = trace
+        if trace:
+            self.tracer = Tracer()
+        else:
+            self.tracer = None
 
     def link_to_entities_instances(self):
         for key, entity_instance in self.entities.items():
@@ -483,7 +479,6 @@ class Simulation(object):
         self.get_holder(variable_name).set_input(period, value)
 
     def get_variable_entity(self, variable_name):
-
         variable = self.tax_benefit_system.get_variable(variable_name, check_existence = True)
         return self.get_entity(variable.entity)
 

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -37,17 +37,14 @@ class Simulation(object):
             entities_instances = None
             ):
         """
-            Create an empty simulation
-
-            To fill the simulation with input data, you can use the :any:`SimulationBuilder` or proceed manually.
+            This constructor is reserved for internal use; see :any:`SimulationBuilder`,
+            which is the preferred way to obtain a Simulation initialized with a consistent
+            set of Entities.
         """
         self.tax_benefit_system = tax_benefit_system
         assert tax_benefit_system is not None
 
-        if entities_instances is not None:
-            self.entities = entities_instances
-        else:
-            self.entities = tax_benefit_system.instantiate_entities()
+        self.entities = entities_instances
         self.persons = self.entities[tax_benefit_system.person_entity.key]
         self.link_to_entities_instances()
         self.create_shortcuts()

--- a/openfisca_core/taxbenefitsystems.py
+++ b/openfisca_core/taxbenefitsystems.py
@@ -120,7 +120,6 @@ class TaxBenefitSystem(object):
                 else:
                     builder.set_default_period(self.period)
                     simulation = builder.build_from_entities(tax_benefit_system, self.dict)
-                    simulation.period = periods.period(self.period)
 
                 simulation.debug = debug
                 simulation.opt_out_cache = opt_out_cache

--- a/openfisca_core/tools/simulation_dumper.py
+++ b/openfisca_core/tools/simulation_dumper.py
@@ -39,7 +39,7 @@ def restore_simulation(directory, tax_benefit_system, **kwargs):
     """
         Restore simulation from directory
     """
-    simulation = Simulation(tax_benefit_system, **kwargs)
+    simulation = Simulation(tax_benefit_system, tax_benefit_system.instantiate_entities())
 
     entities_dump_dir = os.path.join(directory, "__entities__")
     for entity in simulation.entities.values():

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -227,7 +227,8 @@ def _parse_test(tax_benefit_system, test, options, yaml_path):
         period = test.get('period')
         verbose = options.get('verbose')
         builder.set_default_period(period)
-        simulation = builder.build_from_dict(current_tax_benefit_system, input, trace = verbose)
+        simulation = builder.build_from_dict(current_tax_benefit_system, input)
+        simulation.trace = verbose
     except Exception:
         raise ValueError("Unexpected error while parsing {}".format(test['file_path']))
     except SituationParsingError as error:

--- a/openfisca_web_api/handlers.py
+++ b/openfisca_web_api/handlers.py
@@ -41,7 +41,8 @@ def calculate(tax_benefit_system, input_data):
 
 
 def trace(tax_benefit_system, input_data):
-    simulation = SimulationBuilder().build_from_entities(tax_benefit_system, input_data, trace = True)
+    simulation = SimulationBuilder().build_from_entities(tax_benefit_system, input_data)
+    simulation.trace = True
 
     requested_computations = dpath.util.search(input_data, '*/*/*/*', afilter = lambda t: t is None, yielded = True)
     for computation in requested_computations:

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '28.0.1',
+    version = '29.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_calculate_output.py
+++ b/tests/core/test_calculate_output.py
@@ -1,12 +1,17 @@
-from nose.tools import raises
-
 from openfisca_core.model_api import *  # noqa analysis:ignore
-from openfisca_core.simulations import Simulation
+from openfisca_core.simulation_builder import SimulationBuilder
 from openfisca_core.tools import assert_near
 
 from openfisca_country_template import CountryTaxBenefitSystem
 from openfisca_country_template.entities import *  # noqa analysis:ignore
 from openfisca_country_template.situation_examples import single
+
+from pytest import fixture, raises
+
+
+@fixture
+def simulation():
+    return SimulationBuilder().build_from_entities(tax_benefit_system, single)
 
 
 class simple_variable(Variable):
@@ -37,21 +42,18 @@ tax_benefit_system.add_variables(
     )
 
 
-@raises(ValueError)
-def test_calculate_output_default():
-    simulation = Simulation(tax_benefit_system = tax_benefit_system, simulation_json = single)
-    simulation.calculate_output('simple_variable', 2017)
+def test_calculate_output_default(simulation):
+    with raises(ValueError):
+        simulation.calculate_output('simple_variable', 2017)
 
 
-def test_calculate_output_add():
-    simulation = Simulation(tax_benefit_system = tax_benefit_system, simulation_json = single)
+def test_calculate_output_add(simulation):
     simulation.set_input('variable_with_calculate_output_add', '2017-01', [10])
     simulation.set_input('variable_with_calculate_output_add', '2017-05', [20])
     simulation.set_input('variable_with_calculate_output_add', '2017-12', [70])
     assert_near(simulation.calculate_output('variable_with_calculate_output_add', 2017), 100)
 
 
-def test_calculate_output_divide():
-    simulation = Simulation(tax_benefit_system = tax_benefit_system, simulation_json = single)
+def test_calculate_output_divide(simulation):
     simulation.set_input('variable_with_calculate_output_divide', 2017, [12000])
     assert_near(simulation.calculate_output('variable_with_calculate_output_divide', '2017-06'), 1000)

--- a/tests/core/test_dump_restore.py
+++ b/tests/core/test_dump_restore.py
@@ -6,7 +6,7 @@ import tempfile
 
 from numpy.testing import assert_array_equal
 
-from openfisca_core.simulations import Simulation
+from openfisca_core.simulation_builder import SimulationBuilder
 from openfisca_country_template.situation_examples import couple
 from openfisca_core.tools.simulation_dumper import dump_simulation, restore_simulation
 
@@ -15,7 +15,7 @@ from .test_countries import tax_benefit_system
 
 def test_dump():
     directory = tempfile.mkdtemp(prefix = "openfisca_")
-    simulation = Simulation(tax_benefit_system = tax_benefit_system, simulation_json = couple)
+    simulation = SimulationBuilder().build_from_entities(tax_benefit_system, couple)
     calculated_value = simulation.calculate('disposable_income', '2018-01')
     dump_simulation(simulation, directory)
 

--- a/tests/core/test_formulas.py
+++ b/tests/core/test_formulas.py
@@ -4,10 +4,13 @@
 import numpy as np
 
 from openfisca_core.periods import MONTH
+from openfisca_core.simulation_builder import SimulationBuilder
 from openfisca_core.variables import Variable
 from openfisca_core.formula_helpers import switch
 from openfisca_country_template import CountryTaxBenefitSystem
 from openfisca_country_template.entities import Person
+
+from pytest import fixture
 
 
 class choice(Variable):
@@ -49,30 +52,33 @@ class uses_switch(Variable):
 # TaxBenefitSystem instance declared after formulas
 tax_benefit_system = CountryTaxBenefitSystem()
 tax_benefit_system.add_variables(choice, uses_multiplication, uses_switch)
-month = '2013-01'
-scenario = tax_benefit_system.new_scenario().init_from_attributes(
-    period = month,
-    input_variables = {
-        # 'choice': [1, 1, 1, 2],
-        'choice': np.random.randint(2, size = 1000) + 1,
-        },
-    )
 
 
-def test_switch():
-    simulation = scenario.new_simulation(debug = True)
+@fixture
+def month():
+    return '2013-01'
+
+
+@fixture
+def simulation(month):
+    builder = SimulationBuilder()
+    builder.default_period = month
+    simulation = builder.build_from_variables(tax_benefit_system, {'choice': np.random.randint(2, size = 1000) + 1})
+    simulation.debug = True
+    return simulation
+
+
+def test_switch(simulation, month):
     uses_switch = simulation.calculate('uses_switch', period = month)
     assert isinstance(uses_switch, np.ndarray)
 
 
-def test_multiplication():
-    simulation = scenario.new_simulation(debug = True)
+def test_multiplication(simulation, month):
     uses_multiplication = simulation.calculate('uses_multiplication', period = month)
     assert isinstance(uses_multiplication, np.ndarray)
 
 
-def test_compare_multiplication_and_switch():
-    simulation = scenario.new_simulation(debug = True)
+def test_compare_multiplication_and_switch(simulation, month):
     uses_multiplication = simulation.calculate('uses_multiplication', period = month)
     uses_switch = simulation.calculate('uses_switch', period = month)
     assert np.all(uses_switch == uses_multiplication)

--- a/tests/core/test_simulation_builder.py
+++ b/tests/core/test_simulation_builder.py
@@ -281,7 +281,7 @@ def test_canonicalize_period_keys(simulation_builder, persons):
 
 
 def test_finalize_group_entity(simulation_builder):
-    simulation = Simulation(tax_benefit_system)
+    simulation = Simulation(tax_benefit_system, tax_benefit_system.instantiate_entities())
     simulation_builder.add_group_entity('persons', ['Alicia', 'Javier', 'Sarah', 'Tom'], simulation.household, {
         'Household_1': {'parents': ['Alicia', 'Javier']},
         'Household_2': {'parents': ['Tom'], 'children': ['Sarah']},

--- a/tests/core/test_simulations.py
+++ b/tests/core/test_simulations.py
@@ -1,18 +1,16 @@
 # -*- coding: utf-8 -*-
 
 
-from openfisca_core.simulations import Simulation
+from openfisca_core.simulation_builder import SimulationBuilder
 
 from openfisca_country_template.situation_examples import single
 
 from .test_countries import tax_benefit_system
 
 
-scenario = tax_benefit_system.new_scenario().init_from_attributes(period = '2017-01')
-
-
 def test_calculate_with_trace():
-    simulation = scenario.new_simulation(trace = True)
+    simulation = SimulationBuilder().build_default_simulation(tax_benefit_system)
+    simulation.trace = True
     simulation.calculate('income_tax', '2017-01')
 
     salary_trace = simulation.tracer.trace['salary<2017-01>']
@@ -30,23 +28,22 @@ def test_calculate_with_trace():
 
 
 def test_get_entity_not_found():
-    simulation = scenario.new_simulation(trace = True)
+    simulation = SimulationBuilder().build_default_simulation(tax_benefit_system)
     assert simulation.get_entity(plural = "no_such_entities") is None
 
 
 def test_clone():
-    simulation = Simulation(
-        tax_benefit_system = tax_benefit_system,
-        simulation_json = {
-            "persons": {
-                "bill": {"salary": {"2017-01": 3000}},
-                },
-            "households": {
-                "household": {
-                    "parents": ["bill"]
+    simulation = SimulationBuilder().build_from_entities(tax_benefit_system,
+            {
+                "persons": {
+                    "bill": {"salary": {"2017-01": 3000}},
+                    },
+                "households": {
+                    "household": {
+                        "parents": ["bill"]
+                        }
                     }
-                }
-            })
+                })
 
     simulation_clone = simulation.clone()
     assert simulation != simulation_clone
@@ -65,7 +62,7 @@ def test_clone():
 
 
 def test_get_memory_usage():
-    simulation = Simulation(tax_benefit_system = tax_benefit_system, simulation_json = single)
+    simulation = SimulationBuilder().build_from_entities(tax_benefit_system, single)
     simulation.calculate('disposable_income', '2017-01')
     memory_usage = simulation.get_memory_usage(variables = ['salary'])
     assert(memory_usage['total_nb_bytes'] > 0)

--- a/tests/core/test_variables.py
+++ b/tests/core/test_variables.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import datetime
-from nose.tools import raises
 
 from openfisca_core.model_api import Variable
 from openfisca_core.periods import MONTH, ETERNITY
@@ -12,7 +11,7 @@ import openfisca_country_template as country_template
 import openfisca_country_template.situation_examples
 from openfisca_country_template.entities import Person
 
-from pytest import fixture
+from pytest import fixture, raises, mark
 
 # Check which date is applied whether it comes from Variable attribute (end)
 # or formula(s) dates.
@@ -28,12 +27,9 @@ def couple():
     return SimulationBuilder().build_from_entities(tax_benefit_system, openfisca_country_template.situation_examples.couple)
 
 
-def new_simulation(tax_benefit_system, month):
-    return tax_benefit_system.new_scenario().init_from_attributes(
-        period = month,
-        input_variables = dict(
-            ),
-        ).new_simulation()
+@fixture
+def simulation():
+    return SimulationBuilder().build_from_entities(tax_benefit_system, openfisca_country_template.situation_examples.single)
 
 
 def vectorize(individu, number):
@@ -117,10 +113,9 @@ def test_variable__end_attribute():
     assert variable.end == datetime.date(1989, 12, 31)
 
 
-def test_variable__end_attribute_set_input():
+def test_variable__end_attribute_set_input(simulation):
     month_before_end = '1989-01'
     month_after_end = '1990-01'
-    simulation = new_simulation(tax_benefit_system, month_before_end)
     simulation.set_input('variable__end_attribute', month_before_end, 10)
     simulation.set_input('variable__end_attribute', month_after_end, 10)
     assert simulation.calculate('variable__end_attribute', month_before_end) == 10
@@ -148,17 +143,14 @@ def test_formulas_attributes_single_formula():
     assert formulas['0001-01-01'] is not None
 
 
-def test_call__end_attribute__one_simple_formula():
+def test_call__end_attribute__one_simple_formula(simulation):
     month = '1979-12'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('end_attribute__one_simple_formula', month) == 100
 
     month = '1989-12'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('end_attribute__one_simple_formula', month) == 100
 
     month = '1990-01'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('end_attribute__one_simple_formula', month) == 0
 
 
@@ -205,17 +197,14 @@ class no_end_attribute__one_formula__start(Variable):
 tax_benefit_system.add_variable(no_end_attribute__one_formula__start)
 
 
-def test_call__no_end_attribute__one_formula__start():
+def test_call__no_end_attribute__one_formula__start(simulation):
     month = '1999-12'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('no_end_attribute__one_formula__start', month) == 0
 
     month = '2000-05'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('no_end_attribute__one_formula__start', month) == 100
 
     month = '2020-01'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('no_end_attribute__one_formula__start', month) == 100
 
 
@@ -240,17 +229,28 @@ class no_end_attribute__one_formula__eternity(Variable):
 tax_benefit_system.add_variable(no_end_attribute__one_formula__eternity)
 
 
-def test_call__no_end_attribute__one_formula__eternity():
+@mark.xfail()
+def test_call__no_end_attribute__one_formula__eternity(simulation):
     month = '1999-12'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('no_end_attribute__one_formula__eternity', month) == 0
 
+    # This fails because a definition period of "ETERNITY" caches for all periods
     month = '2000-01'
-    simulation = new_simulation(tax_benefit_system, month)
+    assert simulation.calculate('no_end_attribute__one_formula__eternity', month) == 100
+
+
+def test_call__no_end_attribute__one_formula__eternity_before(simulation):
+    month = '1999-12'
+    assert simulation.calculate('no_end_attribute__one_formula__eternity', month) == 0
+
+
+def test_call__no_end_attribute__one_formula__eternity_after(simulation):
+    month = '2000-01'
     assert simulation.calculate('no_end_attribute__one_formula__eternity', month) == 100
 
 
 # formula, different start formats
+
 
 class no_end_attribute__formulas__start_formats(Variable):
     value_type = int
@@ -288,21 +288,17 @@ def test_get_formulas():
     assert variable.get_formula('2010-01-01') == formula_2010
 
 
-def test_call__no_end_attribute__formulas__start_formats():
+def test_call__no_end_attribute__formulas__start_formats(simulation):
     month = '1999-12'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('no_end_attribute__formulas__start_formats', month) == 0
 
     month = '2000-01'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('no_end_attribute__formulas__start_formats', month) == 100
 
     month = '2009-12'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('no_end_attribute__formulas__start_formats', month) == 100
 
     month = '2010-01'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('no_end_attribute__formulas__start_formats', month) == 200
 
 
@@ -344,13 +340,11 @@ class no_attribute__formulas__different_names__no_overlap(Variable):
 tax_benefit_system.add_variable(no_attribute__formulas__different_names__no_overlap)
 
 
-def test_call__no_attribute__formulas__different_names__no_overlap():
+def test_call__no_attribute__formulas__different_names__no_overlap(simulation):
     month = '2009-12'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('no_attribute__formulas__different_names__no_overlap', month) == 100
 
     month = '2015-05'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('no_attribute__formulas__different_names__no_overlap', month) == 200
 
 
@@ -373,17 +367,14 @@ class end_attribute__one_formula__start(Variable):
 tax_benefit_system.add_variable(end_attribute__one_formula__start)
 
 
-def test_call__end_attribute__one_formula__start():
+def test_call__end_attribute__one_formula__start(simulation):
     month = '1980-01'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('end_attribute__one_formula__start', month) == 0
 
     month = '2000-01'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('end_attribute__one_formula__start', month) == 100
 
     month = '2002-01'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('end_attribute__one_formula__start', month) == 0
 
 
@@ -420,17 +411,14 @@ class end_attribute_restrictive__one_formula(Variable):
 tax_benefit_system.add_variable(end_attribute_restrictive__one_formula)
 
 
-def test_call__end_attribute_restrictive__one_formula():
+def test_call__end_attribute_restrictive__one_formula(simulation):
     month = '2000-12'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('end_attribute_restrictive__one_formula', month) == 0
 
     month = '2001-01'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('end_attribute_restrictive__one_formula', month) == 100
 
     month = '2000-05'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('end_attribute_restrictive__one_formula', month) == 0
 
 
@@ -456,22 +444,18 @@ class end_attribute__formulas__different_names(Variable):
 tax_benefit_system.add_variable(end_attribute__formulas__different_names)
 
 
-def test_call__end_attribute__formulas__different_names():
+def test_call__end_attribute__formulas__different_names(simulation):
     month = '2000-01'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('end_attribute__formulas__different_names', month) == 100
 
     month = '2005-01'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('end_attribute__formulas__different_names', month) == 200
 
     month = '2010-12'
-    simulation = new_simulation(tax_benefit_system, month)
     assert simulation.calculate('end_attribute__formulas__different_names', month) == 300
 
 
-def test_get_formula(couple):
-    simulation = couple
+def test_get_formula(simulation):
     person = simulation.person
     disposable_income_formula = tax_benefit_system.get_variable('disposable_income').get_formula()
     disposable_income = person('disposable_income', '2017-01')
@@ -480,7 +464,6 @@ def test_get_formula(couple):
     assert_near(disposable_income, disposable_income_2)
 
 
-@raises(ValueError)
 def test_unexpected_attr():
     class variable_with_strange_attr(Variable):
         value_type = int
@@ -488,4 +471,5 @@ def test_unexpected_attr():
         definition_period = MONTH
         unexpected = '???'
 
-    tax_benefit_system.add_variable(variable_with_strange_attr)
+    with raises(ValueError):
+        tax_benefit_system.add_variable(variable_with_strange_attr)

--- a/tests/core/test_variables.py
+++ b/tests/core/test_variables.py
@@ -5,12 +5,14 @@ from nose.tools import raises
 
 from openfisca_core.model_api import Variable
 from openfisca_core.periods import MONTH, ETERNITY
-from openfisca_core.simulations import Simulation
+from openfisca_core.simulation_builder import SimulationBuilder
 from openfisca_core.tools import assert_near
 
 import openfisca_country_template as country_template
-from openfisca_country_template.situation_examples import couple
+import openfisca_country_template.situation_examples
 from openfisca_country_template.entities import Person
+
+from pytest import fixture
 
 # Check which date is applied whether it comes from Variable attribute (end)
 # or formula(s) dates.
@@ -20,6 +22,10 @@ tax_benefit_system = country_template.CountryTaxBenefitSystem()
 
 
 # HELPERS
+
+@fixture
+def couple():
+    return SimulationBuilder().build_from_entities(tax_benefit_system, openfisca_country_template.situation_examples.couple)
 
 
 def new_simulation(tax_benefit_system, month):
@@ -464,10 +470,10 @@ def test_call__end_attribute__formulas__different_names():
     assert simulation.calculate('end_attribute__formulas__different_names', month) == 300
 
 
-def test_get_formula():
-    simulation = Simulation(tax_benefit_system = tax_benefit_system, simulation_json = couple)
-    disposable_income_formula = tax_benefit_system.get_variable('disposable_income').get_formula()
+def test_get_formula(couple):
+    simulation = couple
     person = simulation.person
+    disposable_income_formula = tax_benefit_system.get_variable('disposable_income').get_formula()
     disposable_income = person('disposable_income', '2017-01')
     disposable_income_2 = disposable_income_formula(person, '2017-01', None)  # No need for parameters here
 


### PR DESCRIPTION
#### Breaking changes

- Remove argument `simulation_json` of `Simulation` constructor, which was deprecated as of Core 25
- Remove keyword arguments from Simulation constructor, which should be called only from SimulationBuilder; introduce a property for `trace`
- Remove `period` attribute of Simulation

#### Migration notes

- As of Core 25, the preferred way of constructing new Simulation instances is via SimulationBuilder, any remaining uses of scenarios should be migrated to that API first.
- Any period attribute of the Simulation was coming from the simulation data (test case or JSON structure), use that instead of the attribute in the Simulation instance.
- Any keyword arguments of Simulation that you were using (or passing to Simulation-constructing methods) can now be accessed directly or as properties, `trace` being the most widely used. Example below:

**Before**

```Python
simulation = SimulationBuilder().build_from_entities(tax_benefit_system, input_data, trace = True)
```

**After**

```Python
simulation = SimulationBuilder().build_from_entities(tax_benefit_system, input_data)
simulation.trace = True
```