### PR TITLE
Always use safe_load to load YAML data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 28.0.1 [#845](https://github.com/openfisca/openfisca-core/pull/845)
+
+- Consistently use the safe approach to YAML loading, fixing [this deprecation warning](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation) introduced in PyYAML 5.1
+
 # 28.0.0 [#847](https://github.com/openfisca/openfisca-core/pull/847)
 
 #### Breaking changes

--- a/openfisca_core/scripts/migrations/v24_to_25.py
+++ b/openfisca_core/scripts/migrations/v24_to_25.py
@@ -52,7 +52,7 @@ class Migrator(object):
         print('Migrating {}.'.format(path))
 
         with open(path) as yaml_file:
-            tests = yaml.load(yaml_file, Loader=yaml.FullLoader)
+            tests = yaml.safe_load(yaml_file)
         if isinstance(tests, CommentedSeq):
             migrated_tests = [self.convert_test(test) for test in tests]
         else:

--- a/openfisca_core/scripts/migrations/v24_to_25.py
+++ b/openfisca_core/scripts/migrations/v24_to_25.py
@@ -52,7 +52,7 @@ class Migrator(object):
         print('Migrating {}.'.format(path))
 
         with open(path) as yaml_file:
-            tests = yaml.load(yaml_file)
+            tests = yaml.load(yaml_file, Loader=yaml.FullLoader)
         if isinstance(tests, CommentedSeq):
             migrated_tests = [self.convert_test(test) for test in tests]
         else:

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -25,12 +25,6 @@ log = logging.getLogger(__name__)
 
 
 def import_yaml():
-    if sys.version_info < (3, 6):
-        # In Python 2, we need a YAML loader that preserves the dict orders, as it's not natively suported.
-        from ruamel.yaml import YAML
-        yaml = YAML()
-        return yaml, None
-
     import yaml
     try:
         from yaml import CLoader as Loader

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -174,7 +174,7 @@ def _generate_tests_from_directory(tax_benefit_system, path_to_dir, options):
 def _parse_test_file(tax_benefit_system, yaml_path, options):
     with open(yaml_path) as yaml_file:
         try:
-            tests = yaml.load(yaml_file, Loader=yaml.FullLoader)
+            tests = yaml.safe_load(yaml_file)
         except (yaml.scanner.ScannerError, TypeError):
             message = os.linesep.join([
                 traceback.format_exc(),

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -174,7 +174,7 @@ def _generate_tests_from_directory(tax_benefit_system, path_to_dir, options):
 def _parse_test_file(tax_benefit_system, yaml_path, options):
     with open(yaml_path) as yaml_file:
         try:
-            tests = yaml.load(yaml_file)
+            tests = yaml.load(yaml_file, Loader=yaml.FullLoader)
         except (yaml.scanner.ScannerError, TypeError):
             message = os.linesep.join([
                 traceback.format_exc(),

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -41,7 +41,7 @@ def import_yaml():
             'test suite slower to run. Once you have installed libyaml, run `pip '
             'uninstall pyyaml && pip install pyyaml --no-cache-dir` so that it is used in your '
             'Python environment.')
-        from yaml import Loader
+        from yaml import SafeLoader as Loader
     return yaml, Loader
 
 
@@ -174,7 +174,7 @@ def _generate_tests_from_directory(tax_benefit_system, path_to_dir, options):
 def _parse_test_file(tax_benefit_system, yaml_path, options):
     with open(yaml_path) as yaml_file:
         try:
-            tests = yaml.safe_load(yaml_file)
+            tests = yaml.load(yaml_file, Loader = Loader)
         except (yaml.scanner.ScannerError, TypeError):
             message = os.linesep.join([
                 traceback.format_exc(),

--- a/openfisca_web_api/loader/spec.py
+++ b/openfisca_web_api/loader/spec.py
@@ -16,7 +16,7 @@ OPEN_API_CONFIG_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), 
 def build_openAPI_specification(api_data):
     tax_benefit_system = api_data['tax_benefit_system']
     file = open(OPEN_API_CONFIG_FILE, 'r')
-    spec = yaml.load(file, Loader=yaml.FullLoader)
+    spec = yaml.safe_load(file)
     country_package_name = api_data['country_package_metadata']['name'].title()
     dpath.new(spec, 'info/title', spec['info']['title'].replace("{COUNTRY_PACKAGE_NAME}", country_package_name))
     dpath.new(spec, 'info/description', spec['info']['description'].replace("{COUNTRY_PACKAGE_NAME}", country_package_name))

--- a/openfisca_web_api/loader/spec.py
+++ b/openfisca_web_api/loader/spec.py
@@ -16,7 +16,7 @@ OPEN_API_CONFIG_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), 
 def build_openAPI_specification(api_data):
     tax_benefit_system = api_data['tax_benefit_system']
     file = open(OPEN_API_CONFIG_FILE, 'r')
-    spec = yaml.load(file)
+    spec = yaml.load(file, Loader=yaml.FullLoader)
     country_package_name = api_data['country_package_metadata']['name'].title()
     dpath.new(spec, 'info/title', spec['info']['title'].replace("{COUNTRY_PACKAGE_NAME}", country_package_name))
     dpath.new(spec, 'info/description', spec['info']['description'].replace("{COUNTRY_PACKAGE_NAME}", country_package_name))

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '28.0.0',
+    version = '28.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_axes.py
+++ b/tests/core/test_axes.py
@@ -143,7 +143,7 @@ def test_simulation_with_axes(simulation_builder):
                   max: 3000
                   period: 2018-11
     """
-    data = yaml.load(input_yaml)
+    data = yaml.load(input_yaml, Loader=yaml.FullLoader)
     simulation = simulation_builder.build_from_dict(tax_benefit_system, data)
     assert simulation.get_array('salary', '2018-11') == approx([0, 0, 0, 0, 0, 0])
     assert simulation.get_array('rent', '2018-11') == approx([0, 0, 3000, 0])

--- a/tests/core/test_axes.py
+++ b/tests/core/test_axes.py
@@ -143,7 +143,7 @@ def test_simulation_with_axes(simulation_builder):
                   max: 3000
                   period: 2018-11
     """
-    data = yaml.load(input_yaml, Loader=yaml.FullLoader)
+    data = yaml.safe_load(input_yaml)
     simulation = simulation_builder.build_from_dict(tax_benefit_system, data)
     assert simulation.get_array('salary', '2018-11') == approx([0, 0, 0, 0, 0, 0])
     assert simulation.get_array('rent', '2018-11') == approx([0, 0, 3000, 0])

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -68,7 +68,7 @@ def test_entity_structure_with_constructor():
             - claudia
     """
 
-    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.load(simulation_yaml))
+    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.load(simulation_yaml, Loader=yaml.FullLoader))
 
     household = simulation.household
 
@@ -102,7 +102,7 @@ def test_entity_variables_with_constructor():
               2017-06: 600
     """
 
-    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.load(simulation_yaml))
+    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.load(simulation_yaml, Loader=yaml.FullLoader))
     household = simulation.household
     assert_near(household('rent', "2017-06"), [800, 600])
 
@@ -135,7 +135,7 @@ def test_person_variable_with_constructor():
             - claudia
     """
 
-    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.load(simulation_yaml))
+    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.load(simulation_yaml, Loader=yaml.FullLoader))
     person = simulation.person
     assert_near(person('salary', "2017-11"), [1500, 0, 3000, 0, 0])
     assert_near(person('salary', "2017-12"), [2000, 0, 4000, 0, 0])
@@ -174,7 +174,7 @@ def test_set_input_with_constructor():
             - claudia
     """
 
-    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.load(simulation_yaml))
+    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.load(simulation_yaml, Loader=yaml.FullLoader))
     person = simulation.person
     assert_near(person('salary', "2017-12"), [2000, 0, 4000, 0, 0])
     assert_near(person('salary', "2017-10"), [2000, 3000, 1600, 0, 0])

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -68,7 +68,7 @@ def test_entity_structure_with_constructor():
             - claudia
     """
 
-    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.load(simulation_yaml, Loader=yaml.FullLoader))
+    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.safe_load(simulation_yaml))
 
     household = simulation.household
 
@@ -102,7 +102,7 @@ def test_entity_variables_with_constructor():
               2017-06: 600
     """
 
-    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.load(simulation_yaml, Loader=yaml.FullLoader))
+    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.safe_load(simulation_yaml))
     household = simulation.household
     assert_near(household('rent', "2017-06"), [800, 600])
 
@@ -135,7 +135,7 @@ def test_person_variable_with_constructor():
             - claudia
     """
 
-    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.load(simulation_yaml, Loader=yaml.FullLoader))
+    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.safe_load(simulation_yaml))
     person = simulation.person
     assert_near(person('salary', "2017-11"), [1500, 0, 3000, 0, 0])
     assert_near(person('salary', "2017-12"), [2000, 0, 4000, 0, 0])
@@ -174,7 +174,7 @@ def test_set_input_with_constructor():
             - claudia
     """
 
-    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.load(simulation_yaml, Loader=yaml.FullLoader))
+    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.safe_load(simulation_yaml))
     person = simulation.person
     assert_near(person('salary', "2017-12"), [2000, 0, 4000, 0, 0])
     assert_near(person('salary', "2017-10"), [2000, 3000, 1600, 0, 0])

--- a/tests/core/test_simulation_builder.py
+++ b/tests/core/test_simulation_builder.py
@@ -353,7 +353,7 @@ def test_some_person_without_household(simulation_builder):
         persons: {'Alicia': {}, 'Bob': {}}
         household: {'parents': ['Alicia']}
     """
-    simulation = simulation_builder.build_from_dict(tax_benefit_system, yaml.load(input_yaml, Loader=yaml.FullLoader))
+    simulation = simulation_builder.build_from_dict(tax_benefit_system, yaml.safe_load(input_yaml))
     assert simulation.household.count == 2
     parents_in_households = simulation.household.nb_persons(role = simulation.household.PARENT)
     assert parents_in_households.tolist() == [1, 1]  # household member default role is first_parent
@@ -444,7 +444,7 @@ def test_simulation(simulation_builder):
             2016-10: 12000
     """
 
-    simulation = simulation_builder.build_from_dict(tax_benefit_system, yaml.load(input_yaml, Loader=yaml.FullLoader))
+    simulation = simulation_builder.build_from_dict(tax_benefit_system, yaml.safe_load(input_yaml))
 
     assert simulation.get_array("salary", "2016-10") == 12000
     simulation.calculate("income_tax", "2016-10")
@@ -457,7 +457,7 @@ def test_vectorial_input(simulation_builder):
             2016-10: [12000, 20000]
     """
 
-    simulation = simulation_builder.build_from_dict(tax_benefit_system, yaml.load(input_yaml, Loader=yaml.FullLoader))
+    simulation = simulation_builder.build_from_dict(tax_benefit_system, yaml.safe_load(input_yaml))
 
     assert_near(simulation.get_array("salary", "2016-10"), [12000, 20000])
     simulation.calculate("income_tax", "2016-10")
@@ -479,7 +479,7 @@ def test_single_entity_shortcut(simulation_builder):
           parents: [Alicia, Javier]
     """
 
-    simulation = simulation_builder.build_from_dict(tax_benefit_system, yaml.load(input_yaml, Loader=yaml.FullLoader))
+    simulation = simulation_builder.build_from_dict(tax_benefit_system, yaml.safe_load(input_yaml))
     assert simulation.household.count == 1
 
 
@@ -495,7 +495,7 @@ def test_order_preserved(simulation_builder):
           children: [Tom, Sarah]
     """
 
-    data = yaml.load(input_yaml, Loader=yaml.FullLoader)
+    data = yaml.safe_load(input_yaml)
     simulation = simulation_builder.build_from_dict(tax_benefit_system, data)
 
     assert simulation.persons.ids == ['Javier', 'Alicia', 'Sarah', 'Tom']
@@ -509,5 +509,5 @@ def test_inconsistent_input(simulation_builder):
             2016-10: [100, 200, 300]
     """
     with raises(ValueError) as error:
-        simulation_builder.build_from_dict(tax_benefit_system, yaml.load(input_yaml, Loader=yaml.FullLoader))
+        simulation_builder.build_from_dict(tax_benefit_system, yaml.safe_load(input_yaml))
     assert "its length is 3 while there are 2" in error.value.args[0]

--- a/tests/core/test_simulation_builder.py
+++ b/tests/core/test_simulation_builder.py
@@ -353,7 +353,7 @@ def test_some_person_without_household(simulation_builder):
         persons: {'Alicia': {}, 'Bob': {}}
         household: {'parents': ['Alicia']}
     """
-    simulation = simulation_builder.build_from_dict(tax_benefit_system, yaml.load(input_yaml))
+    simulation = simulation_builder.build_from_dict(tax_benefit_system, yaml.load(input_yaml, Loader=yaml.FullLoader))
     assert simulation.household.count == 2
     parents_in_households = simulation.household.nb_persons(role = simulation.household.PARENT)
     assert parents_in_households.tolist() == [1, 1]  # household member default role is first_parent
@@ -444,7 +444,7 @@ def test_simulation(simulation_builder):
             2016-10: 12000
     """
 
-    simulation = simulation_builder.build_from_dict(tax_benefit_system, yaml.load(input_yaml))
+    simulation = simulation_builder.build_from_dict(tax_benefit_system, yaml.load(input_yaml, Loader=yaml.FullLoader))
 
     assert simulation.get_array("salary", "2016-10") == 12000
     simulation.calculate("income_tax", "2016-10")
@@ -457,7 +457,7 @@ def test_vectorial_input(simulation_builder):
             2016-10: [12000, 20000]
     """
 
-    simulation = simulation_builder.build_from_dict(tax_benefit_system, yaml.load(input_yaml))
+    simulation = simulation_builder.build_from_dict(tax_benefit_system, yaml.load(input_yaml, Loader=yaml.FullLoader))
 
     assert_near(simulation.get_array("salary", "2016-10"), [12000, 20000])
     simulation.calculate("income_tax", "2016-10")
@@ -479,7 +479,7 @@ def test_single_entity_shortcut(simulation_builder):
           parents: [Alicia, Javier]
     """
 
-    simulation = simulation_builder.build_from_dict(tax_benefit_system, yaml.load(input_yaml))
+    simulation = simulation_builder.build_from_dict(tax_benefit_system, yaml.load(input_yaml, Loader=yaml.FullLoader))
     assert simulation.household.count == 1
 
 
@@ -495,7 +495,7 @@ def test_order_preserved(simulation_builder):
           children: [Tom, Sarah]
     """
 
-    data = yaml.load(input_yaml)
+    data = yaml.load(input_yaml, Loader=yaml.FullLoader)
     simulation = simulation_builder.build_from_dict(tax_benefit_system, data)
 
     assert simulation.persons.ids == ['Javier', 'Alicia', 'Sarah', 'Tom']
@@ -509,5 +509,5 @@ def test_inconsistent_input(simulation_builder):
             2016-10: [100, 200, 300]
     """
     with raises(ValueError) as error:
-        simulation_builder.build_from_dict(tax_benefit_system, yaml.load(input_yaml))
+        simulation_builder.build_from_dict(tax_benefit_system, yaml.load(input_yaml, Loader=yaml.FullLoader))
     assert "its length is 3 while there are 2" in error.value.args[0]


### PR DESCRIPTION
#### Technical changes

- Consistently use the safe approach to YAML loading, fixing [this deprecation warning](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation) introduced in PyYAML 5.1
