### PR TITLE
Fix AttributeError on simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-# 29.0.1 [#851](https://github.com/openfisca/openfisca-core/pull/851)
+### 29.0.2 [#858](https://github.com/openfisca/openfisca-core/pull/858)
+
+#### Bug fix
+
+- Fix error on simulation debug attribute at simulation clone
+- Details:   
+  - Fixes `AttributeError: 'Simulation' object has no attribute 'debug'` introduced by Core v.`29.0.0`.
+
+### 29.0.1 [#851](https://github.com/openfisca/openfisca-core/pull/851)
 
 - Remove print statements from `simulations.py`, add linting options to detect stray print statements
 

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -491,11 +491,6 @@ class Simulation(object):
 
         new.debug = debug
         new.trace = trace
-        if debug or trace:
-            if self.debug or self.trace:
-                new_dict['tracer'] = self.tracer.clone()
-            else:
-                new_dict['tracer'] = Tracer()
 
         return new
 

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -489,8 +489,8 @@ class Simulation(object):
             new.entities[entity.key] = entity
             setattr(new, entity_class.key, entity)  # create shortcut simulation.household (for instance)
 
-        new_dict['debug'] = debug
-        new_dict['trace'] = trace
+        new.debug = debug
+        new.trace = trace
         if debug or trace:
             if self.debug or self.trace:
                 new_dict['tracer'] = self.tracer.clone()

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -489,10 +489,8 @@ class Simulation(object):
             new.entities[entity.key] = entity
             setattr(new, entity_class.key, entity)  # create shortcut simulation.household (for instance)
 
-        if debug:
-            new_dict['debug'] = True
-        if trace:
-            new_dict['trace'] = True
+        new_dict['debug'] = debug
+        new_dict['trace'] = trace
         if debug or trace:
             if self.debug or self.trace:
                 new_dict['tracer'] = self.tracer.clone()

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '29.0.1',
+    version = '29.0.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
#### Bug fix

- Fix `AttributeError: 'Simulation' object has no attribute 'debug'`
  - Error detected on `build` step in openfisca/openfisca-france#1293

> Unlink `debug` and `Tracer` init on simulation clone. If you clone a simulation with `debug = True`, it will not activate the `trace` attribute anymore.