### PR TITLE
Do not ignore inputs for several months or years

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 30.0.3 [#859](https://github.com/openfisca/openfisca-core/pull/859)
+
+- Raise an error instead of silently ignoring the input when a user tries to set an input for a variable for several months (or several years), but the variable has no `set_input` declared.
+
 ### 30.0.2 [#860](https://github.com/openfisca/openfisca-core/pull/860)
 
 - Apply `flake8-bugbear` recommendations and enforce same in continuous integration.

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -212,18 +212,14 @@ class Holder(object):
         if self.variable.definition_period != ETERNITY:
             if period is None:
                 raise ValueError('A period must be specified to set values, except for variables with ETERNITY as as period_definition.')
-            if ((self.variable.definition_period == MONTH and period.unit != periods.MONTH) or
-               (self.variable.definition_period == YEAR and period.unit != periods.YEAR)):
+            if (self.variable.definition_period != period.unit or period.size > 1):
+                name = self.variable.name
+                period_size_adj = f'{period.unit}' if (period.size == 1) else f'{period.size}-{period.unit}s'
                 error_message = os.linesep.join([
-                    'Unable to set a value for variable {0} for {1}-long period {2}.',
-                    '{0} is only defined for {3}s. Please adapt your input.',
-                    'If you are the maintainer of {0}, you can consider adding it a set_input attribute to enable automatic period casting.'
-                    ]).format(
-                        self.variable.name,
-                        period.unit,
-                        period,
-                        self.variable.definition_period
-                    ).encode('utf-8')
+                    f'Unable to set a value for variable "{name}" for {period_size_adj}-long period "{period}".',
+                    f'"{name}" can only be set for one {self.variable.definition_period} at a time. Please adapt your input.',
+                    f'If you are the maintainer of "{name}", you can consider adding it a set_input attribute to enable automatic period casting.'
+                    ])
 
                 raise PeriodMismatchError(
                     self.variable.name,

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '30.0.2',
+    version = '30.0.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -3,8 +3,6 @@
 import numpy as np
 import pytest
 
-from nose.tools import assert_equal, assert_is_none
-
 import openfisca_country_template.situation_examples
 from openfisca_core.simulation_builder import SimulationBuilder
 from openfisca_core.periods import period as make_period, ETERNITY
@@ -36,7 +34,7 @@ def test_set_input_enum_string(couple):
     status_occupancy = np.asarray(['free_lodger'])
     simulation.household.get_holder('housing_occupancy_status').set_input(period, status_occupancy)
     result = simulation.calculate('housing_occupancy_status', period)
-    assert_equal(result, HousingOccupancyStatus.free_lodger)
+    assert result == HousingOccupancyStatus.free_lodger
 
 
 def test_set_input_enum_int(couple):
@@ -44,7 +42,7 @@ def test_set_input_enum_int(couple):
     status_occupancy = np.asarray([2], dtype = np.int16)
     simulation.household.get_holder('housing_occupancy_status').set_input(period, status_occupancy)
     result = simulation.calculate('housing_occupancy_status', period)
-    assert_equal(result, HousingOccupancyStatus.free_lodger)
+    assert result == HousingOccupancyStatus.free_lodger
 
 
 def test_set_input_enum_item(couple):
@@ -52,7 +50,7 @@ def test_set_input_enum_item(couple):
     status_occupancy = np.asarray([HousingOccupancyStatus.free_lodger])
     simulation.household.get_holder('housing_occupancy_status').set_input(period, status_occupancy)
     result = simulation.calculate('housing_occupancy_status', period)
-    assert_equal(result, HousingOccupancyStatus.free_lodger)
+    assert result == HousingOccupancyStatus.free_lodger
 
 
 def test_yearly_input_month_variable(couple):
@@ -84,7 +82,7 @@ def test_enum_dtype(couple):
 def test_permanent_variable_empty(single):
     simulation = single
     holder = simulation.person.get_holder('birth')
-    assert_is_none(holder.get_array(None))
+    assert holder.get_array(None) is None
 
 
 def test_permanent_variable_filled(single):
@@ -92,9 +90,9 @@ def test_permanent_variable_filled(single):
     holder = simulation.person.get_holder('birth')
     value = np.asarray(['1980-01-01'], dtype = holder.variable.dtype)
     holder.set_input(make_period(ETERNITY), value)
-    assert_equal(holder.get_array(None), value)
-    assert_equal(holder.get_array(ETERNITY), value)
-    assert_equal(holder.get_array('2016-01'), value)
+    assert holder.get_array(None) == value
+    assert holder.get_array(ETERNITY) == value
+    assert holder.get_array('2016-01') == value
 
 
 def test_delete_arrays(single):
@@ -102,26 +100,26 @@ def test_delete_arrays(single):
     salary_holder = simulation.person.get_holder('salary')
     salary_holder.set_input(make_period(2017), np.asarray([30000]))
     salary_holder.set_input(make_period(2018), np.asarray([60000]))
-    assert_equal(simulation.person('salary', '2017-01'), 2500)
-    assert_equal(simulation.person('salary', '2018-01'), 5000)
+    assert simulation.person('salary', '2017-01') == 2500
+    assert simulation.person('salary', '2018-01') == 5000
     salary_holder.delete_arrays(period = 2018)
     salary_holder.set_input(make_period(2018), np.asarray([15000]))
-    assert_equal(simulation.person('salary', '2017-01'), 2500)
-    assert_equal(simulation.person('salary', '2018-01'), 1250)
+    assert simulation.person('salary', '2017-01') == 2500
+    assert simulation.person('salary', '2018-01') == 1250
 
 
 def test_get_memory_usage(single):
     simulation = single
     salary_holder = simulation.person.get_holder('salary')
     memory_usage = salary_holder.get_memory_usage()
-    assert_equal(memory_usage['total_nb_bytes'], 0)
+    assert memory_usage['total_nb_bytes'] == 0
     salary_holder.set_input(make_period(2017), np.asarray([30000]))
     memory_usage = salary_holder.get_memory_usage()
-    assert_equal(memory_usage['nb_cells_by_array'], 1)
-    assert_equal(memory_usage['cell_size'], 4)  # float 32
-    assert_equal(memory_usage['nb_cells_by_array'], 1)  # one person
-    assert_equal(memory_usage['nb_arrays'], 12)  # 12 months
-    assert_equal(memory_usage['total_nb_bytes'], 4 * 12 * 1)
+    assert memory_usage['nb_cells_by_array'] == 1
+    assert memory_usage['cell_size'] == 4  # float 32
+    assert memory_usage['nb_cells_by_array'] == 1  # one person
+    assert memory_usage['nb_arrays'] == 12  # 12 months
+    assert memory_usage['total_nb_bytes'] == 4 * 12 * 1
 
 
 def test_get_memory_usage_with_trace(single):
@@ -134,8 +132,8 @@ def test_get_memory_usage_with_trace(single):
     simulation.calculate('salary', '2017-02')
     simulation.calculate_add('salary', '2017')  # 12 calculations
     memory_usage = salary_holder.get_memory_usage()
-    assert_equal(memory_usage['nb_requests'], 15)
-    assert_equal(memory_usage['nb_requests_by_array'], 1.25)  # 15 calculations / 12 arrays
+    assert memory_usage['nb_requests'] == 15
+    assert memory_usage['nb_requests_by_array'] == 1.25  # 15 calculations / 12 arrays
 
 
 def test_set_input_dispatch_by_period(single):
@@ -157,12 +155,12 @@ def test_delete_arrays_on_disk(single):
     salary_holder = simulation.person.get_holder('salary')
     salary_holder.set_input(make_period(2017), np.asarray([30000]))
     salary_holder.set_input(make_period(2018), np.asarray([60000]))
-    assert_equal(simulation.person('salary', '2017-01'), 2500)
-    assert_equal(simulation.person('salary', '2018-01'), 5000)
+    assert simulation.person('salary', '2017-01') == 2500
+    assert simulation.person('salary', '2018-01') == 5000
     salary_holder.delete_arrays(period = 2018)
     salary_holder.set_input(make_period(2018), np.asarray([15000]))
-    assert_equal(simulation.person('salary', '2017-01'), 2500)
-    assert_equal(simulation.person('salary', '2018-01'), 1250)
+    assert simulation.person('salary', '2017-01') == 2500
+    assert simulation.person('salary', '2018-01') == 1250
 
 
 def test_cache_disk(couple):
@@ -186,7 +184,7 @@ def test_known_periods(couple):
     holder.put_in_cache(data, month)
     holder._memory_storage.put(data, month_2)
 
-    assert_equal(sorted(holder.get_known_periods()), [month, month_2])
+    assert sorted(holder.get_known_periods()), [month == month_2]
 
 
 def test_cache_enum_on_disk(single):
@@ -195,7 +193,7 @@ def test_cache_enum_on_disk(single):
     month = make_period('2017-01')
     simulation.calculate('housing_occupancy_status', month)  # First calculation
     housing_occupancy_status = simulation.calculate('housing_occupancy_status', month)  # Read from cache
-    assert_equal(housing_occupancy_status, HousingOccupancyStatus.tenant)
+    assert housing_occupancy_status == HousingOccupancyStatus.tenant
 
 
 def test_set_not_cached_variable(single):
@@ -205,7 +203,7 @@ def test_set_not_cached_variable(single):
     holder = simulation.person.get_holder('salary')
     array = np.asarray([2000])
     holder.set_input('2015-01', array)
-    assert_equal(simulation.calculate('salary', '2015-01'), array)
+    assert simulation.calculate('salary', '2015-01') == array
 
 
 def test_set_input_float_to_int(single):
@@ -213,4 +211,4 @@ def test_set_input_float_to_int(single):
     age = np.asarray([50.6])
     simulation.person.get_holder('age').set_input(period, age)
     result = simulation.calculate('age', period)
-    assert_equal(result, np.asarray([50]))
+    assert result == np.asarray([50])

--- a/tests/core/test_parameters.py
+++ b/tests/core/test_parameters.py
@@ -12,8 +12,8 @@ def test_get_at_instant():
     assert isinstance(parameters, ParameterNode), parameters
     parameters_at_instant = parameters('2016-01-01')
     assert isinstance(parameters_at_instant, ParameterNodeAtInstant), parameters_at_instant
-    assert_equal(parameters_at_instant.taxes.income_tax_rate, 0.15)
-    assert_equal(parameters_at_instant.benefits.basic_income, 600)
+    assert parameters_at_instant.taxes.income_tax_rate == 0.15
+    assert parameters_at_instant.benefits.basic_income == 600
 
 
 def test_param_values():
@@ -58,7 +58,7 @@ def test_stopped_parameter_after_end_value():
 
 def test_parameter_for_period():
     income_tax_rate = tax_benefit_system.parameters.taxes.income_tax_rate
-    assert_equal(income_tax_rate("2015"), income_tax_rate("2015-01-01"))
+    assert income_tax_rate("2015") == income_tax_rate("2015-01-01")
 
 
 @raises(ValueError)
@@ -73,26 +73,26 @@ def test_parameter_repr():
     tf.write(repr(parameters).encode('utf-8'))
     tf.close()
     tf_parameters = load_parameter_file(file_path = tf.name)
-    assert_equal(repr(parameters), repr(tf_parameters))
+    assert repr(parameters) == repr(tf_parameters)
 
 
 def test_parameters_metadata():
     parameter = tax_benefit_system.parameters.benefits.basic_income
-    assert_equal(parameter.metadata['reference'], 'https://law.gov.example/basic-income/amount')
-    assert_equal(parameter.metadata['unit'], 'currency-EUR')
-    assert_equal(parameter.values_list[0].metadata['reference'], 'https://law.gov.example/basic-income/amount/2015-12')
-    assert_equal(parameter.values_list[0].metadata['unit'], 'currency-EUR')
+    assert parameter.metadata['reference'] == 'https://law.gov.example/basic-income/amount'
+    assert parameter.metadata['unit'] == 'currency-EUR'
+    assert parameter.values_list[0].metadata['reference'] == 'https://law.gov.example/basic-income/amount/2015-12'
+    assert parameter.values_list[0].metadata['unit'] == 'currency-EUR'
     scale = tax_benefit_system.parameters.taxes.social_security_contribution
-    assert_equal(scale.metadata['threshold_unit'], 'currency-EUR')
-    assert_equal(scale.metadata['rate_unit'], '/1')
+    assert scale.metadata['threshold_unit'] == 'currency-EUR'
+    assert scale.metadata['rate_unit'] == '/1'
 
 
 def test_parameter_node_metadata():
     parameter = tax_benefit_system.parameters.benefits
-    assert_equal(parameter.description, 'Social benefits')
+    assert parameter.description == 'Social benefits'
 
     parameter_2 = tax_benefit_system.parameters.taxes.housing_tax
-    assert_equal(parameter_2.description, 'Housing tax')
+    assert parameter_2.description == 'Housing tax'
 
 
 def test_parameter_documentation():

--- a/tests/web_api/case_with_extension/test_extensions.py
+++ b/tests/web_api/case_with_extension/test_extensions.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from http.client import OK
-from nose.tools import assert_equal
 from openfisca_core.scripts import build_tax_benefit_system
 from openfisca_web_api.app import create_app
 
@@ -16,14 +15,14 @@ extended_subject = create_app(tax_benefit_system).test_client()
 
 def test_return_code():
     parameters_response = extended_subject.get('/parameters')
-    assert_equal(parameters_response.status_code, OK)
+    assert parameters_response.status_code == OK
 
 
 def test_return_code_existing_parameter():
     extension_parameter_response = extended_subject.get('/parameter/local_town.child_allowance.amount')
-    assert_equal(extension_parameter_response.status_code, OK)
+    assert extension_parameter_response.status_code == OK
 
 
 def test_return_code_existing_variable():
     extension_variable_response = extended_subject.get('/variable/local_town_child_allowance')
-    assert_equal(extension_variable_response.status_code, OK)
+    assert extension_variable_response.status_code == OK

--- a/tests/web_api/test_calculate.py
+++ b/tests/web_api/test_calculate.py
@@ -48,7 +48,7 @@ def check_response(data, expected_error_code, path_to_check, content_to_check):
     ('{"persons": {"bob": {}}, "households": {"household": {"parents": ["bob", {}]}}}', BAD_REQUEST, 'households/household/parents/1', 'Invalid type',),
     ('{"persons": {"bob": {"salary": {"invalid period": 2000 }}}}', BAD_REQUEST, 'persons/bob/salary', 'Expected a period',),
     ('{"persons": {"bob": {"salary": {"invalid period": null }}}}', BAD_REQUEST, 'persons/bob/salary', 'Expected a period',),
-    ('{"persons": {"bob": {"basic_income": {"2017": 2000 }}}, "households": {"household": {"parents": ["bob"]}}}', BAD_REQUEST, 'persons/bob/basic_income/2017', 'basic_income is only defined for months',),
+    ('{"persons": {"bob": {"basic_income": {"2017": 2000 }}}, "households": {"household": {"parents": ["bob"]}}}', BAD_REQUEST, 'persons/bob/basic_income/2017', '"basic_income" can only be set for one month',),
     ('{"persons": {"bob": {"salary": {"ETERNITY": 2000 }}}, "households": {"household": {"parents": ["bob"]}}}', BAD_REQUEST, 'persons/bob/salary/ETERNITY', 'salary is only defined for months',)
     ])
 def test_responses(test):

--- a/tests/web_api/test_entities.py
+++ b/tests/web_api/test_entities.py
@@ -12,7 +12,7 @@ entities_response = subject.get('/entities')
 
 
 def test_return_code():
-    assert_equal(entities_response.status_code, OK)
+    assert entities_response.status_code == OK
 
 
 def test_response_data():

--- a/tests/web_api/test_headers.py
+++ b/tests/web_api/test_headers.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from nose.tools import assert_equal
 from . import distribution, subject
 
 parameters_response = subject.get('/parameters')
 
 
 def test_package_name_header():
-    assert_equal(parameters_response.headers.get('Country-Package'), distribution.key)
+    assert parameters_response.headers.get('Country-Package') == distribution.key
 
 
 def test_package_version_header():
-    assert_equal(parameters_response.headers.get('Country-Package-Version'), distribution.version)
+    assert parameters_response.headers.get('Country-Package-Version') == distribution.version

--- a/tests/web_api/test_helpers.py
+++ b/tests/web_api/test_helpers.py
@@ -1,7 +1,5 @@
 import os
 
-from nose.tools import assert_equal
-
 from openfisca_core.parameters import load_parameter_file
 from openfisca_web_api.loader.parameters import build_api_values_history, get_value
 
@@ -18,7 +16,7 @@ def test_build_api_values_history():
         '2015-01-01': 0.04,
         '2013-01-01': 0.03,
         }
-    assert_equal(build_api_values_history(parameter), values)
+    assert build_api_values_history(parameter) == values
 
 
 def test_build_api_values_history_with_stop_date():
@@ -32,23 +30,23 @@ def test_build_api_values_history_with_stop_date():
         '2013-01-01': 0.03,
         }
 
-    assert_equal(build_api_values_history(parameter), values)
+    assert build_api_values_history(parameter) == values
 
 
 def test_get_value():
     values = {'2013-01-01': 0.03, '2017-01-01': 0.02, '2015-01-01': 0.04}
 
-    assert_equal(get_value('2013-01-01', values), 0.03)
-    assert_equal(get_value('2014-01-01', values), 0.03)
-    assert_equal(get_value('2015-02-01', values), 0.04)
-    assert_equal(get_value('2016-12-31', values), 0.04)
-    assert_equal(get_value('2017-01-01', values), 0.02)
-    assert_equal(get_value('2018-01-01', values), 0.02)
+    assert get_value('2013-01-01', values) == 0.03
+    assert get_value('2014-01-01', values) == 0.03
+    assert get_value('2015-02-01', values) == 0.04
+    assert get_value('2016-12-31', values) == 0.04
+    assert get_value('2017-01-01', values) == 0.02
+    assert get_value('2018-01-01', values) == 0.02
 
 
 def test_get_value_with_none():
     values = {'2015-01-01': 0.04, '2017-01-01': None}
 
-    assert_equal(get_value('2016-12-31', values), 0.04)
-    assert_equal(get_value('2017-01-01', values), None)
-    assert_equal(get_value('2011-01-01', values), None)
+    assert get_value('2016-12-31', values) == 0.04
+    assert get_value('2017-01-01', values) is None
+    assert get_value('2011-01-01', values) is None

--- a/tests/web_api/test_parameters.py
+++ b/tests/web_api/test_parameters.py
@@ -13,7 +13,7 @@ GITHUB_URL_REGEX = r'^https://github\.com/openfisca/country-template/blob/\d+\.\
 
 
 def test_return_code():
-    assert_equal(parameters_response.status_code, OK)
+    assert parameters_response.status_code == OK
 
 
 def test_response_data():
@@ -36,44 +36,43 @@ def test_response_data():
 
 def test_error_code_non_existing_parameter():
     response = subject.get('/parameter/non/existing.parameter')
-    assert_equal(response.status_code, NOT_FOUND)
+    assert response.status_code == NOT_FOUND
 
 
 def test_return_code_existing_parameter():
     response = subject.get('/parameter/taxes/income_tax_rate')
-    assert_equal(response.status_code, OK)
+    assert response.status_code == OK
 
 
 def test_legacy_parameter_route():
     response = subject.get('/parameter/taxes.income_tax_rate')
-    assert_equal(response.status_code, OK)
+    assert response.status_code == OK
 
 
 def test_parameter_values():
     response = subject.get('/parameter/taxes/income_tax_rate')
     parameter = json.loads(response.data)
-    assert_equal(sorted(list(parameter.keys())), ['description', 'id', 'metadata', 'source', 'values'])
-    assert_equal(parameter['id'], 'taxes.income_tax_rate')
-    assert_equal(parameter['description'], 'Income tax rate')
-    assert_equal(parameter['values'], {'2015-01-01': 0.15, '2014-01-01': 0.14, '2013-01-01': 0.13, '2012-01-01': 0.16})
-    assert_equal(parameter['values'], {'2015-01-01': 0.15, '2014-01-01': 0.14, '2013-01-01': 0.13, '2012-01-01': 0.16})
-    assert_equal(parameter['metadata'], {'unit': '/1'})
+    assert sorted(list(parameter.keys())), ['description', 'id', 'metadata', 'source', 'values']
+    assert parameter['id'] == 'taxes.income_tax_rate'
+    assert parameter['description'] == 'Income tax rate'
+    assert parameter['values'] == {'2015-01-01': 0.15, '2014-01-01': 0.14, '2013-01-01': 0.13, '2012-01-01': 0.16}
+    assert parameter['metadata'] == {'unit': '/1'}
     assert_regexp_matches(parameter['source'], GITHUB_URL_REGEX)
     assert_in('taxes/income_tax_rate.yaml', parameter['source'])
 
     # 'documentation' attribute exists only when a value is defined
     response = subject.get('/parameter/benefits/housing_allowance')
     parameter = json.loads(response.data)
-    assert_equal(sorted(list(parameter.keys())), ['description', 'documentation', 'id', 'metadata', 'source', 'values'])
+    assert sorted(list(parameter.keys())), ['description', 'documentation', 'id', 'metadata', 'source' == 'values']
     assert_equal(parameter['documentation'],
         'A fraction of the rent.\nFrom the 1st of Dec 2016, the housing allowance no longer exists.')
 
 
 def test_parameter_node():
     response = subject.get('/parameter/benefits')
-    assert_equal(response.status_code, OK)
+    assert response.status_code == OK
     parameter = json.loads(response.data)
-    assert_equal(sorted(list(parameter.keys())), ['description', 'documentation', 'id', 'metadata', 'source', 'subparams'])
+    assert sorted(list(parameter.keys())), ['description', 'documentation', 'id', 'metadata', 'source' == 'subparams']
     assert_equal(parameter['documentation'],
                 "Government support for the citizens and residents of society. "
                 "\nThey may be provided to people of any income level, as with social security, "
@@ -88,13 +87,13 @@ def test_parameter_node():
 def test_stopped_parameter_values():
     response = subject.get('/parameter/benefits/housing_allowance')
     parameter = json.loads(response.data)
-    assert_equal(parameter['values'], {'2016-12-01': None, '2010-01-01': 0.25})
+    assert parameter['values'] == {'2016-12-01': None, '2010-01-01': 0.25}
 
 
 def test_scale():
     response = subject.get('/parameter/taxes/social_security_contribution')
     parameter = json.loads(response.data)
-    assert_equal(sorted(list(parameter.keys())), ['brackets', 'description', 'id', 'metadata', 'source'])
+    assert sorted(list(parameter.keys())), ['brackets', 'description', 'id', 'metadata' == 'source']
     assert_equal(parameter['brackets'], {
         '2013-01-01': {"0.0": 0.03, "12000.0": 0.10},
         '2014-01-01': {"0.0": 0.03, "12100.0": 0.10},
@@ -106,7 +105,7 @@ def test_scale():
 
 def check_code(route, code):
     response = subject.get(route)
-    assert_equal(response.status_code, code)
+    assert response.status_code == code
 
 
 @pytest.mark.parametrize("expected_code", [
@@ -125,4 +124,4 @@ def test_routes_robustness(expected_code):
 
 def test_parameter_encoding():
     parameter_response = subject.get('/parameter/general/age_of_retirement')
-    assert_equal(parameter_response.status_code, OK)
+    assert parameter_response.status_code == OK

--- a/tests/web_api/test_spec.py
+++ b/tests/web_api/test_spec.py
@@ -4,20 +4,20 @@ import json
 from http.client import OK
 
 import dpath
-from nose.tools import assert_equal, assert_in
+from nose.tools import assert_in
 
 from . import subject
 
 
 def assert_items_equal(x, y):
-    assert_equal(sorted(x), sorted(y))
+    assert sorted(x) == sorted(y)
 
 
 openAPI_response = subject.get('/spec')
 
 
 def test_return_code():
-    assert_equal(openAPI_response.status_code, OK)
+    assert openAPI_response.status_code == OK
 
 
 body = json.loads(openAPI_response.data.decode('utf-8'))
@@ -42,7 +42,7 @@ def test_entity_definition():
     assert_in('children', dpath.get(body, 'definitions/Household/properties'))
     assert_in('salary', dpath.get(body, 'definitions/Person/properties'))
     assert_in('rent', dpath.get(body, 'definitions/Household/properties'))
-    assert_equal('number', dpath.get(body, 'definitions/Person/properties/salary/additionalProperties/type'))
+    assert 'number' == dpath.get(body, 'definitions/Person/properties/salary/additionalProperties/type')
 
 
 def test_situation_definition():
@@ -51,5 +51,5 @@ def test_situation_definition():
     for situation in situation_input, situation_output:
         assert_in('households', dpath.get(situation, '/properties'))
         assert_in('persons', dpath.get(situation, '/properties'))
-        assert_equal("#/definitions/Household", dpath.get(situation, '/properties/households/additionalProperties/$ref'))
-        assert_equal("#/definitions/Person", dpath.get(situation, '/properties/persons/additionalProperties/$ref'))
+        assert "#/definitions/Household" == dpath.get(situation, '/properties/households/additionalProperties/$ref')
+        assert "#/definitions/Person" == dpath.get(situation, '/properties/persons/additionalProperties/$ref')

--- a/tests/web_api/test_trace.py
+++ b/tests/web_api/test_trace.py
@@ -3,7 +3,7 @@
 import json
 from copy import deepcopy
 
-from nose.tools import assert_equal, assert_is_instance
+from nose.tools import assert_is_instance
 from http.client import OK
 import dpath
 from openfisca_country_template.situation_examples import single, couple
@@ -12,13 +12,13 @@ from . import subject
 
 
 def assert_items_equal(x, y):
-    assert_equal(set(x), set(y))
+    assert set(x) == set(y)
 
 
 def test_trace_basic():
     simulation_json = json.dumps(single)
     response = subject.post('/trace', data = simulation_json, content_type = 'application/json')
-    assert_equal(response.status_code, OK)
+    assert response.status_code == OK
     response_json = json.loads(response.data.decode('utf-8'))
     disposable_income_value = dpath.util.get(response_json, 'trace/disposable_income<2017-01>/value')
     assert_is_instance(disposable_income_value, list)
@@ -59,4 +59,4 @@ def test_str_variable():
 
     response = subject.post('/trace', data = simulation_json, content_type = 'application/json')
 
-    assert_equal(response.status_code, OK)
+    assert response.status_code == OK

--- a/tests/web_api/test_variables.py
+++ b/tests/web_api/test_variables.py
@@ -8,7 +8,7 @@ from . import subject
 
 
 def assert_items_equal(x, y):
-    assert_equal(set(x), set(y))
+    assert set(x) == set(y)
 
 
 # /variables
@@ -18,7 +18,7 @@ GITHUB_URL_REGEX = r'^https://github\.com/openfisca/country-template/blob/\d+\.\
 
 
 def test_return_code():
-    assert_equal(variables_response.status_code, OK)
+    assert variables_response.status_code == OK
 
 
 def test_response_data():
@@ -37,7 +37,7 @@ def test_response_data():
 
 def test_error_code_non_existing_variable():
     response = subject.get('/variable/non_existing_variable')
-    assert_equal(response.status_code, NOT_FOUND)
+    assert response.status_code == NOT_FOUND
 
 
 input_variable_response = subject.get('/variable/birth')
@@ -45,11 +45,11 @@ input_variable = json.loads(input_variable_response.data.decode('utf-8'))
 
 
 def test_return_code_existing_input_variable():
-    assert_equal(input_variable_response.status_code, OK)
+    assert input_variable_response.status_code == OK
 
 
 def check_input_variable_value(key, expected_value):
-    assert_equal(input_variable[key], expected_value)
+    assert input_variable[key] == expected_value
 
 
 @pytest.mark.parametrize("expected_values", [
@@ -73,11 +73,11 @@ variable = json.loads(variable_response.data.decode('utf-8'))
 
 
 def test_return_code_existing_variable():
-    assert_equal(variable_response.status_code, OK)
+    assert variable_response.status_code == OK
 
 
 def check_variable_value(key, expected_value):
-    assert_equal(variable[key], expected_value)
+    assert variable[key] == expected_value
 
 
 @pytest.mark.parametrize("expected_values", [
@@ -97,7 +97,7 @@ def test_variable_formula_github_link():
 
 def test_variable_formula_content():
     formula_code = "def formula(person, period, parameters):\n    return person('salary', period) * parameters(period).taxes.income_tax_rate\n"
-    assert_equal(variable['formulas']['0001-01-01']['content'], formula_code)
+    assert variable['formulas']['0001-01-01']['content'] == formula_code
 
 
 def test_null_values_are_dropped():
@@ -117,8 +117,8 @@ def test_variable_with_start_and_stop_date():
 def test_variable_with_enum():
     response = subject.get('/variable/housing_occupancy_status')
     variable = json.loads(response.data.decode('utf-8'))
-    assert_equal(variable['valueType'], 'String')
-    assert_equal(variable['defaultValue'], 'tenant')
+    assert variable['valueType'] == 'String'
+    assert variable['defaultValue'] == 'tenant'
     assert_in('possibleValues', variable.keys())
     assert_equal(variable['possibleValues'], {
         'free_lodger': 'Free lodger',
@@ -132,7 +132,7 @@ dated_variable = json.loads(dated_variable_response.data.decode('utf-8'))
 
 
 def test_return_code_existing_dated_variable():
-    assert_equal(dated_variable_response.status_code, OK)
+    assert dated_variable_response.status_code == OK
 
 
 def test_dated_variable_formulas_dates():
@@ -151,7 +151,7 @@ def test_dated_variable_formulas_content():
 
 def test_variable_encoding():
     variable_response = subject.get('/variable/pension')
-    assert_equal(variable_response.status_code, OK)
+    assert variable_response.status_code == OK
 
 
 def test_variable_documentation():


### PR DESCRIPTION
Fixes #841 

When a user tries to set an input for a variable for several months (or several years), but the variable has no `set_input` declared, raise an error instead of ignoring the input.

> I couldn't resist removing some nose dependencies on the way. The real changes brought by this PR are in `holders.py` and `test_holders.py`.