### PR TITLE
Raise an error when keys are duplicated in parameters files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# 33.0.0
+
+### Breaking changes
+
+- Duplicate keys in YAML parameter files now raise an error
+    - Before, only one of the two values declared was taking into account, while the other was silently ignored
+
 ### 32.1.1 [#864](https://github.com/openfisca/openfisca-core/pull/864)
 
 - Fix host in the `/spec` route of the Web API

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -41,6 +41,17 @@ def date_constructor(loader, node):
     return node.value
 
 
+def dict_no_duplicate_constructor(loader, node, deep=False):
+    keys = [key.value for key, value in node.value]
+
+    if len(keys) != len(set(keys)):
+        duplicate = next((key for key in keys if keys.count(key) > 1))
+        raise yaml.parser.ParserError('', node.start_mark, f"Found duplicate key '{duplicate}'")
+
+    return loader.construct_mapping(node, deep)
+
+
+yaml.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, dict_no_duplicate_constructor, Loader = Loader)
 yaml.add_constructor('tag:yaml.org,2002:timestamp', date_constructor, Loader = Loader)
 
 

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -75,7 +75,7 @@ class ParameterNotFound(AttributeError):
         message += (
             " was not found in the {} tax and benefit system."
             ).format(instant_str)
-        super(ParameterNotFound, self).__init__(message.encode('utf-8'))
+        super(ParameterNotFound, self).__init__(message)
 
 
 class ParameterParsingError(Exception):
@@ -95,7 +95,7 @@ class ParameterParsingError(Exception):
                 message
                 ])
         if traceback is not None:
-            message = os.linesep.join([traceback, message]).encode('utf-8')
+            message = os.linesep.join([traceback, message])
         super(ParameterParsingError, self).__init__(message)
 
 
@@ -437,9 +437,9 @@ class ParameterNode(object):
         :param child: The new child, an instance of :any:`Scale` or :any:`Parameter` or :any:`ParameterNode`.
         """
         if name in self.children:
-            raise ValueError("{} has already a child named {}".format(self.name, name).encode('utf-8'))
+            raise ValueError("{} has already a child named {}".format(self.name, name))
         if not (isinstance(child, ParameterNode) or isinstance(child, Parameter) or isinstance(child, Scale)):
-            raise TypeError("child must be of type ParameterNode, Parameter, or Scale. Instead got {}".format(type(child)).encode('utf-8'))
+            raise TypeError("child must be of type ParameterNode, Parameter, or Scale. Instead got {}".format(type(child)))
         self.children[name] = child
         setattr(self, name, child)
 
@@ -518,7 +518,7 @@ class ParameterNodeAtInstant(object):
                 for name, value in self._children.items()]
             )
         if sys.version_info < (3, 0):
-            return result.encode('utf-8')
+            return result
         return result
 
 
@@ -568,7 +568,7 @@ class VectorialParameterNodeAtInstant(object):
                 node._name,
                 '.'.join([node_with_key, missing_key]),
                 '.'.join([node_without_key, missing_key]),
-                ).encode('utf-8')
+                )
 
             raise ValueError(message)
 
@@ -582,7 +582,7 @@ class VectorialParameterNodeAtInstant(object):
                 node._name,
                 node_name,
                 non_node_name,
-                ).encode('utf-8')
+                )
 
             raise ValueError(message)
 
@@ -595,7 +595,7 @@ class VectorialParameterNodeAtInstant(object):
                 node._name,
                 node_name,
                 node_type,
-                ).encode('utf-8')
+                )
             raise NotImplementedError(message)
 
         def extract_named_children(node):
@@ -817,7 +817,7 @@ def load_parameter_file(file_path, name = ''):
     :returns: An instance of :any:`ParameterNode` or :any:`Scale` or :any:`Parameter`.
     """
     if not os.path.exists(file_path):
-        raise ValueError("{} doest not exist".format(file_path).encode('utf-8'))
+        raise ValueError("{} doest not exist".format(file_path))
     if os.path.isdir(file_path):
         return ParameterNode(name, directory_path = file_path)
     data = _load_yaml_file(file_path)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ general_requirements = [
     'numpy >= 1.11, < 1.16',
     'psutil == 5.4.6',
     'PyYAML >= 3.10',
-    'ruamel.yaml >= 0.15.80, < 0.16',
     'sortedcontainers == 1.5.9',
     'numexpr == 2.6.8',
     ]

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '32.1.1',
+    version = '33.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/parameter_validation/duplicate_key.yaml
+++ b/tests/core/parameter_validation/duplicate_key.yaml
@@ -1,0 +1,6 @@
+description: Some parameter
+values:
+  2015-11-01:
+    value: 1.0
+  2015-11-01:
+    value: 2.0

--- a/tests/core/parameter_validation/test_parameter_validation.py
+++ b/tests/core/parameter_validation/test_parameter_validation.py
@@ -33,6 +33,7 @@ def check(file_name, keywords):
     ('wrong_type_in_brackets', {'must be of type array'}),
     ('wrong_type_in_bracket', {'must be of type object'}),
     ('missing_value', {'missing', 'value'}),
+    ('duplicate_key', {'duplicate'}),
     ])
 def test_parsing_errors(test):
     with pytest.raises(ParameterParsingError):

--- a/tests/core/parameters_fancy_indexing/test_fancy_indexing.py
+++ b/tests/core/parameters_fancy_indexing/test_fancy_indexing.py
@@ -17,7 +17,7 @@ P = parameters.rate('2015-01-01')
 
 
 def get_message(error):
-    return error.args[0].decode()
+    return error.args[0]
 
 
 def test_on_leaf():


### PR DESCRIPTION
#### Breaking changes

- Duplicate keys in YAML parameters files now raise an error
    - Before, only one of the two values declared was taking into account, while the other was silently ignored

#### Rationale
- Duplicate keys are easy to introduce by mistake while editing parameters files. They can cause bugs that are hard to detect immediately, and result in ambiguities in the code base that are hard to fix afterwards.

#### Performance impact

This implementation has no performance impact on the loading of the parameters file.

> For the record, a first approach trying to use `ruamel.yaml` instead of `pyyaml` ended up degrading the loading time (with C loader) by a factor of almost 2, and was abandoned. 