### PR TITLE
[WIP] Introduce subpopulations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ dist/
 .tags*
 .noseids
 .pytest_cache
-
+.mypy_cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 35.0.0
+
+#### Breaking changes
+
+- `population.ids` is now a NumPy array, and not a regular Python list.
+
+#### New features
+
+- Introduce `population.get_subpopbulation(condition)`
+  - This allow to extract a supopulation based on a condition
+  - Subpopulations can be used the same way than regular populations
+
+#### Technical notes
+
+- Subpopulations don't handle their own cache: they write and read in their super_population cache
+
+#### Minor changes
+
+- Add type-checking to the build
+
 ### 34.0.1
 
 #### Bug fix

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ clean:
 check-syntax-errors:
 	python -m compileall -q .
 
+check-types:
+	mypy openfisca_core && mypy openfisca_web_api
+
 check-style:
 	@# Do not analyse .gitignored files.
 	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
@@ -24,7 +27,7 @@ format-style:
 	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
 	autopep8 `git ls-files | grep "\.py$$"`
 
-test: clean check-syntax-errors check-style
+test: clean check-syntax-errors check-style check-types
 	env PYTEST_ADDOPTS="$$PYTEST_ADDOPTS --cov=openfisca_core" pytest
 
 api:

--- a/openfisca_core/commons.py
+++ b/openfisca_core/commons.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-import numpy as np
 from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
 
 
 class Dummy(object):
@@ -33,5 +35,11 @@ def stringify_array(array):
 
 @dataclass(frozen = True)
 class PartialArray:
+    """
+        Represents a value known for only a subset of a population.
+        ``mask`` has the size of the super-population, and is ``True`` for the K individuals the value is known for.
+        If ``mask`` is ``None``, the value is known for all individuals.
+        ``value`` contains the K known values.
+    """
     value: np.ndarray
-    mask: np.ndarray[bool] = None
+    mask: Optional[np.ndarray[bool]] = None

--- a/openfisca_core/commons.py
+++ b/openfisca_core/commons.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import annotations
+
+import numpy as np
+from dataclasses import dataclass
+
 
 class Dummy(object):
     """A class that does nothing
@@ -24,3 +29,9 @@ def stringify_array(array):
         str(cell)
         for cell in array
         )) if array is not None else 'None'
+
+
+@dataclass(frozen = True)
+class PartialArray:
+    value: np.ndarray
+    mask: np.ndarray[bool] = None

--- a/openfisca_core/data_storage.py
+++ b/openfisca_core/data_storage.py
@@ -2,50 +2,43 @@
 
 import shutil
 import os
+from typing import Dict, Optional
 
 import numpy as np
 
 from openfisca_core import periods
-from openfisca_core.periods import ETERNITY
+from openfisca_core.periods import Period, ETERNITY_PERIOD
 from openfisca_core.indexed_enums import EnumArray
-
+from openfisca_core.commons import PartialArray
 
 class InMemoryStorage(object):
     """
     Low-level class responsible for storing and retrieving calculated vectors in memory
     """
 
-    def __init__(self, is_eternal = False):
-        self._arrays = {}
+    def __init__(self, is_eternal:bool = False):
+        self._arrays: Dict = {}
         self.is_eternal = is_eternal
 
-    def get(self, period):
+    def get(self, period: Optional[Period]) -> Optional[PartialArray]:
         if self.is_eternal:
-            period = periods.period(ETERNITY)
-        period = periods.period(period)
+            period = ETERNITY_PERIOD
 
         values = self._arrays.get(period)
         if values is None:
             return None
-        if isinstance(values, dict):
-            return next(iter(values.values()))
         return values
 
-    def put(self, value, period):
+    def put(self, value: PartialArray, period: Optional[Period]):
         if self.is_eternal:
-            period = periods.period(ETERNITY)
-        period = periods.period(period)
+            period = ETERNITY_PERIOD
 
         self._arrays[period] = value
 
-    def delete(self, period = None):
-        if period is None:
+    def delete(self, period: Period = None):
+        if period is None or self.is_eternal:
             self._arrays = {}
             return
-
-        if self.is_eternal:
-            period = periods.period(ETERNITY)
-        period = periods.period(period)
 
         self._arrays = {
             period_item: value
@@ -77,12 +70,20 @@ class OnDiskStorage(object):
     Low-level class responsible for storing and retrieving calculated vectors on disk
     """
 
-    def __init__(self, storage_dir, is_eternal = False, preserve_storage_dir = False):
-        self._files = {}
-        self._enums = {}
+    def __init__(self, storage_dir: str, is_eternal: bool = False, preserve_storage_dir: bool = False):
+        self._files: Dict = {}
+        self._enums: Dict = {}
         self.is_eternal = is_eternal
         self.preserve_storage_dir = preserve_storage_dir
         self.storage_dir = storage_dir
+        self.values_dir = os.path.join(storage_dir, 'values')
+        self.masks_dir = os.path.join(storage_dir, 'masks')
+        if not os.path.isdir(self.storage_dir):
+            os.mkdir(self.storage_dir)
+        if not os.path.isdir(self.values_dir):
+            os.mkdir(self.values_dir)
+        if not os.path.isdir(self.masks_dir):
+            os.mkdir(self.masks_dir)
 
     def _decode_file(self, file):
         enum = self._enums.get(file)
@@ -91,46 +92,51 @@ class OnDiskStorage(object):
         else:
             return np.load(file)
 
-    def get(self, period):
+    def get(self, period: Optional[Period]) -> Optional[PartialArray]:
         if self.is_eternal:
-            period = periods.period(ETERNITY)
-        period = periods.period(period)
+            period = ETERNITY_PERIOD
 
         values = self._files.get(period)
         if values is None:
             return None
-        if isinstance(values, dict):
-            return self._decode_file(next(iter(values.values())))
-        return self._decode_file(values)
+        values_file, mask_file = values
+        values = self._decode_file(values_file)
+        mask = self._decode_file(mask_file) if mask_file else None
 
-    def put(self, value, period):
+        return PartialArray(values, mask)
+
+    def put(self, partial_array: PartialArray, period: Optional[Period]):
         if self.is_eternal:
-            period = periods.period(ETERNITY)
-        period = periods.period(period)
+            period = ETERNITY_PERIOD
+
+        value = partial_array.value
+        mask = partial_array.mask
 
         filename = str(period)
-        path = os.path.join(self.storage_dir, filename) + '.npy'
-        if isinstance(value, EnumArray):
-            self._enums[path] = value.possible_values
-            value = value.view(np.ndarray)
-        np.save(path, value)
-        self._files[period] = path
+        value_file = os.path.join(self.values_dir, filename) + '.npy'
+        mask_file =  os.path.join(self.masks_dir, filename) + '.npy'
 
-    def delete(self, period = None):
-        if period is None:
+        if isinstance(value, EnumArray):
+            self._enums[value_file] = value.possible_values
+            value = value.view(np.ndarray)
+
+        np.save(value_file, value)
+        if mask is not None:
+            np.save(mask_file, mask)
+            self._files[period] = (value_file, mask_file)
+        else:
+            self._files[period] = (value_file, None)
+
+    def delete(self, period: Optional[Period] = None):
+        if period is None or self.is_eternal:
             self._files = {}
             return
 
-        if self.is_eternal:
-            period = periods.period(ETERNITY)
-        period = periods.period(period)
-
-        if period is not None:
-            self._files = {
-                period_item: value
-                for period_item, value in self._files.items()
-                if not period.contains(period_item)
-                }
+        self._files = {
+            period_item: value
+            for period_item, value in self._files.items()
+            if not period.contains(period_item)
+            }
 
     def get_known_periods(self):
         return self._files.keys()
@@ -138,13 +144,16 @@ class OnDiskStorage(object):
     def restore(self):
         self._files = files = {}
         # Restore self._files from content of storage_dir.
-        for filename in os.listdir(self.storage_dir):
+        for filename in os.listdir(self.values_dir):
             if not filename.endswith('.npy'):
                 continue
-            path = os.path.join(self.storage_dir, filename)
+            values_file = os.path.join(self.values_dir, filename)
+            masks_file = os.path.join(self.masks_dir, filename)
+            if not os.path.isfile(masks_file):
+                masks_file = None
             filename_core = filename.rsplit('.', 1)[0]
             period = periods.period(filename_core)
-            files[period] = path
+            files[period] = (values_file, masks_file)
 
     def __del__(self):
         if self.preserve_storage_dir:

--- a/openfisca_core/data_storage.py
+++ b/openfisca_core/data_storage.py
@@ -11,12 +11,13 @@ from openfisca_core.periods import Period, ETERNITY_PERIOD
 from openfisca_core.indexed_enums import EnumArray
 from openfisca_core.commons import PartialArray
 
+
 class InMemoryStorage(object):
     """
     Low-level class responsible for storing and retrieving calculated vectors in memory
     """
 
-    def __init__(self, is_eternal:bool = False):
+    def __init__(self, is_eternal: bool = False):
         self._arrays: Dict = {}
         self.is_eternal = is_eternal
 
@@ -114,7 +115,7 @@ class OnDiskStorage(object):
 
         filename = str(period)
         value_file = os.path.join(self.values_dir, filename) + '.npy'
-        mask_file =  os.path.join(self.masks_dir, filename) + '.npy'
+        mask_file = os.path.join(self.masks_dir, filename) + '.npy'
 
         if isinstance(value, EnumArray):
             self._enums[value_file] = value.possible_values

--- a/openfisca_core/data_storage.py
+++ b/openfisca_core/data_storage.py
@@ -64,18 +64,11 @@ class InMemoryStorage(object):
                 cell_size = np.nan,
                 )
 
-        nb_arrays = sum([
-            len(array_or_dict) if isinstance(array_or_dict, dict) else 1
-            for array_or_dict in self._arrays.values()
-            ])
-
-        array = next(iter(self._arrays.values()))
-        if isinstance(array, dict):
-            array = array.values()[0]
+        values = [partial_array.value for partial_array in self._arrays.values()]
         return dict(
-            nb_arrays = nb_arrays,
-            total_nb_bytes = array.nbytes * nb_arrays,
-            cell_size = array.itemsize,
+            nb_arrays = len(self._arrays),
+            total_nb_bytes = sum(value.nbytes for value in values),
+            cell_size = values[0].itemsize,
             )
 
 

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -23,6 +23,7 @@ class Entity(object):
     """
         Represents an entity (e.g. a person, a household, etc.) on which calculations can be run.
     """
+
     def __init__(self, key, plural, label, doc):
         self.key = key
         self.label = label
@@ -58,6 +59,7 @@ class GroupEntity(Entity):
     """
         Represents an entity composed of several persons with different roles, on which calculations are run.
     """
+
     def __init__(self, key, plural, label, doc, roles):
         super().__init__(key, plural, label, doc)
         self.roles_description = roles

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import warnings
+from typing import Optional
 
 import numpy as np
 import psutil
@@ -114,6 +115,7 @@ class Holder(object):
             return value
         if self._disk_storage:
             return self._disk_storage.get(period)
+        return None
 
     def get_memory_usage(self):
         """
@@ -221,14 +223,14 @@ class Holder(object):
                     .format(value, self.variable.name, self.variable.dtype, value.dtype))
         return value
 
-    def _check_value_size(self, value: np.ndarray, mask: np.ndarray[Bool] = None):
+    def _check_value_size(self, value: np.ndarray, mask: np.ndarray[bool] = None):
         count = self.population.count if mask is None else np.sum(mask)
         if len(value) != count:
             raise ValueError(
                 f'Unable to set value "{value}" for variable "{self.variable.name}", as its length is {len(value)} while there are {self.population.count} {self.population.entity.plural} in the simulation.'
                 )
 
-    def _set(self, period: Period, value: np.ndarray, mask: np.ndarray[Bool] = None):
+    def _set(self, period: Period, value: np.ndarray, mask: np.ndarray[bool] = None):
         value = self._to_array(value)
         self._check_value_size(value, mask)
         if self.variable.definition_period != ETERNITY:
@@ -263,7 +265,7 @@ class Holder(object):
         else:
             self._memory_storage.put(partial_array, period)
 
-    def put_in_cache(self, value: np.ndarray, period: Period, mask: np.ndarray[Bool] = None):
+    def put_in_cache(self, value: np.ndarray, period: Period, mask: np.ndarray[bool] = None):
         if self._do_not_store:
             return
 
@@ -366,4 +368,4 @@ from dataclasses import dataclass
 @dataclass(frozen = True)
 class PartialArray:
     value: np.ndarray
-    mask: np.ndarray[Bool] = None
+    mask: np.ndarray[bool] = None

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -99,7 +99,7 @@ class Holder(object):
         if cached_array.mask is None:
             return cached_array.value
 
-        return np.ma.masked_array(
+        return np.ma.masked_array(  # Masked arrays are a subclass of NumPy arrays that have missing values.
             combine([(cached_array.mask, cached_array.value)]),
             np.logical_not(cached_array.mask)
             )

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -85,7 +85,6 @@ class Holder(object):
         if self._disk_storage:
             self._disk_storage.delete(period)
 
-
     def get_array(self, period: Optional[CastableToPeriod]) -> Optional[np.ndarray]:
         """
             Get the value of the variable for the given period.
@@ -103,7 +102,7 @@ class Holder(object):
         return np.ma.masked_array(
             combine([(cached_array.mask, cached_array.value)]),
             np.logical_not(cached_array.mask)
-        )
+            )
 
     def get_cached_array(self, period: Optional[Period]) -> Optional[PartialArray]:
         if self.variable.is_neutralized:

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -247,12 +247,12 @@ class Holder(object):
 
         self._set(period, value)
 
-    def default_array(self):
+    def default_array(self, mask = None):
         """
         Return a new array of the appropriate length for the entity, filled with the variable default values.
         """
-
-        return self.variable.default_array(self.population.count)
+        if mask:
+            return self.variable.default_array(self.population.count)
 
 
 def set_input_dispatch_by_period(holder, period, array):

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -17,7 +17,7 @@ from openfisca_core.data_storage import InMemoryStorage, OnDiskStorage
 from openfisca_core.errors import PeriodMismatchError
 from openfisca_core.indexed_enums import Enum
 from openfisca_core.periods import MONTH, YEAR, ETERNITY
-from openfisca_core.tools import eval_expression, ternary_combine
+from openfisca_core.tools import eval_expression, combine
 
 log = logging.getLogger(__name__)
 
@@ -101,7 +101,7 @@ class Holder(object):
             return cached_array.value
 
         return np.ma.masked_array(
-            ternary_combine(cached_array.mask, cached_array.value, np.nan),
+            combine([(cached_array.mask, cached_array.value)]),
             np.logical_not(cached_array.mask)
         )
 

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -247,12 +247,11 @@ class Holder(object):
 
         self._set(period, value)
 
-    def default_array(self, mask = None):
+    def default_array(self):
         """
         Return a new array of the appropriate length for the entity, filled with the variable default values.
         """
-        if mask:
-            return self.variable.default_array(self.population.count)
+        return self.variable.default_array(self.population.count)
 
 
 def set_input_dispatch_by_period(holder, period, array):

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -8,7 +8,7 @@ import os
 import sys
 import logging
 import traceback
-from typing import Union, Iterable
+from typing import Optional, Iterable
 
 import yaml
 import numpy as np
@@ -326,7 +326,7 @@ class ParameterNode(object):
         A node in the legislation `parameter tree <https://openfisca.org/doc/coding-the-legislation/legislation_parameters.html>`_.
     """
 
-    _allowed_keys: Union[None, Iterable[str]] = None  # By default, no restriction on the keys
+    _allowed_keys: Optional[Iterable[str]] = None  # By default, no restriction on the keys
 
     def __init__(self, name = "", directory_path = None, data = None, file_path = None):
         """

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -8,6 +8,7 @@ import os
 import sys
 import logging
 import traceback
+from typing import Union, Iterable
 
 import yaml
 import numpy as np
@@ -26,7 +27,7 @@ try:
 except ImportError:
     log.warning(
         "libyaml is not installed in your environment. This can make OpenFisca slower to start. Once you have installed libyaml, run 'pip uninstall pyyaml && pip install pyyaml --no-cache-dir' so that it is used in your Python environment." + os.linesep)
-    from yaml import Loader
+    from yaml import Loader  # type: ignore # (see https://github.com/python/mypy/issues/1153#issuecomment-455802270)
 
 
 FILE_EXTENSIONS = {'.yaml', '.yml'}
@@ -325,7 +326,7 @@ class ParameterNode(object):
         A node in the legislation `parameter tree <https://openfisca.org/doc/coding-the-legislation/legislation_parameters.html>`_.
     """
 
-    _allowed_keys = None  # By default, no restriction on the keys
+    _allowed_keys: Union[None, Iterable[str]] = None  # By default, no restriction on the keys
 
     def __init__(self, name = "", directory_path = None, data = None, file_path = None):
         """

--- a/openfisca_core/periods.py
+++ b/openfisca_core/periods.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import annotations
+
 
 """Toolbox to handle date intervals
 
@@ -12,7 +14,7 @@ import calendar
 import datetime
 import re
 from os import linesep
-from typing import Dict
+from typing import Dict, Union
 
 
 DAY = 'day'
@@ -785,7 +787,13 @@ def instant_date(instant):
     return instant_date
 
 
-def period(value):
+CastableToPeriod = Union[str, int, Instant, Period]
+
+
+ETERNITY_PERIOD = Period(('eternity', instant(datetime.date.min), float("inf")))
+
+
+def period(value: CastableToPeriod) -> Period:
     """Return a new period, aka a triple (unit, start_instant, size).
 
     >>> period('2014')
@@ -839,7 +847,7 @@ def period(value):
         raise ValueError(message)
 
     if value == 'ETERNITY' or value == ETERNITY:
-        return Period(('eternity', instant(datetime.date.min), float("inf")))
+        return ETERNITY_PERIOD
 
     # check the type
     if isinstance(value, int):

--- a/openfisca_core/periods.py
+++ b/openfisca_core/periods.py
@@ -12,6 +12,7 @@ import calendar
 import datetime
 import re
 from os import linesep
+from typing import Dict
 
 
 DAY = 'day'
@@ -26,8 +27,8 @@ def N_(message):
     return message
 
 
-date_by_instant_cache = {}
-str_by_instant_cache = {}
+date_by_instant_cache: Dict = {}
+str_by_instant_cache: Dict = {}
 year_or_month_or_day_re = re.compile(r'(18|19|20)\d{2}(-(0?[1-9]|1[0-2])(-([0-2]?\d|3[0-1]))?)?$')
 
 

--- a/openfisca_core/populations.py
+++ b/openfisca_core/populations.py
@@ -572,6 +572,9 @@ class Projector(object):
         projector.parent = self
         return projector
 
+    @property
+    def ids(self):
+        return self.transform_and_bubble_up(self.reference_entity.ids)
 
 # For instance person.family
 class EntityToPersonProjector(Projector):

--- a/openfisca_core/populations.py
+++ b/openfisca_core/populations.py
@@ -627,7 +627,7 @@ class SubPopulation(Population):
         if cache_content is None:
             return self.population.put_in_cache(variable_name, period, array, mask = self.condition)
 
-        new_mask = cache_content.mask + self.condition  # all indials for whom the value is known
+        new_mask = cache_content.mask + self.condition
         new_array = combine([
             (self.condition[new_mask], array),
             (cache_content.mask[new_mask], cache_content.value)

--- a/openfisca_core/populations.py
+++ b/openfisca_core/populations.py
@@ -604,7 +604,13 @@ class GroupSubPopulation(GroupPopulation, SubPopulation):
 
     @cached_property
     def members_entity_id(self):
-        return self.population.members_entity_id[self.members.condition]
+        members_entity_id_in_population = self.population.members_entity_id[self.members.condition]
+
+        # This step is necessary to preserve the invariant that entity indices are consecutive.
+        # Will for instance change [0,0,2,5] to [0,0,1,2]
+        _, result = np.unique(members_entity_id_in_population, return_inverse = True)
+
+        return result
 
     @cached_property
     def members_role(self):

--- a/openfisca_core/populations.py
+++ b/openfisca_core/populations.py
@@ -70,7 +70,7 @@ class Population(object):
         return projector
 
     def get_index(self, id):
-        return self.ids.index(id)
+        return np.where(self.ids == id)[0][0]
 
     # Calculations
 
@@ -119,7 +119,7 @@ class Population(object):
     # Helpers
 
     def get_cached_array(self, variable_name: str, period: Period) -> Optional[PartialArray]:
-        return self.get_holder(variable_name).get_array(period)
+        return self.get_holder(variable_name).get_cached_array(period)
 
     def default_array(self, variable_name: str) -> np.ndarray:
         return self.get_holder(variable_name).default_array()

--- a/openfisca_core/populations.py
+++ b/openfisca_core/populations.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import traceback
+import os
 
 from typing import Iterable
 
@@ -66,13 +67,13 @@ class Population(object):
         if period is None:
             stack = traceback.extract_stack()
             filename, line_number, function_name, line_of_code = stack[-3]
-            raise ValueError('''
-You requested computation of variable "{}", but you did not specify on which period in "{}:{}":
-    {}
-When you request the computation of a variable within a formula, you must always specify the period as the second parameter. The convention is to call this parameter "period". For example:
-    computed_salary = person('salary', period).
-See more information at <https://openfisca.org/doc/coding-the-legislation/35_periods.html#periods-in-variable-definition>.
-'''.format(variable_name, filename, line_number, line_of_code))
+            raise ValueError(os.linesep.join([
+                f'You requested computation of variable "{variable_name}", but you did not specify on which period in "{filename}:{line_number}":',
+                f'    {line_of_code}',
+                f'When you request the computation of a variable within a formula, you must always specify the period as the second parameter. The convention is to call this parameter "period". For example:',
+                f'    computed_salary = person(\'salary\', period).',
+                f'See more information at <https://openfisca.org/doc/coding-the-legislation/35_periods.html#periods-in-variable-definition>.',
+            ]))
 
     def __call__(self, variable_name, period = None, options = None, **parameters):
         """

--- a/openfisca_core/populations.py
+++ b/openfisca_core/populations.py
@@ -650,11 +650,18 @@ class SubPopulation(Population):
         if cache_content is None:
             return self.population.put_in_cache(variable_name, period, array, mask = self.condition)
 
-        new_mask = cache_content.mask + self.condition
-        new_array = combine([
-            (self.condition[new_mask], array),
-            (cache_content.mask[new_mask], cache_content.value)
-        ])
+        if cache_content.mask is None:  # All valus are alredy in cache
+            new_mask = None
+            new_array = combine([
+                (self.condition, array),
+                (True, cache_content.value)
+            ])
+        else:
+            new_mask = cache_content.mask + self.condition
+            new_array = combine([
+                (self.condition[new_mask], array),
+                (cache_content.mask[new_mask], cache_content.value)
+            ])
         return self.population.put_in_cache(variable_name, period, new_array, mask = new_mask)
 
     def get_subpopulation(self, condition: np.ndarray[bool]) -> SubPopulation:

--- a/openfisca_core/populations.py
+++ b/openfisca_core/populations.py
@@ -214,6 +214,8 @@ class Population(object):
         result[condition] = sub_result
         return result
 
+    def get_subpopulation(self, condition):
+        return SubPopulation(self, condition)
 
 
 class GroupPopulation(Population):
@@ -288,6 +290,9 @@ class GroupPopulation(Population):
     @members_position.setter
     def members_position(self, members_position):
         self._members_position = members_position
+
+    def get_subpopulation(self, condition):
+        return GroupSubPopulation(self, condition)
 
     #  Aggregation persons -> entity
 

--- a/openfisca_core/populations.py
+++ b/openfisca_core/populations.py
@@ -37,7 +37,17 @@ class Population(object):
         self.entity = entity
         self._holders = {}
         self.count = 0
-        self.ids = []
+        self._ids = np.asarray([])
+
+    @property
+    def ids(self):
+        return self._ids
+
+    @ids.setter
+    def ids(self, ids: Iterable[str]):
+        if isinstance(ids, np.ndarray):
+            self._ids = ids
+        self._ids = np.asarray(ids)
 
     def clone(self, simulation):
         result = Population(self.entity)

--- a/openfisca_core/populations.py
+++ b/openfisca_core/populations.py
@@ -110,9 +110,9 @@ class Population(object):
         if ADD in options and DIVIDE in options:
             raise ValueError('Options ADD and DIVIDE are incompatible (trying to compute variable {})'.format(variable_name).encode('utf-8'))
         elif ADD in options:
-            return self.simulation.calculate_add(variable_name, period, **parameters)
+            return self.simulation.calculate_add(_self, variable_name, period, **parameters)
         elif DIVIDE in options:
-            return self.simulation.calculate_divide(variable_name, period, **parameters)
+            return self.simulation.calculate_divide_(self, variable_name, period, **parameters)
         else:
             return self.simulation.calculate_(self, variable_name, period, **parameters)
 

--- a/openfisca_core/populations.py
+++ b/openfisca_core/populations.py
@@ -614,6 +614,8 @@ class SubPopulation(Population):
             return
         if population_cached_array.mask is None:
             return PartialArray(population_cached_array.value[self.condition], None)
+        if not np.any(population_cached_array.mask * self.condition):
+            return
 
         mask = population_cached_array.mask[self.condition]
         cached_array = population_cached_array.value[self.condition[population_cached_array.mask]]

--- a/openfisca_core/populations.py
+++ b/openfisca_core/populations.py
@@ -13,6 +13,7 @@ from openfisca_core.entities import Role
 from openfisca_core.indexed_enums import EnumArray
 from openfisca_core.holders import Holder, PartialArray
 from openfisca_core.periods import Period
+from openfisca_core.tools import combine
 
 
 ADD = 'add'
@@ -613,6 +614,11 @@ class SubPopulation(Population):
             return
         if population_cached_array.mask is None:
             return PartialArray(population_cached_array.value[self.condition], None)
+
+        mask = population_cached_array.mask[self.condition]
+        cached_array = population_cached_array.value[self.condition[population_cached_array.mask]]
+
+        return PartialArray(cached_array, mask)
 
     def put_in_cache(self, variable_name: str, period: Period, array: np.ndarray):
         self.population.get_holder(variable_name).put_in_cache(array, period, mask = self.condition)

--- a/openfisca_core/projectors.py
+++ b/openfisca_core/projectors.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+import abc
+import typing
+from typing import Optional
+
+import numpy as np
+
+if typing.TYPE_CHECKING:
+    from openfisca_core.populations import GroupPopulation, Population
+
+
+class Projector(abc.ABC):
+    reference_population: Population
+    parent: Optional[Projector]
+
+    def __getattr__(self, attribute):
+        projector = self.get_projector(attribute)
+        if projector:
+            return projector
+
+        reference_attr = getattr(self.reference_population, attribute)
+        if not hasattr(reference_attr, 'projectable'):
+            return reference_attr
+
+        def projector_function(*args, **kwargs):
+            result = reference_attr(*args, **kwargs)
+            return self.transform_and_bubble_up(result)
+
+        return projector_function
+
+    def __call__(self, *args, **kwargs):
+        result = self.reference_population(*args, **kwargs)
+        return self.transform_and_bubble_up(result)
+
+    def transform_and_bubble_up(self, result):
+        transformed_result = self.transform(result)
+        if self.parent is None:
+            return transformed_result
+        else:
+            return self.parent.transform_and_bubble_up(transformed_result)
+
+    @abc.abstractmethod
+    def transform(self, result):
+        pass
+
+    def get_projector(self, attribute: str):
+        projector = self.reference_population.get_projector(attribute)
+        if not projector:
+            return
+        projector.parent = self
+        return projector
+
+    @property
+    def ids(self):
+        return self.transform_and_bubble_up(self.reference_population.ids)
+
+
+# For instance person.family
+class EntityToPersonProjector(Projector):
+
+    def __init__(self, group_population, parent = None):
+        self.reference_population = group_population
+        self.parent = parent
+
+    def transform(self, result):
+        return self.reference_population.project(result)
+
+
+# For instance famille.first_person
+class FirstPersonToEntityProjector(Projector):
+
+    def __init__(self, group_population, parent = None):
+        self.target_population = group_population
+        self.reference_population = group_population.members
+        self.parent = parent
+
+    def transform(self, result):
+        return self.target_population.value_from_first_person(result)
+
+
+# For instance famille.declarant_principal
+class UniqueRoleToEntityProjector(Projector):
+
+    def __init__(self, group_population, role, parent = None):
+        self.target_population = group_population
+        self.reference_population = group_population.members
+        self.parent = parent
+        self.role = role
+
+    def transform(self, result):
+        return self.target_population.value_from_person(result, self.role)
+
+
+# For instance person.family, where person is a sub-population
+class EntityToSubPopulationProjector(Projector):
+
+    def __init__(self, group_population: GroupPopulation, condition: np.ndarray[bool], parent: Projector = None):
+        self.reference_population = group_population.get_subpopulation(
+            group_population.any(condition)
+            )  # we'll run calculations only on a sub-population of the groups
+        self.parent = parent
+        self.condition = condition
+
+    def transform(self, result):
+        result = self.reference_population.project(result)  # projected on all members of the group subpopulation, but that's more than what we need
+        relative_condition = self.condition[self.reference_population.members_condition]  # condition to find the original subpopulation within the group sup-population members
+
+        return result[relative_condition]

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -134,7 +134,7 @@ class Simulation(object):
         if cached_array is not None and cached_array.mask is None:  # The value is known for the whole population
             if self.trace:
                 self.tracer.record_calculation_end(variable.name, period, cached_array, **parameters)
-            return cached_array
+            return cached_array.value
 
         if cached_array is not None:  # The value is known for only a subpopulation
             complem_population = population.get_subpopulation(np.logical_not(cached_array.mask))

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -12,7 +12,7 @@ from openfisca_core.commons import empty_clone, stringify_array
 from openfisca_core.tracers import Tracer, TracingParameterNodeAtInstant
 from openfisca_core.indexed_enums import Enum, EnumArray
 from openfisca_core.populations import SubPopulation
-from openfisca_core.tools import combine
+from openfisca_core.tools import ternary_combine
 from openfisca_core.holders import PartialArray
 
 log = logging.getLogger(__name__)
@@ -139,7 +139,7 @@ class Simulation(object):
         if cached_array is not None:  # The value is known for only a subpopulation
             complem_population = population.get_subpopulation(np.logical_not(cached_array.mask))
             result_comp_pop = self.calculate_(complem_population, variable_name, period, **parameters)
-            result = combine(cached_array.mask, cached_array.value, result_comp_pop)
+            result = ternary_combine(cached_array.mask, cached_array.value, result_comp_pop)
             population.put_in_cache(variable_name, period, result)
             return result
 

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -140,7 +140,6 @@ class Simulation(object):
             complem_population = population.get_subpopulation(np.logical_not(cached_array.mask))
             result_comp_pop = self.calculate_(complem_population, variable_name, period, **parameters)
             result = ternary_combine(cached_array.mask, cached_array.value, result_comp_pop)
-            population.put_in_cache(variable_name, period, result)
             return result
 
 

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -115,7 +115,7 @@ class Simulation(object):
         """
 
         population = self.get_variable_population(variable_name)
-        return self._calculate(population, variable_name, period, **parameters)
+        return self.calculate_(population, variable_name, period, **parameters)
 
     def calculate_(self, population, variable_name, period, **parameters):
         variable = self.tax_benefit_system.get_variable(variable_name, check_existence = True)

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -176,6 +176,10 @@ class Simulation(object):
             holder.delete_arrays(_period)
 
     def calculate_add(self, variable_name, period, **parameters):
+        population = self.get_variable_population(variable_name)
+        return self.calculate_add_(population, variable_name, period, **parameters)
+
+    def calculate_add_(self, population, variable_name, period, **parameters):
         variable = self.tax_benefit_system.get_variable(variable_name, check_existence = True)
 
         if period is not None and not isinstance(period, periods.Period):
@@ -195,11 +199,15 @@ class Simulation(object):
                 period))
 
         return sum(
-            self.calculate(variable_name, sub_period, **parameters)
+            self.calculate_(population, variable_name, sub_period, **parameters)
             for sub_period in period.get_subperiods(variable.definition_period)
             )
 
     def calculate_divide(self, variable_name, period, **parameters):
+        population = self.get_variable_population(variable_name)
+        return self.calculate_divide_(population, variable_name, period, **parameters)
+
+    def calculate_divide_(self, population, variable_name, period, **parameters):
         variable = self.tax_benefit_system.get_variable(variable_name, check_existence = True)
 
         if period is not None and not isinstance(period, periods.Period):
@@ -216,9 +224,9 @@ class Simulation(object):
 
         if period.unit == periods.MONTH:
             computation_period = period.this_year
-            return self.calculate(variable_name, period = computation_period, **parameters) / 12.
+            return self.calculate_(population, variable_name, period = computation_period, **parameters) / 12.
         elif period.unit == periods.YEAR:
-            return self.calculate(variable_name, period, **parameters)
+            return self.calculate_(population, variable_name, period, **parameters)
 
         raise ValueError("Unable to divide the value of '{}' to match period {}.".format(
             variable_name,

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -11,9 +11,7 @@ from openfisca_core import periods
 from openfisca_core.commons import empty_clone, stringify_array
 from openfisca_core.tracers import Tracer, TracingParameterNodeAtInstant
 from openfisca_core.indexed_enums import Enum, EnumArray
-from openfisca_core.populations import SubPopulation
 from openfisca_core.tools import ternary_combine
-from openfisca_core.commons import PartialArray
 from openfisca_core.holders import Holder
 
 log = logging.getLogger(__name__)
@@ -144,7 +142,6 @@ class Simulation(object):
             if self.trace:
                 self._record_calculation_end(variable_name, period)
             return result
-
 
         array = None
 

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -13,7 +13,8 @@ from openfisca_core.tracers import Tracer, TracingParameterNodeAtInstant
 from openfisca_core.indexed_enums import Enum, EnumArray
 from openfisca_core.populations import SubPopulation
 from openfisca_core.tools import ternary_combine
-from openfisca_core.holders import PartialArray
+from openfisca_core.commons import PartialArray
+from openfisca_core.holders import Holder
 
 log = logging.getLogger(__name__)
 
@@ -383,7 +384,7 @@ class Simulation(object):
             period = periods.period(period)
         return self.get_holder(variable_name).get_array(period)
 
-    def get_holder(self, variable_name):
+    def get_holder(self, variable_name: str) -> Holder:
         """
             Get the :any:`Holder` associated with the variable ``variable_name`` for the simulation
         """

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -278,7 +278,7 @@ class Simulation(object):
                 'month' if variable.definition_period == periods.MONTH else 'year'
                 ))
 
-    def _check_formula_result(self, value, variable, entity, period):
+    def _check_formula_result(self, value, variable, population, period):
 
         assert isinstance(value, np.ndarray), (linesep.join([
             "You tried to compute the formula '{0}' for the period '{1}'.".format(variable.name, str(period)),
@@ -287,11 +287,10 @@ class Simulation(object):
             "Learn more about Numpy arrays and vectorial computing:",
             "<https://openfisca.org/doc/coding-the-legislation/25_vectorial_computing.html.>"
             ]))
-
-        assert value.size == entity.count, \
+        assert value.size == population.count, \
             "Function {}@{}<{}>() --> <{}>{} returns an array of size {}, but size {} is expected for {}".format(
-                variable.name, entity.key, str(period), str(period), stringify_array(value),
-                value.size, entity.count, entity.key)
+                variable.name, population.entity.key, str(period), str(period), stringify_array(value),
+                value.size, population.count, population.entity.key)
 
         if self.debug:
             try:
@@ -299,7 +298,7 @@ class Simulation(object):
                 if np.isnan(np.min(value)):
                     nan_count = np.count_nonzero(np.isnan(value))
                     raise NaNCreationError("Function {}@{}<{}>() --> <{}>{} returns {} NaN value(s)".format(
-                        variable.name, entity.key, str(period), str(period), stringify_array(value),
+                        variable.name, population.entity.key, str(period), str(period), stringify_array(value),
                         nan_count))
             except TypeError:
                 pass

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -140,7 +140,7 @@ class Simulation(object):
         # First, try to run a formula
         try:
             self._check_for_cycle(variable, period)
-            array = self._run_formula(variable, population if mask is None else SubPopulation(population, mask), period)
+            array = self._run_formula(variable, population if mask is None else population.get_subpopulation(mask), period)
 
             # If no result, use the default value and cache it
             if array is None:

--- a/openfisca_core/tools/__init__.py
+++ b/openfisca_core/tools/__init__.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import annotations
+
 
 import os
 
 import numexpr
+import numpy as np
 
 from openfisca_core.indexed_enums import EnumArray
 
@@ -76,3 +79,10 @@ def eval_expression(expression):
         return numexpr.evaluate(expression)
     except (KeyError, TypeError):
         return expression
+
+
+def combine(condition: np.ndarray[Bool], value_for_trues: np.ndarray, values_for_falses: np.ndarray) -> np.ndarray:
+    result = np.zeros(condition.size, dtype = value_for_trues.dtype)
+    result[condition] = value_for_trues
+    result[np.logical_not(condition)] = values_for_falses
+    return result

--- a/openfisca_core/tools/__init__.py
+++ b/openfisca_core/tools/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 
 import os
+from typing import Sequence, Tuple
 
 import numexpr
 import numpy as np
@@ -81,14 +82,14 @@ def eval_expression(expression):
         return expression
 
 
-def ternary_combine(condition: Array[Bool], value_for_trues: Array, values_for_falses: Array) -> Array:
+def ternary_combine(condition: np.ndarray[bool], value_for_trues: np.ndarray, values_for_falses: np.ndarray) -> np.ndarray:
     return combine([
         (condition, value_for_trues),
         (np.logical_not(condition), values_for_falses)
         ])
 
 
-def combine(cond_values_pairs: Iterable[Array[Bool], Array]) -> Array:
+def combine(cond_values_pairs: Sequence[Tuple[np.ndarray[bool], np.ndarray]]) -> np.ndarray:
     cond_1, value_1 = cond_values_pairs[0]
     result = np.empty(cond_1.size, dtype = value_1.dtype)
 

--- a/openfisca_core/tools/__init__.py
+++ b/openfisca_core/tools/__init__.py
@@ -81,8 +81,17 @@ def eval_expression(expression):
         return expression
 
 
-def combine(condition: np.ndarray[Bool], value_for_trues: np.ndarray, values_for_falses: np.ndarray) -> np.ndarray:
-    result = np.zeros(condition.size, dtype = value_for_trues.dtype)
-    result[condition] = value_for_trues
-    result[np.logical_not(condition)] = values_for_falses
+def ternary_combine(condition: Array[Bool], value_for_trues: Array, values_for_falses: Array) -> Array:
+    return combine([
+        (condition, value_for_trues),
+        (np.logical_not(condition), values_for_falses)
+        ])
+
+
+def combine(cond_values_pairs: Iterable[Array[Bool], Array]) -> Array:
+    cond_1, value_1 = cond_values_pairs[0]
+    result = np.empty(cond_1.size, dtype = value_1.dtype)
+
+    for (condition, values) in reversed(cond_values_pairs):  # start with the last value to give priority to the first one
+        result[condition] = values
     return result

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -5,6 +5,7 @@ import sys
 import os
 import traceback
 import textwrap
+from typing import Dict
 
 import pytest
 
@@ -34,7 +35,7 @@ TEST_KEYWORDS = {'absolute_error_margin', 'description', 'extensions', 'ignore_v
 
 yaml, Loader = import_yaml()
 
-_tax_benefit_system_cache = {}
+_tax_benefit_system_cache: Dict = {}
 
 
 def run_tests(tax_benefit_system, paths, options = None):

--- a/openfisca_core/tracers.py
+++ b/openfisca_core/tracers.py
@@ -89,18 +89,17 @@ class Tracer(object):
         return new
 
     @staticmethod
-    def _get_key(variable_name, period, **parameters):
+    def _get_key(variable_name, period):
         return "{}<{}>".format(variable_name, period)
 
-    def record_calculation_start(self, variable_name, period, **parameters):
+    def record_calculation_start(self, variable_name, period):
         """
             Record that OpenFisca started computing a variable.
 
             :param str variable_name: Name of the variable starting to be computed
             :param Period period: Period for which the variable is being computed
-            :param list parameters: Parameter with which the variable is being computed
         """
-        key = self._get_key(variable_name, period, **parameters)
+        key = self._get_key(variable_name, period)
 
         if self.stack:  # The variable is a dependency of another variable
             parent = self.stack[-1]
@@ -128,16 +127,15 @@ class Tracer(object):
             )
         self.trace[parent]['parameters'][parameter_key] = value
 
-    def record_calculation_end(self, variable_name, period, result, **parameters):
+    def record_calculation_end(self, variable_name, period, result):
         """
             Record that OpenFisca finished computing a variable.
 
             :param str variable_name: Name of the variable starting to be computed
             :param Period period: Period for which the variable is being computed
             :param numpy.ndarray result: Result of the computation
-            :param list parameters: Parameter with which the variable is being computed
         """
-        key = self._get_key(variable_name, period, **parameters)
+        key = self._get_key(variable_name, period)
         expected_key = self.stack.pop()
 
         if not key == expected_key:
@@ -185,7 +183,7 @@ class Tracer(object):
 
     def print_trace(self, variable_name, period, max_depth = 1, aggregate = False, ignore_zero = False):
         """
-            Print value, the dependencies, and the dependencies values of the variable for the given period (and possibly the given set of extra parameters).
+            Print value, the dependencies, and the dependencies values of the variable for the given period.
 
             :param str variable_name: Name of the variable to investigate
             :param Period period: Period to investigate

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,3 +17,9 @@ in-place     = true
 addopts      = --showlocals --doctest-modules --disable-pytest-warnings
 testpaths    = tests
 python_files = **/*.py
+
+[mypy]
+ignore_missing_imports = True
+
+[mypy-openfisca_core.scripts.*]
+ignore_errors = True

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ dev_requirements = [
     'flake8-bugbear >= 19.3.0, < 20.0.0',
     'flake8-print >= 3.1.0, < 4.0.0',
     'pytest-cov >= 2.6.1, < 3.0.0',
+    'mypy >= 0.701, < 0.800',
     'openfisca-country-template >= 3.6.0rc0, < 4.0.0',
     'openfisca-extension-template >= 1.2.0rc0, < 2.0.0'
     ] + api_requirements

--- a/tests/core/test_data_storage.py
+++ b/tests/core/test_data_storage.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+import tempfile
+
+import numpy as np
+from numpy.testing import assert_array_equal
+from pytest import fixture
+
+from openfisca_core.data_storage import OnDiskStorage
+from openfisca_core.commons import PartialArray
+from openfisca_core.periods import period as make_period
+
+
+period = make_period('2019-05')
+
+
+@fixture
+def disk_storage():
+    temp_dir = tempfile.mkdtemp(prefix = "openfisca_test_")
+    return OnDiskStorage(temp_dir)
+
+
+def test_put_get(disk_storage):
+    array = PartialArray(np.asarray([1,2,3]), np.asarray([True, True, False, True, False]))
+    disk_storage.put(array, period)
+    cached_array = disk_storage.get(period)
+    assert_array_equal(array.value, cached_array.value)
+    assert_array_equal(array.mask, cached_array.mask)
+
+
+def test_put_get_2(disk_storage):
+    array = PartialArray(np.asarray([1,2,3]), None)
+    disk_storage.put(array, period)
+    cached_array = disk_storage.get(period)
+    assert_array_equal(array.value, cached_array.value)
+    assert array.mask is None

--- a/tests/core/test_data_storage.py
+++ b/tests/core/test_data_storage.py
@@ -21,7 +21,7 @@ def disk_storage():
 
 
 def test_put_get(disk_storage):
-    array = PartialArray(np.asarray([1,2,3]), np.asarray([True, True, False, True, False]))
+    array = PartialArray(np.asarray([1, 2, 3]), np.asarray([True, True, False, True, False]))
     disk_storage.put(array, period)
     cached_array = disk_storage.get(period)
     assert_array_equal(array.value, cached_array.value)
@@ -29,7 +29,7 @@ def test_put_get(disk_storage):
 
 
 def test_put_get_2(disk_storage):
-    array = PartialArray(np.asarray([1,2,3]), None)
+    array = PartialArray(np.asarray([1, 2, 3]), None)
     disk_storage.put(array, period)
     cached_array = disk_storage.get(period)
     assert_array_equal(array.value, cached_array.value)

--- a/tests/core/test_dump_restore.py
+++ b/tests/core/test_dump_restore.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 
 from numpy.testing import assert_array_equal
+import numpy as np
 
 from openfisca_core.simulation_builder import SimulationBuilder
 from openfisca_country_template.situation_examples import couple
@@ -37,5 +38,25 @@ def test_dump():
     cached_value = disposable_income_holder.get_array('2018-01')
     assert cached_value is not None
     assert_array_equal(cached_value, calculated_value)
+
+    shutil.rmtree(directory)
+
+
+def test_dump_sub_pop():
+    directory = tempfile.mkdtemp(prefix = "openfisca_")
+    simulation = SimulationBuilder().build_from_entities(tax_benefit_system, couple)
+
+    sub_pop = simulation.persons.get_subpopulation(np.asarray([False, True]))
+    calculated_value = sub_pop('disposable_income', '2018-01')
+    dump_simulation(simulation, directory)
+
+    simulation_2 = restore_simulation(directory, tax_benefit_system)
+
+    # Check calculated values are in cache
+
+    disposable_income_holder = simulation_2.person.get_holder('disposable_income')
+    cached_value = disposable_income_holder.get_array('2018-01')
+    assert cached_value is not None
+    assert cached_value[1] == calculated_value
 
     shutil.rmtree(directory)

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -3,6 +3,7 @@
 from copy import deepcopy
 
 import numpy as np
+from numpy.testing import assert_array_equal, assert_allclose
 
 from openfisca_core.simulation_builder import SimulationBuilder
 from openfisca_core.tools import assert_near
@@ -42,11 +43,11 @@ def new_simulation(test_case, period = MONTH):
 
 def test_role_index_and_positions():
     simulation = new_simulation(TEST_CASE)
-    assert_near(simulation.household.members_entity_id, [0, 0, 0, 0, 1, 1])
-    assert((simulation.household.members_role == [FIRST_PARENT, SECOND_PARENT, CHILD, CHILD, FIRST_PARENT, CHILD]).all())
-    assert_near(simulation.household.members_position, [0, 1, 2, 3, 0, 1])
-    assert(simulation.person.ids == ["ind0", "ind1", "ind2", "ind3", "ind4", "ind5"])
-    assert(simulation.household.ids == ['h1', 'h2'])
+    assert_array_equal(simulation.household.members_entity_id, [0, 0, 0, 0, 1, 1])
+    assert_array_equal(simulation.household.members_role, [FIRST_PARENT, SECOND_PARENT, CHILD, CHILD, FIRST_PARENT, CHILD])
+    assert_array_equal(simulation.household.members_position, [0, 1, 2, 3, 0, 1])
+    assert_array_equal(simulation.person.ids, ["ind0", "ind1", "ind2", "ind3", "ind4", "ind5"])
+    assert_array_equal(simulation.household.ids, ['h1', 'h2'])
 
 
 def test_entity_structure_with_constructor():
@@ -74,9 +75,9 @@ def test_entity_structure_with_constructor():
 
     household = simulation.household
 
-    assert_near(household.members_entity_id, [0, 0, 1, 0, 0])
-    assert((household.members_role == [FIRST_PARENT, SECOND_PARENT, FIRST_PARENT, CHILD, CHILD]).all())
-    assert_near(household.members_position, [0, 1, 0, 2, 3])
+    assert_array_equal(household.members_entity_id, [0, 0, 1, 0, 0])
+    assert_array_equal(household.members_role, [FIRST_PARENT, SECOND_PARENT, FIRST_PARENT, CHILD, CHILD])
+    assert_array_equal(household.members_position, [0, 1, 0, 2, 3])
 
 
 def test_entity_variables_with_constructor():
@@ -106,7 +107,7 @@ def test_entity_variables_with_constructor():
 
     simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.safe_load(simulation_yaml))
     household = simulation.household
-    assert_near(household('rent', "2017-06"), [800, 600])
+    assert_array_equal(household('rent', "2017-06"), [800, 600])
 
 
 def test_person_variable_with_constructor():
@@ -139,8 +140,8 @@ def test_person_variable_with_constructor():
 
     simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.safe_load(simulation_yaml))
     person = simulation.person
-    assert_near(person('salary', "2017-11"), [1500, 0, 3000, 0, 0])
-    assert_near(person('salary', "2017-12"), [2000, 0, 4000, 0, 0])
+    assert_array_equal(person('salary', "2017-11"), [1500, 0, 3000, 0, 0])
+    assert_array_equal(person('salary', "2017-12"), [2000, 0, 4000, 0, 0])
 
 
 def test_set_input_with_constructor():
@@ -178,22 +179,22 @@ def test_set_input_with_constructor():
 
     simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.safe_load(simulation_yaml))
     person = simulation.person
-    assert_near(person('salary', "2017-12"), [2000, 0, 4000, 0, 0])
-    assert_near(person('salary', "2017-10"), [2000, 3000, 1600, 0, 0])
+    assert_array_equal(person('salary', "2017-12"), [2000, 0, 4000, 0, 0])
+    assert_array_equal(person('salary', "2017-10"), [2000, 3000, 1600, 0, 0])
 
 
 def test_has_role():
     simulation = new_simulation(TEST_CASE)
     individu = simulation.persons
-    assert_near(individu.has_role(CHILD), [False, False, True, True, False, True])
+    assert_array_equal(individu.has_role(CHILD), [False, False, True, True, False, True])
 
 
 def test_has_role_with_subrole():
     simulation = new_simulation(TEST_CASE)
     individu = simulation.persons
-    assert_near(individu.has_role(PARENT), [True, True, False, False, True, False])
-    assert_near(individu.has_role(FIRST_PARENT), [True, False, False, False, True, False])
-    assert_near(individu.has_role(SECOND_PARENT), [False, True, False, False, False, False])
+    assert_array_equal(individu.has_role(PARENT), [True, True, False, False, True, False])
+    assert_array_equal(individu.has_role(FIRST_PARENT), [True, False, False, False, True, False])
+    assert_array_equal(individu.has_role(SECOND_PARENT), [False, True, False, False, False, False])
 
 
 def test_project():
@@ -206,10 +207,10 @@ def test_project():
     housing_tax = household('housing_tax', YEAR)
     projected_housing_tax = household.project(housing_tax)
 
-    assert_near(projected_housing_tax, [20000, 20000, 20000, 20000, 0, 0])
+    assert_array_equal(projected_housing_tax, [20000, 20000, 20000, 20000, 0, 0])
 
     housing_tax_projected_on_parents = household.project(housing_tax, role = PARENT)
-    assert_near(housing_tax_projected_on_parents, [20000, 20000, 0, 0, 0, 0])
+    assert_array_equal(housing_tax_projected_on_parents, [20000, 20000, 0, 0, 0, 0])
 
 
 def test_implicit_projection():
@@ -220,7 +221,7 @@ def test_implicit_projection():
     individu = simulation.person
     housing_tax = individu.household('housing_tax', YEAR)
 
-    assert_near(housing_tax, [20000, 20000, 20000, 20000, 0, 0])
+    assert_array_equal(housing_tax, [20000, 20000, 20000, 20000, 0, 0])
 
 
 def test_sum():
@@ -236,11 +237,11 @@ def test_sum():
     salary = household.members('salary', "2016-01")
     total_salary_by_household = household.sum(salary)
 
-    assert_near(total_salary_by_household, [2500, 3500])
+    assert_array_equal(total_salary_by_household, [2500, 3500])
 
     total_salary_parents_by_household = household.sum(salary, role = PARENT)
 
-    assert_near(total_salary_parents_by_household, [2500, 3000])
+    assert_array_equal(total_salary_parents_by_household, [2500, 3000])
 
 
 def test_any():
@@ -251,11 +252,11 @@ def test_any():
     age = household.members('age', period = MONTH)
     condition_age = (age <= 18)
     has_household_member_with_age_inf_18 = household.any(condition_age)
-    assert_near(has_household_member_with_age_inf_18, [True, False])
+    assert_array_equal(has_household_member_with_age_inf_18, [True, False])
 
     condition_age_2 = (age > 18)
     has_household_CHILD_with_age_sup_18 = household.any(condition_age_2, role = CHILD)
-    assert_near(has_household_CHILD_with_age_sup_18, [False, True])
+    assert_array_equal(has_household_CHILD_with_age_sup_18, [False, True])
 
 
 def test_all():
@@ -267,10 +268,10 @@ def test_all():
 
     condition_age = (age >= 18)
     all_persons_age_sup_18 = household.all(condition_age)
-    assert_near(all_persons_age_sup_18, [False, True])
+    assert_array_equal(all_persons_age_sup_18, [False, True])
 
     all_parents_age_sup_18 = household.all(condition_age, role = PARENT)
-    assert_near(all_parents_age_sup_18, [True, True])
+    assert_array_equal(all_parents_age_sup_18, [True, True])
 
 
 def test_max():
@@ -281,10 +282,10 @@ def test_max():
     age = household.members('age', period = MONTH)
 
     age_max = household.max(age)
-    assert_near(age_max, [40, 54])
+    assert_array_equal(age_max, [40, 54])
 
     age_max_child = household.max(age, role = CHILD)
-    assert_near(age_max_child, [9, 20])
+    assert_array_equal(age_max_child, [9, 20])
 
 
 def test_min():
@@ -295,10 +296,10 @@ def test_min():
     age = household.members('age', period = MONTH)
 
     age_min = household.min(age)
-    assert_near(age_min, [7, 20])
+    assert_array_equal(age_min, [7, 20])
 
     age_min_parents = household.min(age, role = PARENT)
-    assert_near(age_min_parents, [37, 54])
+    assert_array_equal(age_min_parents, [37, 54])
 
 
 def test_value_nth_person():
@@ -308,16 +309,16 @@ def test_value_nth_person():
     array = household.members('age', MONTH)
 
     result0 = household.value_nth_person(0, array, default=-1)
-    assert_near(result0, [40, 54])
+    assert_array_equal(result0, [40, 54])
 
     result1 = household.value_nth_person(1, array, default=-1)
-    assert_near(result1, [37, 20])
+    assert_array_equal(result1, [37, 20])
 
     result2 = household.value_nth_person(2, array, default=-1)
-    assert_near(result2, [7, -1])
+    assert_array_equal(result2, [7, -1])
 
     result3 = household.value_nth_person(3, array, default=-1)
-    assert_near(result3, [9, -1])
+    assert_array_equal(result3, [9, -1])
 
 
 def test_rank():
@@ -327,10 +328,10 @@ def test_rank():
 
     age = person('age', MONTH)  # [40, 37, 7, 9, 54, 20]
     rank = person.get_rank(person.household, age)
-    assert_near(rank, [3, 2, 0, 1, 1, 0])
+    assert_array_equal(rank, [3, 2, 0, 1, 1, 0])
 
     rank_in_siblings = person.get_rank(person.household, - age, condition = person.has_role(Household.CHILD))
-    assert_near(rank_in_siblings, [-1, -1, 1, 0, -1, 0])
+    assert_array_equal(rank_in_siblings, [-1, -1, 1, 0, -1, 0])
 
 
 def test_partner():
@@ -347,7 +348,7 @@ def test_partner():
 
     salary_second_parent = persons.value_from_partner(salary, persons.household, PARENT)
 
-    assert_near(salary_second_parent, [1500, 1000, 0, 0, 0, 0])
+    assert_array_equal(salary_second_parent, [1500, 1000, 0, 0, 0, 0])
 
 
 def test_value_from_first_person():
@@ -363,7 +364,7 @@ def test_value_from_first_person():
     salaries = household.members('salary', period = MONTH)
     salary_first_person = household.value_from_first_person(salaries)
 
-    assert_near(salary_first_person, [1000, 3000])
+    assert_array_equal(salary_first_person, [1000, 3000])
 
 
 def test_projectors_methods():
@@ -402,7 +403,7 @@ def test_sum_following_bug_ipp_1():
     eligible_i = household.members('salary', period = MONTH) < 1500
     nb_eligibles_by_household = household.sum(eligible_i, role = CHILD)
 
-    assert_near(nb_eligibles_by_household, [0, 2])
+    assert_array_equal(nb_eligibles_by_household, [0, 2])
 
 
 def test_sum_following_bug_ipp_2():
@@ -424,7 +425,7 @@ def test_sum_following_bug_ipp_2():
     eligible_i = household.members('salary', period = MONTH) < 1500
     nb_eligibles_by_household = household.sum(eligible_i, role = CHILD)
 
-    assert_near(nb_eligibles_by_household, [2, 0])
+    assert_array_equal(nb_eligibles_by_household, [2, 0])
 
 
 def test_get_memory_usage():
@@ -467,41 +468,40 @@ def test_unordered_persons():
 
     # Aggregation/Projection persons -> entity
 
-    assert_near(household.sum(salary), [2520, 3500])
-    assert_near(household.max(salary), [1500, 3000])
-    assert_near(household.min(salary), [0, 500])
-    assert_near(household.all(salary > 0), [False, True])
-    assert_near(household.any(salary > 2000), [False, True])
-    assert_near(household.first_person('salary', "2016-01"), [0, 3000])
-    assert_near(household.first_parent('salary', "2016-01"), [1000, 3000])
-    assert_near(household.second_parent('salary', "2016-01"), [1500, 0])
-    assert_near(person.value_from_partner(salary, person.household, PARENT), [0, 0, 1000, 0, 0, 1500])
+    assert_array_equal(household.sum(salary), [2520, 3500])
+    assert_array_equal(household.max(salary), [1500, 3000])
+    assert_array_equal(household.min(salary), [0, 500])
+    assert_array_equal(household.all(salary > 0), [False, True])
+    assert_array_equal(household.any(salary > 2000), [False, True])
+    assert_array_equal(household.first_person('salary', "2016-01"), [0, 3000])
+    assert_array_equal(household.first_parent('salary', "2016-01"), [1000, 3000])
+    assert_array_equal(household.second_parent('salary', "2016-01"), [1500, 0])
+    assert_array_equal(person.value_from_partner(salary, person.household, PARENT), [0, 0, 1000, 0, 0, 1500])
 
-    assert_near(household.sum(salary, role = PARENT), [2500, 3000])
-    assert_near(household.sum(salary, role = CHILD), [20, 500])
-    assert_near(household.max(salary, role = PARENT), [1500, 3000])
-    assert_near(household.max(salary, role = CHILD), [20, 500])
-    assert_near(household.min(salary, role = PARENT), [1000, 3000])
-    assert_near(household.min(salary, role = CHILD), [0, 500])
-    assert_near(household.all(salary > 0, role = PARENT), [True, True])
-    assert_near(household.all(salary > 0, role = CHILD), [False, True])
-    assert_near(household.any(salary < 1500, role = PARENT), [True, False])
-    assert_near(household.any(salary > 200, role = CHILD), [False, True])
+    assert_array_equal(household.sum(salary, role = PARENT), [2500, 3000])
+    assert_array_equal(household.sum(salary, role = CHILD), [20, 500])
+    assert_array_equal(household.max(salary, role = PARENT), [1500, 3000])
+    assert_array_equal(household.max(salary, role = CHILD), [20, 500])
+    assert_array_equal(household.min(salary, role = PARENT), [1000, 3000])
+    assert_array_equal(household.min(salary, role = CHILD), [0, 500])
+    assert_array_equal(household.all(salary > 0, role = PARENT), [True, True])
+    assert_array_equal(household.all(salary > 0, role = CHILD), [False, True])
+    assert_array_equal(household.any(salary < 1500, role = PARENT), [True, False])
+    assert_array_equal(household.any(salary > 200, role = CHILD), [False, True])
 
     # nb_persons
 
-    assert_near(household.nb_persons(), [4, 2])
-    assert_near(household.nb_persons(role = PARENT), [2, 1])
-    assert_near(household.nb_persons(role = CHILD), [2, 1])
+    assert_array_equal(household.nb_persons(), [4, 2])
+    assert_array_equal(household.nb_persons(role = PARENT), [2, 1])
+    assert_array_equal(household.nb_persons(role = CHILD), [2, 1])
 
     # Projection entity -> persons
 
-    assert_near(household.project(accommodation_size), [60, 160, 160, 160, 60, 160])
-    assert_near(household.project(accommodation_size, role = PARENT), [60, 0, 160, 0, 0, 160])
-    assert_near(household.project(accommodation_size, role = CHILD), [0, 160, 0, 160, 60, 0])
+    assert_array_equal(household.project(accommodation_size), [60, 160, 160, 160, 60, 160])
+    assert_array_equal(household.project(accommodation_size, role = PARENT), [60, 0, 160, 0, 0, 160])
+    assert_array_equal(household.project(accommodation_size, role = CHILD), [0, 160, 0, 160, 60, 0])
 
 
-    assert_near
 
 def test_if():
     simulation = new_simulation(TEST_CASE)
@@ -512,7 +512,7 @@ def test_if():
 
     salary_adults = persons.if_(age > 18, lambda persons: persons('salary', MONTH))
 
-    assert_near(salary_adults , [1200, 1400, 0, 0, 2000, 0])
+    assert_array_equal(salary_adults , [1200, 1400, 0, 0, 2000, 0])
 
 def test_if_2():
     simulation = new_simulation(TEST_CASE)
@@ -523,4 +523,4 @@ def test_if_2():
 
     income_tax_adults = persons.if_(age > 18, lambda persons: persons('income_tax', MONTH))
 
-    assert_near(income_tax_adults , [180, 210, 0, 0, 300, 0], absolute_error_margin = 1e-4)
+    assert_allclose(income_tax_adults , [180, 210, 0, 0, 300, 0])

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -6,7 +6,6 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 
 from openfisca_core.simulation_builder import SimulationBuilder
-from openfisca_core.tools import assert_near
 from openfisca_core.tools.test_runner import yaml
 from openfisca_country_template.entities import Household
 from openfisca_country_template.situation_examples import single, couple
@@ -502,7 +501,6 @@ def test_unordered_persons():
     assert_array_equal(household.project(accommodation_size, role = CHILD), [0, 160, 0, 160, 60, 0])
 
 
-
 def test_if():
     simulation = new_simulation(TEST_CASE)
     persons = simulation.persons
@@ -512,7 +510,8 @@ def test_if():
 
     salary_adults = persons.if_(age > 18, lambda persons: persons('salary', MONTH))
 
-    assert_array_equal(salary_adults , [1200, 1400, 0, 0, 2000, 0])
+    assert_array_equal(salary_adults, [1200, 1400, 0, 0, 2000, 0])
+
 
 def test_if_2():
     simulation = new_simulation(TEST_CASE)
@@ -523,4 +522,4 @@ def test_if_2():
 
     income_tax_adults = persons.if_(age > 18, lambda persons: persons('income_tax', MONTH))
 
-    assert_allclose(income_tax_adults , [180, 210, 0, 0, 300, 0])
+    assert_allclose(income_tax_adults, [180, 210, 0, 0, 300, 0])

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -505,7 +505,6 @@ def test_if():
     simulation = new_simulation(TEST_CASE)
     persons = simulation.persons
     simulation.set_input('salary', MONTH, [1200, 1400, 0, 0, 2000, 800])
-
     age = np.asarray([40, 37, 7, 9, 54, 16])
 
     salary_adults = persons.if_(age > 18, lambda persons: persons('salary', MONTH))
@@ -517,9 +516,26 @@ def test_if_2():
     simulation = new_simulation(TEST_CASE)
     persons = simulation.persons
     simulation.set_input('salary', MONTH, [1200, 1400, 0, 0, 2000, 800])
-
     age = np.asarray([40, 37, 7, 9, 54, 16])
 
     income_tax_adults = persons.if_(age > 18, lambda persons: persons('income_tax', MONTH))
 
     assert_allclose(income_tax_adults, [180, 210, 0, 0, 300, 0])
+
+
+def test_if_with_false():
+    simulation = new_simulation(TEST_CASE)
+    persons = simulation.persons
+    simulation.set_input('salary', MONTH, [1200, 1400, 500, 600, 2000, 800])
+    age = np.asarray([40, 37, 7, 9, 54, 16])
+
+    result = persons.if_(
+        age > 18,
+        lambda persons: persons('salary', MONTH),
+        lambda persons: persons('salary', MONTH) / 2
+        )
+
+    assert_allclose(
+        result,
+        np.asarray([1200, 1400, 250, 300, 2000, 400])
+        )

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -2,6 +2,8 @@
 
 from copy import deepcopy
 
+import numpy as np
+
 from openfisca_core.simulation_builder import SimulationBuilder
 from openfisca_core.tools import assert_near
 from openfisca_core.tools.test_runner import yaml
@@ -497,3 +499,28 @@ def test_unordered_persons():
     assert_near(household.project(accommodation_size), [60, 160, 160, 160, 60, 160])
     assert_near(household.project(accommodation_size, role = PARENT), [60, 0, 160, 0, 0, 160])
     assert_near(household.project(accommodation_size, role = CHILD), [0, 160, 0, 160, 60, 0])
+
+
+    assert_near
+
+def test_if():
+    simulation = new_simulation(TEST_CASE)
+    persons = simulation.persons
+    simulation.set_input('salary', MONTH, [1200, 1400, 0, 0, 2000, 800])
+
+    age = np.asarray([40, 37, 7, 9, 54, 16])
+
+    salary_adults = persons.if_(age > 18, lambda persons: persons('salary', MONTH))
+
+    assert_near(salary_adults , [1200, 1400, 0, 0, 2000, 0])
+
+def test_if_2():
+    simulation = new_simulation(TEST_CASE)
+    persons = simulation.persons
+    simulation.set_input('salary', MONTH, [1200, 1400, 0, 0, 2000, 800])
+
+    age = np.asarray([40, 37, 7, 9, 54, 16])
+
+    income_tax_adults = persons.if_(age > 18, lambda persons: persons('income_tax', MONTH))
+
+    assert_near(income_tax_adults , [180, 210, 0, 0, 300, 0], absolute_error_margin = 1e-4)

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 
+import datetime
+
 import numpy as np
+from numpy.testing import assert_array_equal
 import pytest
+from pytest import fixture
 
 import openfisca_country_template.situation_examples
 from openfisca_core.simulation_builder import SimulationBuilder
@@ -13,7 +17,6 @@ from openfisca_core.holders import Holder, set_input_dispatch_by_period
 from openfisca_core.errors import PeriodMismatchError
 from .test_countries import tax_benefit_system
 
-from pytest import fixture
 
 
 @fixture
@@ -220,3 +223,16 @@ def test_get_array_sub_pop(couple):
     sub_pop.put_in_cache('salary', period, np.asarray([2000]))
     array = couple.get_array('salary', period)
 
+    assert array.size == 2
+    assert array[1] == 2000
+
+
+def test_get_array_sub_pop_date(couple):
+    period = make_period('2015-01')
+    couple.delete_arrays('birth')
+    sub_pop = couple.persons.get_subpopulation(np.asarray([False, True]))
+    sub_pop.put_in_cache('birth', period, np.asarray([datetime.date(1990, 1, 1)]))
+    array = couple.get_array('birth', period)
+
+    assert array.size == 2
+    assert array.data[1] == datetime.date(1990, 1, 1)

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -219,5 +219,4 @@ def test_get_array_sub_pop(couple):
     sub_pop = couple.persons.get_subpopulation(np.asarray([False, True]))
     sub_pop.put_in_cache('salary', period, np.asarray([2000]))
     array = couple.get_array('salary', period)
-    import ipdb; ipdb.set_trace()
 

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -212,3 +212,12 @@ def test_set_input_float_to_int(single):
     simulation.person.get_holder('age').set_input(period, age)
     result = simulation.calculate('age', period)
     assert result == np.asarray([50])
+
+
+def test_get_array_sub_pop(couple):
+    period = make_period('2015-01')
+    sub_pop = couple.persons.get_subpopulation(np.asarray([False, True]))
+    sub_pop.put_in_cache('salary', period, np.asarray([2000]))
+    array = couple.get_array('salary', period)
+    import ipdb; ipdb.set_trace()
+

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -3,7 +3,6 @@
 import datetime
 
 import numpy as np
-from numpy.testing import assert_array_equal
 import pytest
 from pytest import fixture
 
@@ -16,7 +15,6 @@ from openfisca_core.memory_config import MemoryConfig
 from openfisca_core.holders import Holder, set_input_dispatch_by_period
 from openfisca_core.errors import PeriodMismatchError
 from .test_countries import tax_benefit_system
-
 
 
 @fixture

--- a/tests/core/test_simulation_builder.py
+++ b/tests/core/test_simulation_builder.py
@@ -6,6 +6,7 @@ from enum import Enum
 from datetime import date
 
 from pytest import raises, fixture, approx
+from numpy.testing import assert_array_equal
 
 from openfisca_core.simulation_builder import SimulationBuilder, Simulation
 from openfisca_core.tools import assert_near
@@ -264,7 +265,7 @@ def test_finalize_person_entity(simulation_builder, persons):
     simulation_builder.finalize_variables_init(population)
     assert_near(population.get_holder('salary').get_array('2018-11'), [3000, 0])
     assert population.count == 2
-    assert population.ids == ['Alicia', 'Javier']
+    assert_array_equal(population.ids ,['Alicia', 'Javier'])
 
 
 def test_canonicalize_period_keys(simulation_builder, persons):
@@ -493,7 +494,7 @@ def test_order_preserved(simulation_builder):
     data = yaml.safe_load(input_yaml)
     simulation = simulation_builder.build_from_dict(tax_benefit_system, data)
 
-    assert simulation.persons.ids == ['Javier', 'Alicia', 'Sarah', 'Tom']
+    assert_array_equal(simulation.persons.ids, ['Javier', 'Alicia', 'Sarah', 'Tom'])
 
 
 def test_inconsistent_input(simulation_builder):

--- a/tests/core/test_simulation_builder.py
+++ b/tests/core/test_simulation_builder.py
@@ -265,7 +265,7 @@ def test_finalize_person_entity(simulation_builder, persons):
     simulation_builder.finalize_variables_init(population)
     assert_near(population.get_holder('salary').get_array('2018-11'), [3000, 0])
     assert population.count == 2
-    assert_array_equal(population.ids ,['Alicia', 'Javier'])
+    assert_array_equal(population.ids, ['Alicia', 'Javier'])
 
 
 def test_canonicalize_period_keys(simulation_builder, persons):

--- a/tests/core/test_subpopulations.py
+++ b/tests/core/test_subpopulations.py
@@ -39,4 +39,3 @@ def test_household_sub_pop():
 
     assert_array_equal(households.sum(age), [40 + 37 + 19 + 7, 54 + 16])
     assert_array_equal(households.any(age > 50), [False, True])
-

--- a/tests/core/test_subpopulations.py
+++ b/tests/core/test_subpopulations.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from openfisca_core.populations import SubPopulation
+from openfisca_core.populations import SubPopulation, GroupSubPopulation
 
 from .test_entities import TEST_CASE, new_simulation
 
@@ -29,10 +29,15 @@ def test_household_sub_pop():
     simulation.set_input('age', period, np.asarray([40, 37, 7, 19, 54, 16, 30]))
 
     condition = simulation.household.nb_persons() > 1
-    households = SubPopulation(simulation.household, condition)
+    households = GroupSubPopulation(simulation.household, condition)
 
     age = households.members('age', period)
-    assert (age == np.asarray([40, 37, 7, 19, 54, 16])).all()
+    assert (age == [40, 37, 7, 19, 54, 16]).all()
 
-    households.sum(age)
+    assert (households.members_entity_id == simulation.household.members_entity_id[:-1]).all()
+    assert (households.members_role == simulation.household.members_role[:-1]).all()
+    assert (households.members_position == simulation.household.members_position[:-1]).all()
+
+    assert (households.sum(age) == [40 + 37 + 19 + 7, 54 + 16]).all()
+    assert (households.any(age > 50) == [False, True]).all()
 

--- a/tests/core/test_subpopulations.py
+++ b/tests/core/test_subpopulations.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+from openfisca_core.populations import SubPopulation
+
+from .test_entities import TEST_CASE, new_simulation
+
+def test_ind_sub_pop():
+    simulation = new_simulation(TEST_CASE)
+    age = np.asarray([40, 37, 7, 19, 54, 16])
+    subpop = SubPopulation(simulation.persons, age >= 18)
+
+
+    assert (subpop.ids == ['ind0', 'ind1', 'ind3', 'ind4']).all()
+    assert (subpop.has_role(simulation.household.entity.PARENT) == [True, True, False, True]).all()
+
+
+def test_household_sub_pop():
+    test_case = {
+        'persons': {'ind0': {}, 'ind1': {}, 'ind2': {}, 'ind3': {}, 'ind4': {}, 'ind5': {}, 'ind6': {}},
+        'households': {
+            'h1': {'children': ['ind2', 'ind3'], 'parents': ['ind0', 'ind1']},
+            'h2': {'children': ['ind5'], 'parents': ['ind4']},
+            'h3': {'parents': ['ind6']}
+            },
+        }
+
+    period = '2019-01'
+    simulation = new_simulation(test_case)
+    simulation.set_input('age', period, np.asarray([40, 37, 7, 19, 54, 16, 30]))
+
+    condition = simulation.household.nb_persons() > 1
+    households = SubPopulation(simulation.household, condition)
+
+    age = households.members('age', period)
+    assert (age == np.asarray([40, 37, 7, 19, 54, 16])).all()
+
+    households.sum(age)
+

--- a/tests/core/test_subpopulations.py
+++ b/tests/core/test_subpopulations.py
@@ -71,6 +71,23 @@ def test_cache_2_subpop_write_global_read(simulation, p_subpop, p_subpop_2):
     assert_array_equal(cached_array.mask, [True, True, True, True, True, False])
 
 
+def test_cache_disjunct_pop(simulation, p_subpop):
+    p_subpop.put_in_cache('salary', period, [1000, 2000, 1200, 2400])
+    p_subpop_2 = simulation.persons.get_subpopulation(np.asarray([False, False, True, False, False, False]))
+
+    assert p_subpop_2.get_cached_array('salary', period) is None
+
+
+def test_global_calculation(simulation, p_subpop):
+    p_subpop.put_in_cache('salary', period, [1000, 2000, 1200, 2400])
+
+    assert_array_equal(
+        simulation.calculate('salary', period),
+        [1000, 2000, 0, 1200, 2400, 0]
+        )
+
+
+
 # def test_household_sub_pop():
 #     test_case = {
 #         'persons': {'ind0': {}, 'ind1': {}, 'ind2': {}, 'ind3': {}, 'ind4': {}, 'ind5': {}, 'ind6': {}},
@@ -82,7 +99,7 @@ def test_cache_2_subpop_write_global_read(simulation, p_subpop, p_subpop_2):
 #         }
 
 #     simulation = new_simulation(test_case)
-#     simulation.set_input('age', period, np.asarray([40, 37, 7, 19, 30, 54, 16]))
+#     simulation.set_input('age', period, [40, 37, 7, 19, 30, 54, 16])
 
 #     condition = simulation.household.nb_persons() > 1
 #     households = simulation.household.get_subpopulation(condition)

--- a/tests/core/test_subpopulations.py
+++ b/tests/core/test_subpopulations.py
@@ -37,8 +37,22 @@ def test_cache_pop_to_subpop(p_subpop):
 
 def test_cache_subpop_to_pop(p_subpop):
     p_subpop.put_in_cache('salary', period, [1000, 2000, 1200, 2400])
-    assert_array_equal(p_subpop.population('salary', period), [1000, 2000, 0, 1200, 2400, 0])
+    assert_array_equal(
+        p_subpop.population('salary', period),
+        [1000, 2000, 0, 1200, 2400, 0]
+        )
 
+
+def test_cache_subpop_to_subpop(p_subpop):
+    simulation = p_subpop.simulation
+    p_subpop.put_in_cache('salary', period, [1000, 2000, 1200, 2400])
+    condition_2 = np.asarray([True, True, True, False, False, False])
+    p_subpop_2 = simulation.persons.get_subpopulation(condition_2)
+
+    assert_array_equal(
+        p_subpop_2.get_cached_array('salary', period).value,
+        [1000, 2000]
+        )
 
 # def test_household_sub_pop():
 #     test_case = {

--- a/tests/core/test_subpopulations.py
+++ b/tests/core/test_subpopulations.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.testing import assert_array_equal
-from pytest import fixture, approx
+from pytest import fixture
 
 from openfisca_core.periods import period as make_period
 
@@ -30,6 +30,7 @@ def p_subpop(simulation):
 def p_subpop_2(simulation):
     condition_2 = np.asarray([True, True, True, False, False, False])
     return simulation.persons.get_subpopulation(condition_2)
+
 
 def test_ids(p_subpop):
     assert_array_equal(p_subpop.ids, ['ind0', 'ind1', 'ind3', 'ind4'])
@@ -63,7 +64,7 @@ def test_cache_subpop_write_subpop_read(p_subpop, p_subpop_2):
     p_subpop.put_in_cache('salary', period, [1000, 2000, 1200, 2400])
 
     cached_array = p_subpop_2.get_cached_array('salary', period)
-    assert_array_equal(cached_array.value,[1000, 2000])
+    assert_array_equal(cached_array.value, [1000, 2000])
     assert_array_equal(cached_array.mask, [True, True, False])
 
 
@@ -85,11 +86,12 @@ def test_cache_disjunct_pop(simulation, p_subpop):
 
 
 def test_sub_subpopulation(p_subpop):
-    p_subpop_3 =  p_subpop.get_subpopulation([True, False, True, False])
+    p_subpop_3 = p_subpop.get_subpopulation([True, False, True, False])
     assert_array_equal(
         p_subpop_3.condition,
         [True, False, False, True, False, False]
-    )
+        )
+
 
 def test_global_calculation(simulation, p_subpop):
     p_subpop.put_in_cache('salary', period, [1000, 2000, 1200, 2400])
@@ -99,12 +101,13 @@ def test_global_calculation(simulation, p_subpop):
         [1000, 2000, 0, 1200, 2400, 0]
         )
 
+
 def test_subpop_calculation(simulation, p_subpop):
     simulation.set_input('salary', period, [1000, 2000, 0, 1200, 2400, 800])
     assert_array_equal(
         p_subpop('salary', period),
         [1000, 2000, 1200, 2400]
-    )
+        )
 
 
 def test_subpop_calculation_subpop_init(p_subpop, p_subpop_2):
@@ -112,7 +115,7 @@ def test_subpop_calculation_subpop_init(p_subpop, p_subpop_2):
     assert_array_equal(
         p_subpop_2('salary', period),
         [1000, 2000, 0]
-    )
+        )
 
 
 @fixture
@@ -143,7 +146,7 @@ def test_household_sub_pop_members(h_subpop):
     assert_array_equal(
         h_subpop.members.condition,
         [True, True, True, True, False, True, True]
-    )
+        )
 
 
 def test_aggregation(simulation_h, h_subpop):
@@ -157,12 +160,11 @@ def test_aggregation(simulation_h, h_subpop):
 
 def test_projection_p_to_h(simulation_h, h_subpop):
     simulation_h.set_input('age', period, np.asarray([40, 37, 7, 19, 30, 54, 16]))
-    age = h_subpop.members('age', period)
 
     assert_array_equal(
         h_subpop.first_parent('age', period),
         [40, 54]
-    )
+        )
 
 
 def test_projection_h_to_p(simulation_h, h_subpop):
@@ -172,11 +174,12 @@ def test_projection_h_to_p(simulation_h, h_subpop):
     assert_array_equal(
         p_subpop.household.ids,
         ['h1', 'h1', 'h1', 'h3', 'h2', 'h2']
-    )
+        )
     assert_array_equal(
         p_subpop.household('housing_tax', 2019),
         [500, 500, 500, 400, 600, 600]
-    )
+        )
+
 
 def test_projection_h_to_p_2(simulation_h, h_subpop):
     simulation_h.set_input('housing_tax', 2019, np.asarray([500, 400, 600]))
@@ -185,11 +188,11 @@ def test_projection_h_to_p_2(simulation_h, h_subpop):
     assert_array_equal(
         p_subpop.household.ids,
         ['h1', 'h1', 'h1', 'h1', 'h2', 'h2']
-    )
+        )
     assert_array_equal(
         p_subpop.household('housing_tax', 2019),
         [500, 500, 500, 500, 600, 600]
-    )
+        )
 
 
 def test_trace(simulation, p_subpop):

--- a/tests/core/test_subpopulations.py
+++ b/tests/core/test_subpopulations.py
@@ -169,7 +169,6 @@ def test_projection_h_to_p(simulation_h, h_subpop):
     simulation_h.set_input('housing_tax', 2019, np.asarray([500, 400, 600]))
     p_subpop = simulation_h.persons.get_subpopulation(np.asarray([True, True, True, False, True, True, True]))
 
-    # import ipdb; ipdb.set_trace()
     assert_array_equal(
         p_subpop.household.ids,
         ['h1', 'h1', 'h1', 'h3', 'h2', 'h2']
@@ -183,7 +182,6 @@ def test_projection_h_to_p_2(simulation_h, h_subpop):
     simulation_h.set_input('housing_tax', 2019, np.asarray([500, 400, 600]))
     p_subpop = simulation_h.persons.get_subpopulation(np.asarray([True, True, True, True, False, True, True]))
 
-    # import ipdb; ipdb.set_trace()
     assert_array_equal(
         p_subpop.household.ids,
         ['h1', 'h1', 'h1', 'h1', 'h2', 'h2']

--- a/tests/core/test_subpopulations.py
+++ b/tests/core/test_subpopulations.py
@@ -190,3 +190,18 @@ def test_projection_h_to_p_2(simulation_h, h_subpop):
         p_subpop.household('housing_tax', 2019),
         [500, 500, 500, 500, 600, 600]
     )
+
+
+def test_trace(simulation, p_subpop):
+    simulation.trace = True
+    simulation.set_input('salary', period, [1000, 2000, 0, 1200, 2400, 800])
+    p_subpop('income_tax', period)
+    traced_value = list(simulation.tracer.trace.values())[0]['value']
+    assert traced_value.size == simulation.persons.count
+
+
+def test_trace_2(simulation, p_subpop):
+    simulation.trace = True
+    p_subpop('disposable_income', period)
+    traced_value = list(simulation.tracer.trace.values())[0]['value']
+    assert traced_value.size == simulation.persons.count

--- a/tests/core/test_subpopulations.py
+++ b/tests/core/test_subpopulations.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_array_equal
 
 from openfisca_core.populations import SubPopulation, GroupSubPopulation
 
@@ -10,8 +11,8 @@ def test_ind_sub_pop():
     subpop = SubPopulation(simulation.persons, age >= 18)
 
 
-    assert (subpop.ids == ['ind0', 'ind1', 'ind3', 'ind4']).all()
-    assert (subpop.has_role(simulation.household.entity.PARENT) == [True, True, False, True]).all()
+    assert_array_equal(subpop.ids, ['ind0', 'ind1', 'ind3', 'ind4'])
+    assert_array_equal(subpop.has_role(simulation.household.entity.PARENT), [True, True, False, True])
 
 
 def test_household_sub_pop():
@@ -19,8 +20,8 @@ def test_household_sub_pop():
         'persons': {'ind0': {}, 'ind1': {}, 'ind2': {}, 'ind3': {}, 'ind4': {}, 'ind5': {}, 'ind6': {}},
         'households': {
             'h1': {'children': ['ind2', 'ind3'], 'parents': ['ind0', 'ind1']},
+            'h3': {'parents': ['ind6']},
             'h2': {'children': ['ind5'], 'parents': ['ind4']},
-            'h3': {'parents': ['ind6']}
             },
         }
 
@@ -32,12 +33,12 @@ def test_household_sub_pop():
     households = GroupSubPopulation(simulation.household, condition)
 
     age = households.members('age', period)
-    assert (age == [40, 37, 7, 19, 54, 16]).all()
+    assert_array_equal(age, [40, 37, 7, 19, 54, 16])
 
-    assert (households.members_entity_id == simulation.household.members_entity_id[:-1]).all()
-    assert (households.members_role == simulation.household.members_role[:-1]).all()
-    assert (households.members_position == simulation.household.members_position[:-1]).all()
+    assert_array_equal(households.members_entity_id, [0, 0, 0, 0, 1, 1])
+    assert_array_equal(households.members_role, simulation.household.members_role[:-1])
+    assert_array_equal(households.members_position, simulation.household.members_position[:-1])
 
-    assert (households.sum(age) == [40 + 37 + 19 + 7, 54 + 16]).all()
-    assert (households.any(age > 50) == [False, True]).all()
+    assert_array_equal(households.sum(age), [40 + 37 + 19 + 7, 54 + 16])
+    assert_array_equal(households.any(age > 50), [False, True])
 

--- a/tests/core/test_subpopulations.py
+++ b/tests/core/test_subpopulations.py
@@ -1,14 +1,12 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from openfisca_core.populations import SubPopulation, GroupSubPopulation
-
 from .test_entities import TEST_CASE, new_simulation
 
 def test_ind_sub_pop():
     simulation = new_simulation(TEST_CASE)
     age = np.asarray([40, 37, 7, 19, 54, 16])
-    subpop = SubPopulation(simulation.persons, age >= 18)
+    subpop = simulation.persons.get_subpopulation(age >= 18)
 
 
     assert_array_equal(subpop.ids, ['ind0', 'ind1', 'ind3', 'ind4'])
@@ -30,7 +28,7 @@ def test_household_sub_pop():
     simulation.set_input('age', period, np.asarray([40, 37, 7, 19, 54, 16, 30]))
 
     condition = simulation.household.nb_persons() > 1
-    households = GroupSubPopulation(simulation.household, condition)
+    households = simulation.household.get_subpopulation(condition)
 
     age = households.members('age', period)
     assert_array_equal(age, [40, 37, 7, 19, 54, 16])

--- a/tests/core/test_subpopulations.py
+++ b/tests/core/test_subpopulations.py
@@ -208,3 +208,12 @@ def test_trace_2(simulation, p_subpop):
     p_subpop('disposable_income', period)
     traced_value = list(simulation.tracer.trace.values())[0]['value']
     assert traced_value.size == simulation.persons.count
+
+
+def test_complex_projection(simulation):
+    simulation.set_input('age', period, np.asarray([40, 37, 7, 19, 54, 16]))
+    p_subpop = simulation.persons.get_subpopulation(simulation.persons.has_role(SECOND_PARENT))
+    assert_array_equal(
+        p_subpop.household.first_parent('age', period),
+        [40]
+        )

--- a/tests/core/test_subpopulations.py
+++ b/tests/core/test_subpopulations.py
@@ -28,34 +28,40 @@ def test_default_array(p_subpop):
     assert_array_equal(p_subpop.default_array('salary'), [0, 0, 0, 0])
 
 
-def test_read_cache(p_subpop):
+def test_cache_pop_to_subpop(p_subpop):
     simulation = p_subpop.simulation
     simulation.set_input('salary', period, [1000, 2000, 0, 1200, 2400, 800])
-    assert_array_equal(p_subpop.get_cached_array('salary', period), [1000, 2000, 1200, 2400])
+    cached_array_subpop = p_subpop.get_cached_array('salary', period).value
+    assert_array_equal(cached_array_subpop, [1000, 2000, 1200, 2400])
 
 
-def test_household_sub_pop():
-    test_case = {
-        'persons': {'ind0': {}, 'ind1': {}, 'ind2': {}, 'ind3': {}, 'ind4': {}, 'ind5': {}, 'ind6': {}},
-        'households': {
-            'h1': {'children': ['ind2', 'ind3'], 'parents': ['ind0', 'ind1']},
-            'h3': {'parents': ['ind4']},
-            'h2': {'children': ['ind6'], 'parents': ['ind5']},
-            },
-        }
+def test_cache_subpop_to_pop(p_subpop):
+    p_subpop.put_in_cache('salary', period, [1000, 2000, 1200, 2400])
+    assert_array_equal(p_subpop.population('salary', period), [1000, 2000, 0, 1200, 2400, 0])
 
-    simulation = new_simulation(test_case)
-    simulation.set_input('age', period, np.asarray([40, 37, 7, 19, 30, 54, 16]))
 
-    condition = simulation.household.nb_persons() > 1
-    households = simulation.household.get_subpopulation(condition)
+# def test_household_sub_pop():
+#     test_case = {
+#         'persons': {'ind0': {}, 'ind1': {}, 'ind2': {}, 'ind3': {}, 'ind4': {}, 'ind5': {}, 'ind6': {}},
+#         'households': {
+#             'h1': {'children': ['ind2', 'ind3'], 'parents': ['ind0', 'ind1']},
+#             'h3': {'parents': ['ind4']},
+#             'h2': {'children': ['ind6'], 'parents': ['ind5']},
+#             },
+#         }
 
-    age = households.members('age', period)
-    assert_array_equal(age, [40, 37, 7, 19, 54, 16])
+#     simulation = new_simulation(test_case)
+#     simulation.set_input('age', period, np.asarray([40, 37, 7, 19, 30, 54, 16]))
 
-    assert_array_equal(households.members_entity_id, [0, 0, 0, 0, 1, 1])
-    assert_array_equal(households.members_role, [FIRST_PARENT, SECOND_PARENT, CHILD, CHILD, FIRST_PARENT, CHILD])
-    assert_array_equal(households.members_position, [0, 1, 2, 3, 0, 1])
+#     condition = simulation.household.nb_persons() > 1
+#     households = simulation.household.get_subpopulation(condition)
 
-    assert_array_equal(households.sum(age), [40 + 37 + 19 + 7, 54 + 16])
-    assert_array_equal(households.any(age > 50), [False, True])
+#     age = households.members('age', period)
+#     assert_array_equal(age, [40, 37, 7, 19, 54, 16])
+
+#     assert_array_equal(households.members_entity_id, [0, 0, 0, 0, 1, 1])
+#     assert_array_equal(households.members_role, [FIRST_PARENT, SECOND_PARENT, CHILD, CHILD, FIRST_PARENT, CHILD])
+#     assert_array_equal(households.members_position, [0, 1, 2, 3, 0, 1])
+
+#     assert_array_equal(households.sum(age), [40 + 37 + 19 + 7, 54 + 16])
+#     assert_array_equal(households.any(age > 50), [False, True])

--- a/tests/core/test_subpopulations.py
+++ b/tests/core/test_subpopulations.py
@@ -165,13 +165,30 @@ def test_projection_p_to_h(simulation_h, h_subpop):
     )
 
 
-# def test_projection_h_to_p(simulation_h, h_subpop):
-#     simulation_h.set_input('housing_tax', 2019, np.asarray([500, 400, 600]))
-#     p_subpop = simulation_h.persons.get_subpopulation([True, True, True, False, True, True, True])
+def test_projection_h_to_p(simulation_h, h_subpop):
+    simulation_h.set_input('housing_tax', 2019, np.asarray([500, 400, 600]))
+    p_subpop = simulation_h.persons.get_subpopulation(np.asarray([True, True, True, False, True, True, True]))
 
-#     # import ipdb; ipdb.set_trace()
-#     p_subpop.household
-#     assert_array_equal(
-#         p_subpop.household('housing_tax', 2019),
-#         [500, 600]
-#     )
+    # import ipdb; ipdb.set_trace()
+    assert_array_equal(
+        p_subpop.household.ids,
+        ['h1', 'h1', 'h1', 'h3', 'h2', 'h2']
+    )
+    assert_array_equal(
+        p_subpop.household('housing_tax', 2019),
+        [500, 500, 500, 400, 600, 600]
+    )
+
+def test_projection_h_to_p_2(simulation_h, h_subpop):
+    simulation_h.set_input('housing_tax', 2019, np.asarray([500, 400, 600]))
+    p_subpop = simulation_h.persons.get_subpopulation(np.asarray([True, True, True, True, False, True, True]))
+
+    # import ipdb; ipdb.set_trace()
+    assert_array_equal(
+        p_subpop.household.ids,
+        ['h1', 'h1', 'h1', 'h1', 'h2', 'h2']
+    )
+    assert_array_equal(
+        p_subpop.household('housing_tax', 2019),
+        [500, 500, 500, 500, 600, 600]
+    )

--- a/tests/core/test_subpopulations.py
+++ b/tests/core/test_subpopulations.py
@@ -86,6 +86,13 @@ def test_global_calculation(simulation, p_subpop):
         [1000, 2000, 0, 1200, 2400, 0]
         )
 
+def test_subpop_calculation(simulation, p_subpop):
+    simulation.set_input('salary', period, [1000, 2000, 500, 1200, 2400, 800])
+    assert_array_equal(
+        p_subpop('salary', period),
+        [1000, 2000, 1200, 2400]
+    )
+
 
 
 # def test_household_sub_pop():

--- a/tests/core/tools/test_combine.py
+++ b/tests/core/tools/test_combine.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+from numpy.testing import assert_array_equal
+
+from openfisca_core.tools import combine
+
+
+def test_combine():
+    condition = np.asarray([True, False, True, True, False])
+    value_for_true = np.asarray([1, 2, 3])
+    value_for_false = np.asarray([10, 20])
+
+    assert_array_equal(
+        combine(condition, value_for_true, value_for_false),
+        [1, 10, 2, 3, 20]
+    )

--- a/tests/core/tools/test_combine.py
+++ b/tests/core/tools/test_combine.py
@@ -13,15 +13,16 @@ def test_ternary_combine():
     assert_array_equal(
         ternary_combine(condition, value_for_true, value_for_false),
         [1, 10, 2, 3, 20]
-    )
+        )
+
 
 def test_combine():
     condition_1 = np.asarray([True, False, True, True, False])
     condition_2 = np.asarray([True, True, True, False, True])
-    value_1 =  np.asarray([1, 3, 4])
-    value_2 =  np.asarray([10, 20, 30, 50])
+    value_1 = np.asarray([1, 3, 4])
+    value_2 = np.asarray([10, 20, 30, 50])
 
     assert_array_equal(
-        combine([(condition_1, value_1), ( condition_2, value_2)]),
+        combine([(condition_1, value_1), (condition_2, value_2)]),
         [1, 20, 3, 4, 50]
-    )
+        )

--- a/tests/core/tools/test_combine.py
+++ b/tests/core/tools/test_combine.py
@@ -2,15 +2,26 @@ import numpy as np
 
 from numpy.testing import assert_array_equal
 
-from openfisca_core.tools import combine
+from openfisca_core.tools import ternary_combine, combine
 
 
-def test_combine():
+def test_ternary_combine():
     condition = np.asarray([True, False, True, True, False])
     value_for_true = np.asarray([1, 2, 3])
     value_for_false = np.asarray([10, 20])
 
     assert_array_equal(
-        combine(condition, value_for_true, value_for_false),
+        ternary_combine(condition, value_for_true, value_for_false),
         [1, 10, 2, 3, 20]
+    )
+
+def test_combine():
+    condition_1 = np.asarray([True, False, True, True, False])
+    condition_2 = np.asarray([True, True, True, False, True])
+    value_1 =  np.asarray([1, 3, 4])
+    value_2 =  np.asarray([10, 20, 30, 50])
+
+    assert_array_equal(
+        combine([(condition_1, value_1), ( condition_2, value_2)]),
+        [1, 20, 3, 4, 50]
     )


### PR DESCRIPTION
Connected to #862 

This PR follows up on the discussion on #862 and aims at building the base needed to allow using the split and combine approach.

I've tried to experiment using the new operator in a couple formulas on a France branch (`xp-split-combine`). I noticed  a 10% reduction of the time needed to run`test_basics.py`.


-------------------------------

#### Breaking changes

- `population.ids` is now a NumPy array, and not a regular Python list.

#### New features

- Introduce `population.get_subpopbulation(condition)`
  - This allow to extract a supopulation based on a condition
  - Subpopulations can be used the same way than regular populations
- Introduce `population.if_()`, which allows ternary conditions using the split and combine approach.

#### Technical notes

- Subpopulations don't handle their own cache: they write and read in their super_population cache

#### Minor changes

- Add type-checking to the build
