### PR TITLE
Allow formulas to return scalar values and broadcast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 34.2.0
+
+#### New features
+
+- Allow formulas to return scalar values; broadcast these values to population-sized arrays
+
 ## 34.1.0
 
 #### New features

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -249,7 +249,6 @@ class Simulation(object):
         else:
             array = formula(population, period, parameters_at)
 
-        self._check_formula_result(array, variable, population, period)
         return array
 
     def _check_period_consistency(self, period, variable):
@@ -307,6 +306,10 @@ class Simulation(object):
     def _cast_formula_result(self, value, variable):
         if variable.value_type == Enum and not isinstance(value, EnumArray):
             return variable.possible_values.encode(value)
+
+        if not isinstance(value, np.ndarray):
+            population = self.get_variable_population(variable.name)
+            value = population.filled_array(value)
 
         if value.dtype != variable.dtype:
             return value.astype(variable.dtype)

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 
 
-from os import linesep
 import tempfile
 import logging
 
 import numpy as np
 
 from openfisca_core import periods
-from openfisca_core.commons import empty_clone, stringify_array
+from openfisca_core.commons import empty_clone
 from openfisca_core.tracers import Tracer, TracingParameterNodeAtInstant
 from openfisca_core.indexed_enums import Enum, EnumArray
 
@@ -276,32 +275,6 @@ class Simulation(object):
                 period,
                 'month' if variable.definition_period == periods.MONTH else 'year'
                 ))
-
-    def _check_formula_result(self, value, variable, entity, period):
-
-        assert isinstance(value, np.ndarray), (linesep.join([
-            "You tried to compute the formula '{0}' for the period '{1}'.".format(variable.name, str(period)),
-            "The formula '{0}@{1}' should return a Numpy array;".format(variable.name, str(period)),
-            "instead it returned '{0}' of {1}.".format(value, type(value)),
-            "Learn more about Numpy arrays and vectorial computing:",
-            "<https://openfisca.org/doc/coding-the-legislation/25_vectorial_computing.html.>"
-            ]))
-
-        assert value.size == entity.count, \
-            "Function {}@{}<{}>() --> <{}>{} returns an array of size {}, but size {} is expected for {}".format(
-                variable.name, entity.key, str(period), str(period), stringify_array(value),
-                value.size, entity.count, entity.key)
-
-        if self.debug:
-            try:
-                # cf https://stackoverflow.com/questions/6736590/fast-check-for-nan-in-numpy
-                if np.isnan(np.min(value)):
-                    nan_count = np.count_nonzero(np.isnan(value))
-                    raise NaNCreationError("Function {}@{}<{}>() --> <{}>{} returns {} NaN value(s)".format(
-                        variable.name, entity.key, str(period), str(period), stringify_array(value),
-                        nan_count))
-            except TypeError:
-                pass
 
     def _cast_formula_result(self, value, variable):
         if variable.value_type == Enum and not isinstance(value, EnumArray):

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '34.1.0',
+    version = '34.2.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_formulas.py
+++ b/tests/core/test_formulas.py
@@ -10,7 +10,7 @@ from openfisca_core.formula_helpers import switch
 from openfisca_country_template import CountryTaxBenefitSystem
 from openfisca_country_template.entities import Person
 
-from pytest import fixture
+from pytest import fixture, approx
 
 
 class choice(Variable):
@@ -29,6 +29,16 @@ class uses_multiplication(Variable):
         choice = person('choice', period)
         result = (choice == 1) * 80 + (choice == 2) * 90
         return result
+
+
+class returns_scalar(Variable):
+    value_type = int
+    entity = Person
+    label = 'Variable with formula that returns a scalar value'
+    definition_period = MONTH
+
+    def formula(person, period):
+        return 666
 
 
 class uses_switch(Variable):
@@ -51,7 +61,7 @@ class uses_switch(Variable):
 
 # TaxBenefitSystem instance declared after formulas
 our_tbs = CountryTaxBenefitSystem()
-our_tbs.add_variables(choice, uses_multiplication, uses_switch)
+our_tbs.add_variables(choice, uses_multiplication, uses_switch, returns_scalar)
 
 
 @fixture
@@ -76,6 +86,12 @@ def test_switch(simulation, month):
 def test_multiplication(simulation, month):
     uses_multiplication = simulation.calculate('uses_multiplication', period = month)
     assert isinstance(uses_multiplication, np.ndarray)
+
+
+def test_broadcast_scalar(simulation, month):
+    array_value = simulation.calculate('returns_scalar', period = month)
+    assert isinstance(array_value, np.ndarray)
+    assert array_value == approx(np.repeat(666, 1000))
 
 
 def test_compare_multiplication_and_switch(simulation, month):


### PR DESCRIPTION
#### Technical changes

- Allow formulas to return scalar values; broadcast these values to population-sized arrays

Note that the check for "formulas must return an array" was not unit tested and included, also untested, functionality to check for NaNs in debug mode; this is removed by that PR.

This fixes the underlying issue of #853 - a formula can now compute a value derived from a parameter, for use in a vector computation.