### PR TITLE
[WIP] Handle heterogenous periods, dispatch and divide in SimulationBuilder

### DIFF
--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -12,7 +12,7 @@ from openfisca_core.commons import empty_clone
 from openfisca_core.data_storage import InMemoryStorage, OnDiskStorage
 from openfisca_core.errors import PeriodMismatchError
 from openfisca_core.indexed_enums import Enum
-from openfisca_core.periods import MONTH, YEAR, ETERNITY
+from openfisca_core.periods import ETERNITY
 from openfisca_core.tools import eval_expression
 
 log = logging.getLogger(__name__)
@@ -151,9 +151,6 @@ class Holder(object):
             >>> holder.set_input([12, 14], '2018-04')
             >>> holder.get_array('2018-04')
             >>> [12, 14]
-
-
-            If a ``set_input`` property has been set for the variable, this method may accept inputs for periods not matching the ``definition_period`` of the variable. To read more about this, check the `documentation <https://openfisca.org/doc/coding-the-legislation/35_periods.html#set-input-automatically-process-variable-inputs-defined-for-periods-not-matching-the-definition-period>`_.
         """
 
         period = periods.period(period)
@@ -179,8 +176,6 @@ class Holder(object):
                 )
         if self.variable.value_type in (float, int) and isinstance(array, str):
             array = eval_expression(array)
-        if self.variable.set_input:
-            return self.variable.set_input(self, period, array)
         return self._set(period, array)
 
     def _to_array(self, value):
@@ -255,82 +250,6 @@ class Holder(object):
         return self.variable.default_array(self.population.count)
 
 
-def set_input_dispatch_by_period(holder, period, array):
-    """
-        This function can be declared as a ``set_input`` attribute of a variable.
+set_input_dispatch_by_period = 'set_input_dispatch_by_period'
 
-        In this case, the variable will accept inputs on larger periods that its definition period, and the value for the larger period will be applied to all its subperiods.
-
-        To read more about ``set_input`` attributes, check the `documentation <https://openfisca.org/doc/coding-the-legislation/35_periods.html#set-input-automatically-process-variable-inputs-defined-for-periods-not-matching-the-definition-period>`_.
-    """
-    array = holder._to_array(array)
-
-    period_size = period.size
-    period_unit = period.unit
-
-    if holder.variable.definition_period == MONTH:
-        cached_period_unit = periods.MONTH
-    elif holder.variable.definition_period == YEAR:
-        cached_period_unit = periods.YEAR
-    else:
-        raise ValueError('set_input_dispatch_by_period can be used only for yearly or monthly variables.')
-
-    after_instant = period.start.offset(period_size, period_unit)
-
-    # Cache the input data, skipping the existing cached months
-    sub_period = period.start.period(cached_period_unit)
-    while sub_period.start < after_instant:
-        existing_array = holder.get_array(sub_period)
-        if existing_array is None:
-            holder._set(sub_period, array)
-        else:
-            # The array of the current sub-period is reused for the next ones.
-            # TODO: refactor or document this behavior
-            array = existing_array
-        sub_period = sub_period.offset(1)
-
-
-def set_input_divide_by_period(holder, period, array):
-    """
-        This function can be declared as a ``set_input`` attribute of a variable.
-
-        In this case, the variable will accept inputs on larger periods that its definition period, and the value for the larger period will be divided between its subperiods.
-
-        To read more about ``set_input`` attributes, check the `documentation <https://openfisca.org/doc/coding-the-legislation/35_periods.html#set-input-automatically-process-variable-inputs-defined-for-periods-not-matching-the-definition-period>`_.
-    """
-    if not isinstance(array, np.ndarray):
-        array = np.array(array)
-    period_size = period.size
-    period_unit = period.unit
-
-    if holder.variable.definition_period == MONTH:
-        cached_period_unit = periods.MONTH
-    elif holder.variable.definition_period == YEAR:
-        cached_period_unit = periods.YEAR
-    else:
-        raise ValueError('set_input_divide_by_period can be used only for yearly or monthly variables.')
-
-    after_instant = period.start.offset(period_size, period_unit)
-
-    # Count the number of elementary periods to change, and the difference with what is already known.
-    remaining_array = array.copy()
-    sub_period = period.start.period(cached_period_unit)
-    sub_periods_count = 0
-    while sub_period.start < after_instant:
-        existing_array = holder.get_array(sub_period)
-        if existing_array is not None:
-            remaining_array -= existing_array
-        else:
-            sub_periods_count += 1
-        sub_period = sub_period.offset(1)
-
-    # Cache the input data
-    if sub_periods_count > 0:
-        divided_array = remaining_array / sub_periods_count
-        sub_period = period.start.period(cached_period_unit)
-        while sub_period.start < after_instant:
-            if holder.get_array(sub_period) is None:
-                holder._set(sub_period, divided_array)
-            sub_period = sub_period.offset(1)
-    elif not (remaining_array == 0).all():
-        raise ValueError("Inconsistent input: variable {0} has already been set for all months contained in period {1}, and value {2} provided for {1} doesn't match the total ({3}). This error may also be thrown if you try to call set_input twice for the same variable and period.".format(holder.variable.name, period, array, array - remaining_array))
+set_input_divide_by_period = 'set_input_divide_by_period'

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -141,45 +141,6 @@ def test_person_variable_with_constructor():
     assert_near(person('salary', "2017-12"), [2000, 0, 4000, 0, 0])
 
 
-def test_set_input_with_constructor():
-    simulation_yaml = """
-        persons:
-          bill:
-            salary:
-              '2017': 24000
-              2017-11: 2000
-              2017-12: 2000
-          bob:
-            salary:
-              '2017': 30000
-              2017-11: 0
-              2017-12: 0
-          claudia:
-            salary:
-              '2017': 24000
-              2017-11: 4000
-              2017-12: 4000
-          janet: {}
-          tom: {}
-        households:
-          first_household:
-            parents:
-            - bill
-            - bob
-            children:
-            - janet
-            - tom
-          second_household:
-            parents:
-            - claudia
-    """
-
-    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.safe_load(simulation_yaml))
-    person = simulation.person
-    assert_near(person('salary', "2017-12"), [2000, 0, 4000, 0, 0])
-    assert_near(person('salary', "2017-10"), [2000, 3000, 1600, 0, 0])
-
-
 def test_has_role():
     simulation = new_simulation(TEST_CASE)
     individu = simulation.persons

--- a/tests/core/test_simulation_builder.py
+++ b/tests/core/test_simulation_builder.py
@@ -276,15 +276,15 @@ def test_finalize_person_entity(simulation_builder, persons):
 
 
 def test_heterogenous_periods(simulation_builder, persons):
+    salary = persons.get_variable('salary')
+    salary.definition_period = MONTH
+    salary.set_input = set_input_divide_by_period
+
     months = {month: 500 for month in ["2018-{:02d}".format(x) for x in range(1, 13)]}
-    year = {'2018': 6000}
+    year = {'2018': 12000}
     persons_json = {'Alicia': {'salary': year}, 'Javier': {'salary': months}}
     simulation_builder.add_person_entity(persons, persons_json)
     population = Population(persons)
-
-    salary = population.entity.get_variable('salary')
-    salary.definition_period = MONTH
-    salary.set_input = set_input_divide_by_period
 
     simulation_builder.finalize_variables_init(population)
     assert_near(population.get_holder('salary').get_array('2018-01'), [1000, 500])

--- a/tests/core/test_simulation_builder.py
+++ b/tests/core/test_simulation_builder.py
@@ -292,6 +292,45 @@ def test_heterogenous_periods(simulation_builder, persons):
     assert population.ids == ['Alicia', 'Javier']
 
 
+def test_partial_allocation_with_heterogenous_periods():
+    simulation_yaml = """
+        persons:
+          bill:
+            salary:
+              '2017': 24000
+              2017-11: 2000
+              2017-12: 2000
+          bob:
+            salary:
+              '2017': 30000
+              2017-11: 0
+              2017-12: 0
+          claudia:
+            salary:
+              '2017': 24000
+              2017-11: 4000
+              2017-12: 4000
+          janet: {}
+          tom: {}
+        households:
+          first_household:
+            parents:
+            - bill
+            - bob
+            children:
+            - janet
+            - tom
+          second_household:
+            parents:
+            - claudia
+    """
+
+    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, yaml.safe_load(simulation_yaml))
+    person = simulation.person
+    assert_near(person('salary', "2017-12"), [2000, 0, 4000, 0, 0])
+    assert_near(person('salary', "2017-10"), [2000, 3000, 1600, 0, 0])
+
+
 def test_canonicalize_period_keys(simulation_builder, persons):
     persons_json = {'Alicia': {'salary': {'year:2018-01': 100}}}
     simulation_builder.add_person_entity(persons, persons_json)


### PR DESCRIPTION
TODO:
- [ ] Handle tabular set_input with temporal inferences (divide/dispatch by period) directly in SimulationBuilder

#### Breaking changes

- Moves the logic for "dispatch by period" and "divide by period" from Holders to SimulationBuilder
  - This preserves the current behaviour for all users of the YAML test formats and JSON payloads, you will however be affected if you are relying on this behaviour when calling `set_input` directly.

#### Migration guide

- If you are calling `set_input` directly AND relying on dispatch or divide behaviour, alter your code to obtain the subperiods of periods larger than the definition period of the variable being set. Alternately, you can construct your simulation data with SimulationBuilder.

Fixes #564

This currently breaks the optimization from #827 because dispatch/divide can happen at the individual level and not just array-wise - @fpagnoux I'm not sure the best way to get that back, I'm thinking of performing checks on array equality at finalize time. WDYT ?