### PR TITLE
Support role indices in join_with_persons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 34.1.0
+
+#### New features
+
+- Support role indices in SimulationBuilder.join_with_persons
+  - This broadens the range of input data we can handle, at some risk of misattributing roles
+
 ### 34.0.1
 
 #### Bug fix

--- a/openfisca_core/simulation_builder.py
+++ b/openfisca_core/simulation_builder.py
@@ -186,8 +186,10 @@ class SimulationBuilder(object):
         return self.populations[entity_singular].nb_persons(role = role)
 
     def join_with_persons(self, group_population, persons_group_assignment, roles: Iterable[str]):
+        # Maps group's identifiers to a 0-based integer range, for indexing into members_roles (see PR#876)
         group_sorted_indices = np.unique(persons_group_assignment, return_inverse = True)[1]
         group_population.members_entity_id = np.argsort(group_population.ids)[group_sorted_indices]
+
         flattened_roles = group_population.entity.flattened_roles
         roles_array = np.array(roles)
         if np.issubdtype(roles_array.dtype, np.integer):

--- a/openfisca_core/simulation_builder.py
+++ b/openfisca_core/simulation_builder.py
@@ -189,8 +189,11 @@ class SimulationBuilder(object):
         group_sorted_indices = np.unique(persons_group_assignment, return_inverse = True)[1]
         group_population.members_entity_id = np.argsort(group_population.ids)[group_sorted_indices]
         flattened_roles = group_population.entity.flattened_roles
-        role_names_array = np.array(roles)
-        group_population.members_role = np.select([role_names_array == role.key for role in flattened_roles], flattened_roles)
+        roles_array = np.array(roles)
+        if np.issubdtype(roles_array.dtype, np.integer):
+            group_population.members_role = np.array(flattened_roles)[roles_array]
+        else:
+            group_population.members_role = np.select([roles_array == role.key for role in flattened_roles], flattened_roles)
 
     def build(self, tax_benefit_system):
         return Simulation(tax_benefit_system, self.populations)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '34.0.1',
+    version = '34.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_simulation_builder.py
+++ b/tests/core/test_simulation_builder.py
@@ -404,6 +404,27 @@ def test_nb_persons_by_role(simulation_builder):
     assert parents_in_households.tolist() == [0, 1, 1]
 
 
+def test_integral_roles(simulation_builder):
+    persons_ids: Iterable = [2, 0, 1, 4, 3]
+    households_ids: Iterable = ['c', 'a', 'b']
+    persons_households: Iterable = ['c', 'a', 'a', 'b', 'a']
+    # Same roles as test_nb_persons_by_role
+    persons_households_roles: Iterable = [2, 0, 1, 0, 2]
+
+    simulation_builder.create_entities(tax_benefit_system)
+    simulation_builder.declare_person_entity('person', persons_ids)
+    household_instance = simulation_builder.declare_entity('household', households_ids)
+
+    simulation_builder.join_with_persons(
+        household_instance,
+        persons_households,
+        persons_households_roles
+        )
+    parents_in_households = household_instance.nb_persons(role = Household.FIRST_PARENT)
+
+    assert parents_in_households.tolist() == [0, 1, 1]
+
+
 # Test Intégration
 
 


### PR DESCRIPTION
#### New features

- Support role indices in SimulationBuilder.join_with_persons
  - This broadens the range of input data we can handle, at some risk of misattributing roles
