### PR TITLE
Enforce type checking in tests and CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ dist/
 .tags*
 .noseids
 .pytest_cache
-
+.mypy_cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 34.2.7 [#886](https://github.com/openfisca/openfisca-core/pull/885)
+
+#### Minor change
+
+- Enforce type checking in tests and Continuous Integration
+
 ### 34.2.6 [#886](https://github.com/openfisca/openfisca-core/pull/886)
 
 #### Minor change

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ clean:
 check-syntax-errors:
 	python -m compileall -q .
 
+check-types:
+	mypy openfisca_core && mypy openfisca_web_api
+
 check-style:
 	@# Do not analyse .gitignored files.
 	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
@@ -24,7 +27,7 @@ format-style:
 	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
 	autopep8 `git ls-files | grep "\.py$$"`
 
-test: clean check-syntax-errors check-style
+test: clean check-syntax-errors check-style check-types
 	env PYTEST_ADDOPTS="$$PYTEST_ADDOPTS --cov=openfisca_core" pytest
 
 api:

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     log.warning(
         "libyaml is not installed in your environment. This can make OpenFisca slower to start. Once you have installed libyaml, run 'pip uninstall pyyaml && pip install pyyaml --no-cache-dir' so that it is used in your Python environment." + os.linesep)
-    from yaml import Loader
+    from yaml import Loader  # type: ignore # (see https://github.com/python/mypy/issues/1153#issuecomment-455802270)
 
 
 FILE_EXTENSIONS = {'.yaml', '.yml'}

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -8,6 +8,7 @@ import os
 import sys
 import logging
 import traceback
+from typing import Iterable, Optional
 
 import yaml
 import numpy as np
@@ -325,7 +326,7 @@ class ParameterNode(object):
         A node in the legislation `parameter tree <https://openfisca.org/doc/coding-the-legislation/legislation_parameters.html>`_.
     """
 
-    _allowed_keys = None  # By default, no restriction on the keys
+    _allowed_keys: Optional[Iterable[str]] = None  # By default, no restriction on the keys
 
     def __init__(self, name = "", directory_path = None, data = None, file_path = None):
         """

--- a/openfisca_core/periods.py
+++ b/openfisca_core/periods.py
@@ -12,6 +12,7 @@ import calendar
 import datetime
 import re
 from os import linesep
+from typing import Dict
 
 
 DAY = 'day'
@@ -26,8 +27,8 @@ def N_(message):
     return message
 
 
-date_by_instant_cache = {}
-str_by_instant_cache = {}
+date_by_instant_cache: Dict = {}
+str_by_instant_cache: Dict = {}
 year_or_month_or_day_re = re.compile(r'(18|19|20)\d{2}(-(0?[1-9]|1[0-2])(-([0-2]?\d|3[0-1]))?)?$')
 
 

--- a/openfisca_core/populations.py
+++ b/openfisca_core/populations.py
@@ -241,6 +241,10 @@ class GroupPopulation(Population):
 
         return self._members_position
 
+    @members_position.setter
+    def members_position(self, members_position):
+        self._members_position = members_position
+
     @property
     def members_entity_id(self):
         return self._members_entity_id
@@ -273,10 +277,6 @@ class GroupPopulation(Population):
 
     def get_role(self, role_name):
         return next((role for role in self.entity.flattened_roles if role.key == role_name), None)
-
-    @members_position.setter
-    def members_position(self, members_position):
-        self._members_position = members_position
 
     #  Aggregation persons -> entity
 

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -5,6 +5,7 @@ import sys
 import os
 import traceback
 import textwrap
+from typing import Dict
 
 import pytest
 
@@ -34,7 +35,7 @@ TEST_KEYWORDS = {'absolute_error_margin', 'description', 'extensions', 'ignore_v
 
 yaml, Loader = import_yaml()
 
-_tax_benefit_system_cache = {}
+_tax_benefit_system_cache: Dict = {}
 
 
 def run_tests(tax_benefit_system, paths, options = None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,3 +17,9 @@ in-place     = true
 addopts      = --showlocals --doctest-modules --disable-pytest-warnings
 testpaths    = tests
 python_files = **/*.py
+
+[mypy]
+ignore_missing_imports = True
+
+[mypy-openfisca_core.scripts.*]
+ignore_errors = True

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '34.2.6',
+    version = '34.2.7',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ dev_requirements = [
     'flake8-bugbear >= 19.3.0, < 20.0.0',
     'flake8-print >= 3.1.0, < 4.0.0',
     'pytest-cov >= 2.6.1, < 3.0.0',
+    'mypy >= 0.701, < 0.800',
     'openfisca-country-template >= 3.6.0rc0, < 4.0.0',
     'openfisca-extension-template >= 1.2.0rc0, < 2.0.0'
     ] + api_requirements


### PR DESCRIPTION
Extracted from #871 


Typing remains optional: the type checker will only make sure that the optional annotations are consistent with the code.

Why typing ? 

- Useful as documentation: methods are easier to understand when the input and outputs type are explicit
- Allows to detect some bugs early (works better when there are more annotations in the code)
- See https://www.youtube.com/watch?v=pMgmKJyWKn8 for more 🙂 
