### PR TITLE
Misc ipp fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 34.2.5 [#888](https://github.com/openfisca/openfisca-core/pull/888)
+
+#### Technical changes
+
+- Define a trim option for average rate function.
+- Convert a dict_values to a list (left-over by the python 3 migration)
+- Use a less stric version dependency for psutils. Problem arising with psutils are mainly due to freeze at install. Use `pip` option `--no-cache-dir` if you face troubles at install.
+
 ### 34.2.4 [#870](https://github.com/openfisca/openfisca-core/pull/870)
 
 #### Bug fix

--- a/openfisca_core/data_storage.py
+++ b/openfisca_core/data_storage.py
@@ -71,7 +71,7 @@ class InMemoryStorage(object):
 
         array = next(iter(self._arrays.values()))
         if isinstance(array, dict):
-            array = array.values()[0]
+            array = list(array.values())[0]
         return dict(
             nb_arrays = nb_arrays,
             total_nb_bytes = array.nbytes * nb_arrays,

--- a/openfisca_core/rates.py
+++ b/openfisca_core/rates.py
@@ -4,14 +4,20 @@
 import numpy
 
 
-def average_rate(target = None, varying = None):
+def average_rate(target = None, varying = None, trim = None):
     '''
     Computes the average rate of a targeted net income, according to the varying gross income.
 
     :param target: Targeted net income, numerator
     :param varying: Varying gross income, denominator
+    :param trim: Lower and upper bound of average rate to return
     '''
-    return 1 - target / varying
+    average_rate = 1 - target / varying
+    if trim is not None:
+        average_rate = numpy.where(average_rate <= max(trim), average_rate, numpy.nan)
+        average_rate = numpy.where(average_rate >= min(trim), average_rate, numpy.nan)
+
+    return average_rate
 
 
 def marginal_rate(target = None, varying = None, trim = None):

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '34.2.4',
+    version = '34.2.5',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ general_requirements = [
     'enum34 >= 1.1.6',
     'pytest >= 4.4.1, < 5.0.0',  # For openfisca test
     'numpy >=1.11,<1.17',
-    'psutil >=5.4.7,>6.0.0',
+    'psutil >=5.4.7,<6.0.0',
     'PyYAML >= 3.10',
     'sortedcontainers == 2.1.0',
     'numexpr ==2.6.9',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ general_requirements = [
     'enum34 >= 1.1.6',
     'pytest >= 4.4.1, < 5.0.0',  # For openfisca test
     'numpy >=1.11,<1.17',
-    'psutil ==5.6.2',
+    'psutil >=5.4.7,>6.0.0',
     'PyYAML >= 3.10',
     'sortedcontainers == 2.1.0',
     'numexpr ==2.6.9',


### PR DESCRIPTION
#### Technical changes

- Define a trim option for average rate function.
- Convert a dict_values to a list (left-over by the python 3 migration)
- Use a less stric version dependency for `psutils`. Problem arising with `psutils` are mainly due to freeze at install. Use `pip` option `--no-cache-dir` if you face troubles at install.