### PR TITLE
Fix serialization error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,22 @@
 # Changelog
 
+### 34.3.1 [#900](https://github.com/openfisca/openfisca-core/pull/900)
+
+#### Bug fix
+
+- Fix serialisation error introduced in [34.2.9](https://github.com/openfisca/openfisca-core/tree/34.2.9) in route `/trace` (Web API)
+  - This was causing an Internal Server Error
+  - Notably, `numpy` arrays were not being parsed correctly as not JSON serialisable
+
 ### 34.3.0 [#894](https://github.com/openfisca/openfisca-core/pull/894)
+
+_Note: this version has been unpublished due to an issue introduced by 34.2.9 in the Web API. Please use 34.3.1 or a more recent version._
 
 - Update pytest version's upper bound to 6.0.0
 
 ### 34.2.9 [#884](https://github.com/openfisca/openfisca-core/pull/884)
+
+_Note: this version has been unpublished due to an issue introduced by 34.2.9 in the Web API. Please use 34.3.1 or a more recent version._
 
 - Refactor simulation tracer implementation
   - These changes should be transparent for users

--- a/openfisca_core/tracers.py
+++ b/openfisca_core/tracers.py
@@ -139,7 +139,7 @@ class FullTracer:
                     self.key(child) for child in node['children']
                     ],
                 'parameters': {
-                    self.key(parameter): parameter['value'] for parameter in node['parameters']
+                    self.key(parameter): self.serialize(parameter['value']) for parameter in node['parameters']
                     },
                 'value': self.serialize(node['value'])
                 }

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '34.3.0',
+    version = '34.3.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_tracers.py
+++ b/tests/core/test_tracers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import json
 import numpy as np
 from pytest import fixture, mark, raises, approx
 
@@ -195,6 +196,18 @@ def test_flat_trace(tracer):
     assert len(trace) == 2
     assert trace['a<2019>']['dependencies'] == ['b<2019>']
     assert trace['b<2019>']['dependencies'] == []
+
+
+def test_flat_trace_serialize_vectorial_values(tracer):
+    tracer.enter_calculation('a', 2019)
+    tracer.record_parameter_access('x.y.z', 2019, np.asarray([100, 200, 300]))
+    tracer.record_calculation_result(np.asarray([10, 20, 30]))
+    tracer.exit_calculation()
+
+    trace = tracer.get_flat_trace()
+
+    assert json.dumps(trace['a<2019>']['value'])
+    assert json.dumps(trace['a<2019>']['parameters']['x.y.z<2019>'])
 
 
 def test_flat_trace_with_parameter(tracer):


### PR DESCRIPTION
Fixes #898
Fixes #899
Fixes openfisca/openfisca-france#1360

Alternative solution to #898 

#### Bug fix

- Fix serialisation error introduced in [34.2.9](https://github.com/openfisca/openfisca-core/tree/34.2.9) in route `/trace` (Web API)
  - This was causing an Internal Server Error
  - Notably, `numpy` arrays were not being parsed correctly as not JSON serialisable