### PR TITLE
Remove incompatible library enum34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 34.5.1 [#911](https://github.com/openfisca/openfisca-core/pull/911)
+
+- Remove the library `enum34` from requirements
+  - The library `enum34` provides a backport of >= 3.4 `enum` to >= 2.7, < 3.4 Python environments.
+  - The standard `enum` and `enum34` are hence incompatible as installed under the same path.
+  - Since we dropped support for <= 3.6, that library is no longer needed.
+
 ## 34.5.0 [#909](https://github.com/openfisca/openfisca-core/pull/909)
 
 - Introduce `tax_benefit_system.annualize_variable(variable_name, period)` method

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '34.5.0',
+    version = '34.5.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ from setuptools import setup, find_packages
 
 general_requirements = [
     'dpath == 1.4.2',
-    'enum34 >= 1.1.6',
     'pytest >= 4.4.1, < 6.0.0',  # For openfisca test
     'numpy >= 1.11, < 1.18',
     'psutil >= 5.4.7, < 6.0.0',


### PR DESCRIPTION
Fixes #910

#### Deprecations

- Remove the library `enum34` from requirements
  - The library `enum34` provides a backport of >= 3.4 `enum` to >= 2.7, < 3.4 Python environments.
  - The standard `enum` and `enum34` are hence incompatible as installed under the same path.
  - Since we dropped support for <= 3.6, that library is no longer needed.

