### PR TITLE
Refactor use of deprecated gunicorn.six

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 34.5.1 [#911](https://github.com/openfisca/openfisca-core/pull/911)
+### 34.5.2 [#914](https://github.com/openfisca/openfisca-core/pull/914)
+
+- Refactor the use of the now-deprecated `gunicorn.six` module.
+  - In versions < 20, [gunicorn](http://docs.gunicorn.org/en/19.3/custom.html) provided the `gunicorn.six` module.
+  - In version >= 20, this [gunicorn](http://docs.gunicorn.org/en/stable/custom.html) module has been deprecated.
+  - Adapt `openfisca serve` code to the new gunicorn API.
+
+### 34.5.1 [#911](https://github.com/openfisca/openfisca-core/pull/911)
 
 - Remove the library `enum34` from requirements
   - The library `enum34` provides a backport of >= 3.4 `enum` to >= 2.7, < 3.4 Python environments.

--- a/openfisca_web_api/scripts/serve.py
+++ b/openfisca_web_api/scripts/serve.py
@@ -9,7 +9,6 @@ from openfisca_web_api.errors import handle_import_error
 
 try:
     from gunicorn.app.base import BaseApplication
-    from gunicorn.six import iteritems
     from gunicorn import config
 except ImportError as error:
     handle_import_error(error)
@@ -68,7 +67,7 @@ class OpenFiscaWebAPIApplication(BaseApplication):
         super(OpenFiscaWebAPIApplication, self).__init__()
 
     def load_config(self):
-        for key, value in iteritems(self.options):
+        for key, value in self.options.items():
             if key in self.cfg.settings:
                 self.cfg.set(key.lower(), value)
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '34.5.1',
+    version = '34.5.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ general_requirements = [
 api_requirements = [
     'flask == 1.1.1',
     'flask-cors == 3.0.7',
-    'gunicorn >= 19.7.1',
+    'gunicorn >= 20.0.0, < 21.0.0',
     ]
 
 dev_requirements = [


### PR DESCRIPTION
Fixes #913 

#### Bug fixing

- Refactor the use of the now-deprecated `gunicorn.six` module.
  - In versions < 20, [gunicorn](http://docs.gunicorn.org/en/19.3/custom.html) provided the `gunicorn.six` module.
  - In version >= 20, this [gunicorn](http://docs.gunicorn.org/en/stable/custom.html) module has been deprecated.
  - This pull request adapts `openfisca serve` code to the new gunicorn API.