### PR TITLE
Downgrade Numpy to 1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
+### 34.6.1 [#926](https://github.com/openfisca/openfisca-core/pull/926)
+
+#### Technical change
+
+- Downgrade numpy version's upper bound to 1.17
+- Details:
+  - Numpy 1.18 deprecates the use of several of its methods.
+  - Changes in `numpy.select` have impacted other packages depending on OpenFisca Core.
+
 ## 34.6.0 [#920](https://github.com/openfisca/openfisca-core/pull/920)
+
+_Note: this version has been unpublished due to an issue introduced by 34.5.4. Please use 34.6.1 or a more recent version._
 
 #### New features
 
@@ -45,7 +56,9 @@
 
 #### Technical change
 
-- Update dependency: numpy
+_Note: this version has been unpublished due to an issue introduced by it. Please use 34.6.1 or a more recent version._
+
+- Update numpy version's upper bound to 1.18
 
 ### 34.5.3 [#915](https://github.com/openfisca/openfisca-core/pull/915)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 general_requirements = [
     'dpath == 1.4.2',
     'pytest >= 4.4.1, < 6.0.0',  # For openfisca test
-    'numpy >= 1.11, < 1.19',
+    'numpy >= 1.11, < 1.18',
     'psutil >= 5.4.7, < 6.0.0',
     'PyYAML >= 3.10',
     'sortedcontainers == 2.1.0',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '34.6.0',
+    version = '34.6.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
#### Technical change

- Downgrade numpy version's upper bound to 1.17
- Details:
  - Numpy 1.18 deprecates the use of several of its methods.
  - Changes in `numpy.select` have impacted other packages depending on OpenFisca Core.