### PR TITLE
Use asarray in taxscales.py when we know arg is array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 34.6.3 [#928](https://github.com/openfisca/openfisca-core/pull/928)
+
+#### Technical changes
+
+- Use `asarray` in `taxscales.py` when we know the argument is a `ndarray`.
+- Details:
+  - It prevents `numpy` to copy the array if the `dtype` is compatible.
+
 ### 34.6.2 [#927](https://github.com/openfisca/openfisca-core/pull/927)
 
 #### Documentation

--- a/openfisca_core/taxscales.py
+++ b/openfisca_core/taxscales.py
@@ -9,6 +9,7 @@ from typing import Any, List, NoReturn, Optional, Union
 from numpy import (
     around,
     array,
+    asarray,
     digitize,
     dot,
     finfo,
@@ -275,7 +276,7 @@ class AbstractRateTaxScale(AbstractTaxScale):
                 self.thresholds,
                 )
 
-        if not size(array(tax_base)):
+        if not size(asarray(tax_base)):
             raise EmptyArgumentError(
                 self.__class__.__name__,
                 "bracket_indices",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '34.6.2',
+    version = '34.6.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
#### Technical changes

- Use `asarray` in `taxscales.py` when we know the argument is a `ndarray`.
- Details:
  - It prevents `numpy` to copy the array if the `dtype` is compatible.
