### PR TITLE
Improve taxscales.py typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 34.6.4 [#929](https://github.com/openfisca/openfisca-core/pull/929)
+
+#### Documentation
+
+- Add more explicit typing annotations for `ndarrays`.
+
 ### 34.6.3 [#928](https://github.com/openfisca/openfisca-core/pull/928)
 
 #### Technical changes

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '34.6.3',
+    version = '34.6.4',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
#### Documentation

- Add more explicit typing annotations for `ndarrays`.