### PR TITLE
Add typing to indexed_enums.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 34.6.7 [#932](https://github.com/openfisca/openfisca-core/pull/932)
+
+#### Documentation
+
+- Add typing to `indexed_enums.py`.
+- Details:
+  - Type-annotate `ndarray` types to help contributors know the actual methods signatures.
+
 ### 34.6.6 [#931](https://github.com/openfisca/openfisca-core/pull/931)
 
 #### Technical changes

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@
 [flake8]
 hang-closing = true
 ignore       = E128,E251,F403,F405,E501,W503,W504
+rst-roles    = any
 
 [pep8]
 hang-closing = true

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '34.6.6',
+    version = '34.6.7',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
#### Documentation

- Add typing to `indexed_enums.py`.
- Details:
  - Type-annotate `ndarray` types to help contributors know the actual methods signatures.