### PR TITLE
Use Python's ABC for abstracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 34.7.0 [#943](https://github.com/openfisca/openfisca-core/pull/943)
+
+#### Deprecations
+
+- Deprecate `Dummy`.
+  - The functionality is now directly provided by `empty_clone`.
+
+#### Technical changes
+
+- Refactor abstract scales to use Python's `abc` lib.
+  - This allows for consistent inheritance, which wasn't the case before.
+
 ### 34.6.11 [#945](https://github.com/openfisca/openfisca-core/pull/945)
 
 #### Technical changes

--- a/openfisca_core/commons.py
+++ b/openfisca_core/commons.py
@@ -1,26 +1,37 @@
-# -*- coding: utf-8 -*-
+import warnings
+
+import numpy
 
 
 class Dummy(object):
-    """A class that does nothing
+    """A class that does nothing."""
 
-    Used by function ``empty_clone`` to create an empty instance from an existing object.
-    """
-    pass
+    def __init__(self) -> None:
+        message = [
+            "The 'Dummy' class has been deprecated since version 34.7.0,",
+            "and will be removed in the future.",
+            ]
+        warnings.warn(" ".join(message), DeprecationWarning)
+        pass
 
 
 def empty_clone(original):
     """Create a new empty instance of the same class of the original object."""
+    class Dummy(original.__class__):
+        def __init__(self) -> None:
+            pass
+
     new = Dummy()
     new.__class__ = original.__class__
     return new
 
 
-def stringify_array(array):
+def stringify_array(array: numpy.ndarray) -> str:
     """
-        Generate a clean string representation of a NumPY array.
+    Generate a clean string representation of a NumPY array.
     """
-    return '[{}]'.format(', '.join(
-        str(cell)
-        for cell in array
-        )) if array is not None else 'None'
+
+    if array is None:
+        return "None"
+
+    return f"[{', '.join(str(cell) for cell in array)}]"

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '34.6.11',
+    version = '34.7.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/tax_scales/test_abstract_tax_scale.py
+++ b/tests/core/tax_scales/test_abstract_tax_scale.py
@@ -5,5 +5,5 @@ import pytest
 
 def test_abstract_tax_scale():
     with pytest.warns(DeprecationWarning):
-        result = taxscales.AbstractRateTaxScale()
-        assert type(result) == taxscales.AbstractRateTaxScale
+        result = taxscales.AbstractTaxScale()
+        assert type(result) == taxscales.AbstractTaxScale

--- a/tests/core/tax_scales/test_linear_average_rate_tax_scale.py
+++ b/tests/core/tax_scales/test_linear_average_rate_tax_scale.py
@@ -1,12 +1,79 @@
-from numpy import array
+import numpy
 
-from openfisca_core.taxscales import LinearAverageRateTaxScale
-from openfisca_core.tools import assert_near
+from openfisca_core import taxscales
+from openfisca_core import tools
+
+import pytest
+
+
+def test_bracket_indices():
+    tax_base = numpy.array([0, 1, 2, 3, 4, 5])
+    tax_scale = taxscales.LinearAverageRateTaxScale()
+    tax_scale.add_bracket(0, 0)
+    tax_scale.add_bracket(2, 0)
+    tax_scale.add_bracket(4, 0)
+
+    result = tax_scale.bracket_indices(tax_base)
+
+    tools.assert_near(result, [0, 0, 0, 1, 1, 2])
+
+
+def test_bracket_indices_with_factor():
+    tax_base = numpy.array([0, 1, 2, 3, 4, 5])
+    tax_scale = taxscales.LinearAverageRateTaxScale()
+    tax_scale.add_bracket(0, 0)
+    tax_scale.add_bracket(2, 0)
+    tax_scale.add_bracket(4, 0)
+
+    result = tax_scale.bracket_indices(tax_base, factor = 2.0)
+
+    tools.assert_near(result, [0, 0, 0, 0, 1, 1])
+
+
+def test_bracket_indices_with_round_decimals():
+    tax_base = numpy.array([0, 1, 2, 3, 4, 5])
+    tax_scale = taxscales.LinearAverageRateTaxScale()
+    tax_scale.add_bracket(0, 0)
+    tax_scale.add_bracket(2, 0)
+    tax_scale.add_bracket(4, 0)
+
+    result = tax_scale.bracket_indices(tax_base, round_decimals = 0)
+
+    tools.assert_near(result, [0, 0, 1, 1, 2, 2])
+
+
+def test_bracket_indices_without_tax_base():
+    tax_base = numpy.array([])
+    tax_scale = taxscales.LinearAverageRateTaxScale()
+    tax_scale.add_bracket(0, 0)
+    tax_scale.add_bracket(2, 0)
+    tax_scale.add_bracket(4, 0)
+
+    with pytest.raises(taxscales.EmptyArgumentError):
+        tax_scale.bracket_indices(tax_base)
+
+
+def test_bracket_indices_without_brackets():
+    tax_base = numpy.array([0, 1, 2, 3, 4, 5])
+    tax_scale = taxscales.LinearAverageRateTaxScale()
+
+    with pytest.raises(taxscales.EmptyArgumentError):
+        tax_scale.bracket_indices(tax_base)
+
+
+def test_to_dict():
+    tax_scale = taxscales.LinearAverageRateTaxScale()
+    tax_scale.add_bracket(0, 0)
+    tax_scale.add_bracket(100, 0.1)
+
+    result = tax_scale.to_dict()
+
+    assert result == {"0": 0.0, "100": 0.1}
 
 
 def test_to_marginal():
-    tax_base = array([1, 1.5, 2, 2.5])
-    tax_scale = LinearAverageRateTaxScale()
+    tax_base = numpy.array([1, 1.5, 2, 2.5])
+    tax_scale = taxscales.LinearAverageRateTaxScale()
     tax_scale.add_bracket(0, 0)
     tax_scale.add_bracket(1, 0.1)
     tax_scale.add_bracket(2, 0.2)
@@ -14,5 +81,9 @@ def test_to_marginal():
     result = tax_scale.to_marginal()
 
     assert result.thresholds == [0, 1, 2]
-    assert_near(result.rates, [0.1, 0.3, 0.2], absolute_error_margin = 0)
-    assert_near(result.calc(tax_base), [0.1, 0.25, 0.4, 0.5], absolute_error_margin = 0)
+    tools.assert_near(result.rates, [0.1, 0.3, 0.2], absolute_error_margin = 0)
+    tools.assert_near(
+        result.calc(tax_base),
+        [0.1, 0.25, 0.4, 0.5],
+        absolute_error_margin = 0,
+        )

--- a/tests/core/tax_scales/test_marginal_amount_tax_scale.py
+++ b/tests/core/tax_scales/test_marginal_amount_tax_scale.py
@@ -1,9 +1,9 @@
 from numpy import array
 
-from openfisca_core.parameters import Scale
-from openfisca_core.periods import Instant
-from openfisca_core.taxscales import MarginalAmountTaxScale
-from openfisca_core.tools import assert_near
+from openfisca_core import parameters
+from openfisca_core import periods
+from openfisca_core import taxscales
+from openfisca_core import tools
 
 from pytest import fixture
 
@@ -24,20 +24,20 @@ def data():
 
 def test_calc():
     tax_base = array([1, 8, 10])
-    tax_scale = MarginalAmountTaxScale()
+    tax_scale = taxscales.MarginalAmountTaxScale()
     tax_scale.add_bracket(6, 0.23)
     tax_scale.add_bracket(9, 0.29)
 
     result = tax_scale.calc(tax_base)
 
-    assert_near(result, [0, 0.23, 0.52])
+    tools.assert_near(result, [0, 0.23, 0.52])
 
 
 # TODO: move, as we're testing Scale, not MarginalAmountTaxScale
 def test_dispatch_scale_type_on_creation(data):
-    scale = Scale("amount_scale", data, "")
-    first_jan = Instant((2017, 11, 1))
+    scale = parameters.Scale("amount_scale", data, "")
+    first_jan = periods.Instant((2017, 11, 1))
 
     result = scale.get_at_instant(first_jan)
 
-    assert isinstance(result, MarginalAmountTaxScale)
+    assert isinstance(result, taxscales.MarginalAmountTaxScale)

--- a/tests/core/tax_scales/test_marginal_rate_tax_scale.py
+++ b/tests/core/tax_scales/test_marginal_rate_tax_scale.py
@@ -1,12 +1,79 @@
-from numpy import array, inf
+import numpy
 
-from openfisca_core.taxscales import MarginalRateTaxScale
-from openfisca_core.tools import assert_near
+from openfisca_core import taxscales
+from openfisca_core import tools
+
+import pytest
+
+
+def test_bracket_indices():
+    tax_base = numpy.array([0, 1, 2, 3, 4, 5])
+    tax_scale = taxscales.LinearAverageRateTaxScale()
+    tax_scale.add_bracket(0, 0)
+    tax_scale.add_bracket(2, 0)
+    tax_scale.add_bracket(4, 0)
+
+    result = tax_scale.bracket_indices(tax_base)
+
+    tools.assert_near(result, [0, 0, 0, 1, 1, 2])
+
+
+def test_bracket_indices_with_factor():
+    tax_base = numpy.array([0, 1, 2, 3, 4, 5])
+    tax_scale = taxscales.LinearAverageRateTaxScale()
+    tax_scale.add_bracket(0, 0)
+    tax_scale.add_bracket(2, 0)
+    tax_scale.add_bracket(4, 0)
+
+    result = tax_scale.bracket_indices(tax_base, factor = 2.0)
+
+    tools.assert_near(result, [0, 0, 0, 0, 1, 1])
+
+
+def test_bracket_indices_with_round_decimals():
+    tax_base = numpy.array([0, 1, 2, 3, 4, 5])
+    tax_scale = taxscales.LinearAverageRateTaxScale()
+    tax_scale.add_bracket(0, 0)
+    tax_scale.add_bracket(2, 0)
+    tax_scale.add_bracket(4, 0)
+
+    result = tax_scale.bracket_indices(tax_base, round_decimals = 0)
+
+    tools.assert_near(result, [0, 0, 1, 1, 2, 2])
+
+
+def test_bracket_indices_without_tax_base():
+    tax_base = numpy.array([])
+    tax_scale = taxscales.LinearAverageRateTaxScale()
+    tax_scale.add_bracket(0, 0)
+    tax_scale.add_bracket(2, 0)
+    tax_scale.add_bracket(4, 0)
+
+    with pytest.raises(taxscales.EmptyArgumentError):
+        tax_scale.bracket_indices(tax_base)
+
+
+def test_bracket_indices_without_brackets():
+    tax_base = numpy.array([0, 1, 2, 3, 4, 5])
+    tax_scale = taxscales.LinearAverageRateTaxScale()
+
+    with pytest.raises(taxscales.EmptyArgumentError):
+        tax_scale.bracket_indices(tax_base)
+
+
+def test_to_dict():
+    tax_scale = taxscales.LinearAverageRateTaxScale()
+    tax_scale.add_bracket(0, 0)
+    tax_scale.add_bracket(100, 0.1)
+
+    result = tax_scale.to_dict()
+
+    assert result == {"0": 0.0, "100": 0.1}
 
 
 def test_calc():
-    tax_base = array([1, 1.5, 2, 2.5, 3.0, 4.0])
-    tax_scale = MarginalRateTaxScale()
+    tax_base = numpy.array([1, 1.5, 2, 2.5, 3.0, 4.0])
+    tax_scale = taxscales.MarginalRateTaxScale()
     tax_scale.add_bracket(0, 0)
     tax_scale.add_bracket(1, 0.1)
     tax_scale.add_bracket(2, 0.2)
@@ -14,18 +81,22 @@ def test_calc():
 
     result = tax_scale.calc(tax_base)
 
-    assert_near(result, [0, 0.05, 0.1, 0.2, 0.3, 0.3], absolute_error_margin = 1e-10)
+    tools.assert_near(
+        result,
+        [0, 0.05, 0.1, 0.2, 0.3, 0.3],
+        absolute_error_margin = 1e-10,
+        )
 
 
 def test_calc_without_round():
-    tax_base = array([200, 200.2, 200.002, 200.6, 200.006, 200.5, 200.005])
-    tax_scale = MarginalRateTaxScale()
+    tax_base = numpy.array([200, 200.2, 200.002, 200.6, 200.006, 200.5, 200.005])
+    tax_scale = taxscales.MarginalRateTaxScale()
     tax_scale.add_bracket(0, 0)
     tax_scale.add_bracket(100, 0.1)
 
     result = tax_scale.calc(tax_base)
 
-    assert_near(
+    tools.assert_near(
         result,
         [10, 10.02, 10.0002, 10.06, 10.0006, 10.05, 10.0005],
         absolute_error_margin = 1e-10,
@@ -33,14 +104,14 @@ def test_calc_without_round():
 
 
 def test_calc_when_round_is_1():
-    tax_base = array([200, 200.2, 200.002, 200.6, 200.006, 200.5, 200.005])
-    tax_scale = MarginalRateTaxScale()
+    tax_base = numpy.array([200, 200.2, 200.002, 200.6, 200.006, 200.5, 200.005])
+    tax_scale = taxscales.MarginalRateTaxScale()
     tax_scale.add_bracket(0, 0)
     tax_scale.add_bracket(100, 0.1)
 
     result = tax_scale.calc(tax_base, round_base_decimals = 1)
 
-    assert_near(
+    tools.assert_near(
         result,
         [10, 10.0, 10.0, 10.1, 10.0, 10, 10.0],
         absolute_error_margin = 1e-10,
@@ -48,14 +119,14 @@ def test_calc_when_round_is_1():
 
 
 def test_calc_when_round_is_2():
-    tax_base = array([200, 200.2, 200.002, 200.6, 200.006, 200.5, 200.005])
-    tax_scale = MarginalRateTaxScale()
+    tax_base = numpy.array([200, 200.2, 200.002, 200.6, 200.006, 200.5, 200.005])
+    tax_scale = taxscales.MarginalRateTaxScale()
     tax_scale.add_bracket(0, 0)
     tax_scale.add_bracket(100, 0.1)
 
     result = tax_scale.calc(tax_base, round_base_decimals = 2)
 
-    assert_near(
+    tools.assert_near(
         result,
         [10, 10.02, 10.0, 10.06, 10.00, 10.05, 10],
         absolute_error_margin = 1e-10,
@@ -63,14 +134,14 @@ def test_calc_when_round_is_2():
 
 
 def test_calc_when_round_is_3():
-    tax_base = array([200, 200.2, 200.002, 200.6, 200.006, 200.5, 200.005])
-    tax_scale = MarginalRateTaxScale()
+    tax_base = numpy.array([200, 200.2, 200.002, 200.6, 200.006, 200.5, 200.005])
+    tax_scale = taxscales.MarginalRateTaxScale()
     tax_scale.add_bracket(0, 0)
     tax_scale.add_bracket(100, 0.1)
 
     result = tax_scale.calc(tax_base, round_base_decimals = 3)
 
-    assert_near(
+    tools.assert_near(
         result,
         [10, 10.02, 10.0, 10.06, 10.001, 10.05, 10],
         absolute_error_margin = 1e-10,
@@ -78,20 +149,20 @@ def test_calc_when_round_is_3():
 
 
 def test_marginal_rates():
-    tax_base = array([0, 10, 50, 125, 250])
-    tax_scale = MarginalRateTaxScale()
+    tax_base = numpy.array([0, 10, 50, 125, 250])
+    tax_scale = taxscales.MarginalRateTaxScale()
     tax_scale.add_bracket(0, 0)
     tax_scale.add_bracket(100, 0.1)
     tax_scale.add_bracket(200, 0.2)
 
     result = tax_scale.marginal_rates(tax_base)
 
-    assert_near(result, [0, 0, 0, 0.1, 0.2])
+    tools.assert_near(result, [0, 0, 0, 0.1, 0.2])
 
 
 def test_inverse():
-    gross_tax_base = array([1, 2, 3, 4, 5, 6])
-    tax_scale = MarginalRateTaxScale()
+    gross_tax_base = numpy.array([1, 2, 3, 4, 5, 6])
+    tax_scale = taxscales.MarginalRateTaxScale()
     tax_scale.add_bracket(0, 0)
     tax_scale.add_bracket(1, 0)
     tax_scale.add_bracket(3, 0)
@@ -99,28 +170,28 @@ def test_inverse():
 
     result = tax_scale.inverse()
 
-    assert_near(result.calc(net_tax_base), gross_tax_base, 1e-15)
+    tools.assert_near(result.calc(net_tax_base), gross_tax_base, 1e-15)
 
 
 def test_scale_tax_scales():
-    tax_base = array([1, 2, 3])
+    tax_base = numpy.array([1, 2, 3])
     tax_base_scale = 12.345
     scaled_tax_base = tax_base * tax_base_scale
-    tax_scale = MarginalRateTaxScale()
+    tax_scale = taxscales.MarginalRateTaxScale()
     tax_scale.add_bracket(1, 0)
     tax_scale.add_bracket(2, 0)
     tax_scale.add_bracket(3, 0)
 
     result = tax_scale.scale_tax_scales(tax_base_scale)
 
-    assert_near(result.thresholds, scaled_tax_base)
+    tools.assert_near(result.thresholds, scaled_tax_base)
 
 
 def test_inverse_scaled_marginal_tax_scales():
-    gross_tax_base = array([1, 2, 3, 4, 5, 6])
+    gross_tax_base = numpy.array([1, 2, 3, 4, 5, 6])
     gross_tax_base_scale = 12.345
     scaled_gross_tax_base = gross_tax_base * gross_tax_base_scale
-    tax_scale = MarginalRateTaxScale()
+    tax_scale = taxscales.MarginalRateTaxScale()
     tax_scale.add_bracket(0, 0)
     tax_scale.add_bracket(1, 0.1)
     tax_scale.add_bracket(3, 0.05)
@@ -132,12 +203,12 @@ def test_inverse_scaled_marginal_tax_scales():
 
     result = scaled_tax_scale.inverse()
 
-    assert_near(result.calc(scaled_net_tax_base), scaled_gross_tax_base, 1e-13)
+    tools.assert_near(result.calc(scaled_net_tax_base), scaled_gross_tax_base, 1e-13)
 
 
 def test_to_average():
-    tax_base = array([1, 1.5, 2, 2.5])
-    tax_scale = MarginalRateTaxScale()
+    tax_base = numpy.array([1, 1.5, 2, 2.5])
+    tax_scale = taxscales.MarginalRateTaxScale()
     tax_scale.add_bracket(0, 0)
     tax_scale.add_bracket(1, 0.1)
     tax_scale.add_bracket(2, 0.2)
@@ -145,9 +216,9 @@ def test_to_average():
     result = tax_scale.to_average()
 
     # Note: assert_near doesn't work for inf.
-    assert result.thresholds == [0, 1, 2, inf]
+    assert result.thresholds == [0, 1, 2, numpy.inf]
     assert result.rates, [0, 0, 0.05, 0.2]
-    assert_near(
+    tools.assert_near(
         result.calc(tax_base),
         [0, 0.0375, 0.1, 0.125],
         absolute_error_margin = 1e-10,

--- a/tests/core/tax_scales/test_single_amount_tax_scale.py
+++ b/tests/core/tax_scales/test_single_amount_tax_scale.py
@@ -1,9 +1,9 @@
-from numpy import array
+import numpy
 
-from openfisca_core.parameters import Scale
-from openfisca_core.periods import Instant
-from openfisca_core.taxscales import SingleAmountTaxScale
-from openfisca_core.tools import assert_near
+from openfisca_core import parameters
+from openfisca_core import periods
+from openfisca_core import taxscales
+from openfisca_core import tools
 
 from pytest import fixture
 
@@ -27,18 +27,18 @@ def data():
 
 
 def test_calc():
-    tax_base = array([1, 8, 10])
-    tax_scale = SingleAmountTaxScale()
+    tax_base = numpy.array([1, 8, 10])
+    tax_scale = taxscales.SingleAmountTaxScale()
     tax_scale.add_bracket(6, 0.23)
     tax_scale.add_bracket(9, 0.29)
 
     result = tax_scale.calc(tax_base)
 
-    assert_near(result, [0, 0.23, 0.29])
+    tools.assert_near(result, [0, 0.23, 0.29])
 
 
 def test_to_dict():
-    tax_scale = SingleAmountTaxScale()
+    tax_scale = taxscales.SingleAmountTaxScale()
     tax_scale.add_bracket(6, 0.23)
     tax_scale.add_bracket(9, 0.29)
 
@@ -49,8 +49,8 @@ def test_to_dict():
 
 # TODO: move, as we're testing Scale, not SingleAmountTaxScale
 def test_assign_thresholds_on_creation(data):
-    scale = Scale("amount_scale", data, "")
-    first_jan = Instant((2017, 11, 1))
+    scale = parameters.Scale("amount_scale", data, "")
+    first_jan = periods.Instant((2017, 11, 1))
     scale_at_instant = scale.get_at_instant(first_jan)
 
     result = scale_at_instant.thresholds
@@ -60,8 +60,8 @@ def test_assign_thresholds_on_creation(data):
 
 # TODO: move, as we're testing Scale, not SingleAmountTaxScale
 def test_assign_amounts_on_creation(data):
-    scale = Scale("amount_scale", data, "")
-    first_jan = Instant((2017, 11, 1))
+    scale = parameters.Scale("amount_scale", data, "")
+    first_jan = periods.Instant((2017, 11, 1))
     scale_at_instant = scale.get_at_instant(first_jan)
 
     result = scale_at_instant.amounts
@@ -71,9 +71,9 @@ def test_assign_amounts_on_creation(data):
 
 # TODO: move, as we're testing Scale, not SingleAmountTaxScale
 def test_dispatch_scale_type_on_creation(data):
-    scale = Scale("amount_scale", data, "")
-    first_jan = Instant((2017, 11, 1))
+    scale = parameters.Scale("amount_scale", data, "")
+    first_jan = periods.Instant((2017, 11, 1))
 
     result = scale.get_at_instant(first_jan)
 
-    assert isinstance(result, SingleAmountTaxScale)
+    assert isinstance(result, taxscales.SingleAmountTaxScale)

--- a/tests/core/tax_scales/test_tax_scales_commons.py
+++ b/tests/core/tax_scales/test_tax_scales_commons.py
@@ -1,13 +1,13 @@
-from openfisca_core.parameters import ParameterNode
-from openfisca_core.taxscales import combine_tax_scales
-from openfisca_core.tools import assert_near
+from openfisca_core import parameters
+from openfisca_core import taxscales
+from openfisca_core import tools
 
-from pytest import fixture
+import pytest
 
 
-@fixture
+@pytest.fixture
 def node():
-    return ParameterNode(
+    return parameters.ParameterNode(
         "baremes",
         data = {
             "health": {
@@ -27,7 +27,7 @@ def node():
 
 
 def test_combine_tax_scales(node):
-    result = combine_tax_scales(node)
+    result = taxscales.combine_tax_scales(node)
 
-    assert_near(result.thresholds, [0, 2000, 3000])
-    assert_near(result.rates, [0.07, 0.12, 0.14], 1e-13)
+    tools.assert_near(result.thresholds, [0, 2000, 3000])
+    tools.assert_near(result.rates, [0.07, 0.12, 0.14], 1e-13)

--- a/tests/core/test_commons.py
+++ b/tests/core/test_commons.py
@@ -1,0 +1,36 @@
+import numpy
+
+from openfisca_core import commons
+
+import pytest
+
+
+def test_dummy():
+    with pytest.warns(DeprecationWarning):
+        result = commons.Dummy()
+        assert result
+
+
+def test_empty_clone():
+    dummy_class = type("Dummmy", (), {})
+    dummy = dummy_class()
+
+    result = commons.empty_clone(dummy)
+
+    assert type(result) == dummy_class
+
+
+def test_stringify_array():
+    array = numpy.array([10, 20])
+
+    result = commons.stringify_array(array)
+
+    assert result == "[10, 20]"
+
+
+def test_stringify_array_when_none():
+    array = None
+
+    result = commons.stringify_array(array)
+
+    assert result == "None"


### PR DESCRIPTION
#### Deprecations

- Deprecate `Dummy`.
  - The functionality is now directly provided by `empty_clone`.

#### Technical changes

- Refactor abstract scales to use Python's `abc` lib.
  - This allows for consistent inheritance, which wasn't the case before.
