### PR TITLE
Fix web api after werkzeug upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 34.6.11 [#945](https://github.com/openfisca/openfisca-core/pull/945)
+
+#### Technical changes
+
+- Fixes web api loading to match latest `Werkzeug` dependency revision (`1.0.0`)
+- Details:
+  - Preserve not merging double slashes by default.
+  - Update `ProxyFix` module loading and initialising arguments.
+
 ### 34.6.10 [#946](https://github.com/openfisca/openfisca-core/pull/946)
 
 #### Technical changes

--- a/openfisca_web_api/app.py
+++ b/openfisca_web_api/app.py
@@ -56,6 +56,7 @@ def create_app(tax_benefit_system,
 
     app.config['JSON_AS_ASCII'] = False  # When False, lets jsonify encode to utf-8
     app.url_map.strict_slashes = False  # Accept url like /parameters/
+    app.url_map.merge_slashes = False  # Do not eliminate // in paths
     app.config['JSON_SORT_KEYS'] = False  # Don't sort JSON keys in the Web API
 
     data = build_data(tax_benefit_system)

--- a/openfisca_web_api/app.py
+++ b/openfisca_web_api/app.py
@@ -50,7 +50,8 @@ def create_app(tax_benefit_system,
         tracker = init_tracker(tracker_url, tracker_idsite, tracker_token)
 
     app = Flask(__name__)
-    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_host=1)  # Fix request.remote_addr to get the real client IP address
+    # Fix request.remote_addr to get the real client IP address
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for = 1, x_host = 1)
     CORS(app, origins = '*')
 
     app.config['JSON_AS_ASCII'] = False  # When False, lets jsonify encode to utf-8

--- a/openfisca_web_api/app.py
+++ b/openfisca_web_api/app.py
@@ -50,7 +50,7 @@ def create_app(tax_benefit_system,
         tracker = init_tracker(tracker_url, tracker_idsite, tracker_token)
 
     app = Flask(__name__)
-    app.wsgi_app = ProxyFix(app.wsgi_app, num_proxies = 1)  # Fix request.remote_addr to get the real client IP address
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_host=1)  # Fix request.remote_addr to get the real client IP address
     CORS(app, origins = '*')
 
     app.config['JSON_AS_ASCII'] = False  # When False, lets jsonify encode to utf-8

--- a/openfisca_web_api/app.py
+++ b/openfisca_web_api/app.py
@@ -12,7 +12,7 @@ from openfisca_web_api import handlers
 try:
     from flask import Flask, jsonify, abort, request, make_response
     from flask_cors import CORS
-    from werkzeug.contrib.fixers import ProxyFix
+    from werkzeug.middleware.proxy_fix import ProxyFix
 except ImportError as error:
     handle_import_error(error)
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '34.6.10',
+    version = '34.6.11',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ general_requirements = [
     ]
 
 api_requirements = [
-    'werkzeug == 0.16.1',
+    'werkzeug >= 1.0.0, < 2.0.0',
     'flask == 1.1.1',
     'flask-cors == 3.0.7',
     'gunicorn >= 20.0.0, < 21.0.0',


### PR DESCRIPTION
#### Technical changes

- Fixes web api loading to match latest `Werkzeug` dependency revision (`1.0.0`)
- Details:
  - Preserve not merging double slashes by default.
  - Update `ProxyFix` module loading and initialising arguments.

---
Detected error : `ModuleNotFoundError: No module named 'werkzeug.contrib'`
At : `openfisca_web_api/app.py", line 17, in <module> handle_import_error(error)`
When the server tried to load openfisca-france latest Web API.

Werkzeug dependency has recently been upgraded from `0.16.1` to `1.0.0` (see [pypi](https://pypi.org/project/Werkzeug/#history)) 

It is a sub-dependency of `Flask`:
```shell
$ pip install pipdeptree
(...)
$ pipdeptree -r -p Werkzeug
Werkzeug==1.0.0
  - Flask==1.1.1 [requires: Werkzeug>=0.15]
    - Flask-Cors==3.0.7 [requires: Flask>=0.9]
```
The old `ProxyFix` module name is deprecated as described in [this documentation](https://werkzeug.palletsprojects.com/en/0.16.x/contrib/fixers/) header.

The constructor signature also changed: `num_proxies` argument is now deprecated. So, I've tried to reset the old behaviour as described in [this issue](https://github.com/pallets/werkzeug/issues/1630).

---

Edit 08/02/2020 by @maukoquiroga

See Werkzeug's 1.0.0 [changelog](https://werkzeug.palletsprojects.com/en/1.0.x/changes/).