### PR TITLE
Fix werkzeug dependency version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 34.6.10 [#946](https://github.com/openfisca/openfisca-core/pull/946)
+
+#### Technical changes
+
+- Fix `Werkzeug` library version
+  - Temporarily fix Web API loading disturbed by some `Werkzeug` deprecations
+
 ### 34.6.9 [#925](https://github.com/openfisca/openfisca-core/pull/925)
 
 #### Documentation

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ general_requirements = [
     ]
 
 api_requirements = [
+    'werkzeug == 0.16.1',
     'flask == 1.1.1',
     'flask-cors == 3.0.7',
     'gunicorn >= 20.0.0, < 21.0.0',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '34.6.9',
+    version = '34.6.10',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
#### Technical changes

- Fix `Werkzeug` library version (temporarily avoid its [yesterday update](https://pypi.org/project/Werkzeug/#history)).

Then migrate to latest version thanks to #945 
Could be tested by running the web api. Example : `openfisca serve -c openfisca_france`