### PR TITLE
Revert dpath bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
+### 34.7.2 [#948](https://github.com/openfisca/openfisca-core/pull/948)
+
+#### Technical changes
+
+- Revert `dpath` dependency bump introduced by [#940](https://github.com/openfisca/openfisca-core/pull/940) 
+  - Fix bug in period interpretation by Web API ([openfisca-france#1413](https://github.com/openfisca/openfisca-france/issues/1413))
+
 ### 34.7.1 [#940](https://github.com/openfisca/openfisca-core/pull/940)
+
+_Note: this version has been unpublished due to an issue introduced by dpath upgrade. Please use 34.7.2 or a more recent version._
 
 #### Technical changes
 

--- a/openfisca_core/simulation_builder.py
+++ b/openfisca_core/simulation_builder.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from typing import Dict, List, Iterable
 
-import dpath.util
+import dpath
 import numpy as np
 from copy import deepcopy
 
@@ -428,7 +428,7 @@ class SimulationBuilder(object):
         # It is only raised when we consume the buffer. We thus don't know which exact key caused the error.
         # We do a basic research to find the culprit path
         culprit_path = next(
-            dpath.util.search(json, "*/{}/{}".format(e.variable_name, str(e.period)), yielded = True),
+            dpath.search(json, "*/{}/{}".format(e.variable_name, str(e.period)), yielded = True),
             None)
         if culprit_path:
             path = [entity.plural] + culprit_path[0].split('/')

--- a/openfisca_web_api/handlers.py
+++ b/openfisca_web_api/handlers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import dpath.util
+import dpath
 
 from openfisca_core.simulation_builder import SimulationBuilder
 from openfisca_core.indexed_enums import Enum
@@ -31,7 +31,7 @@ def calculate(tax_benefit_system, input_data):
 
         dpath.util.new(computation_results, path, entity_result)
 
-    dpath.util.merge(input_data, computation_results)
+    dpath.merge(input_data, computation_results)
 
     return input_data
 

--- a/openfisca_web_api/loader/spec.py
+++ b/openfisca_web_api/loader/spec.py
@@ -4,7 +4,7 @@ import os
 import yaml
 from copy import deepcopy
 
-import dpath.util
+import dpath
 
 from openfisca_core.indexed_enums import Enum
 from openfisca_web_api import handlers
@@ -18,18 +18,18 @@ def build_openAPI_specification(api_data):
     file = open(OPEN_API_CONFIG_FILE, 'r')
     spec = yaml.safe_load(file)
     country_package_name = api_data['country_package_metadata']['name'].title()
-    dpath.util.new(spec, 'info/title', spec['info']['title'].replace("{COUNTRY_PACKAGE_NAME}", country_package_name))
-    dpath.util.new(spec, 'info/description', spec['info']['description'].replace("{COUNTRY_PACKAGE_NAME}", country_package_name))
-    dpath.util.new(spec, 'info/version', api_data['country_package_metadata']['version'])
+    dpath.new(spec, 'info/title', spec['info']['title'].replace("{COUNTRY_PACKAGE_NAME}", country_package_name))
+    dpath.new(spec, 'info/description', spec['info']['description'].replace("{COUNTRY_PACKAGE_NAME}", country_package_name))
+    dpath.new(spec, 'info/version', api_data['country_package_metadata']['version'])
 
     for entity in tax_benefit_system.entities:
         name = entity.key.title()
         spec['definitions'][name] = get_entity_json_schema(entity, tax_benefit_system)
 
     situation_schema = get_situation_json_schema(tax_benefit_system)
-    dpath.util.new(spec, 'definitions/SituationInput', situation_schema)
-    dpath.util.new(spec, 'definitions/SituationOutput', situation_schema.copy())
-    dpath.util.new(spec, 'definitions/Trace/properties/entitiesDescription/properties', {
+    dpath.new(spec, 'definitions/SituationInput', situation_schema)
+    dpath.new(spec, 'definitions/SituationOutput', situation_schema.copy())
+    dpath.new(spec, 'definitions/Trace/properties/entitiesDescription/properties', {
         entity.plural: {'type': 'array', 'items': {"type": "string"}}
         for entity in tax_benefit_system.entities
         })
@@ -42,24 +42,24 @@ def build_openAPI_specification(api_data):
         parameter_example = api_data['parameters'][parameter_path]
     else:
         parameter_example = next(iter(api_data['parameters'].values()))
-    dpath.util.new(spec, 'definitions/Parameter/example', parameter_example)
+    dpath.new(spec, 'definitions/Parameter/example', parameter_example)
 
     if tax_benefit_system.open_api_config.get('variable_example'):
         variable_example = api_data['variables'][tax_benefit_system.open_api_config['variable_example']]
     else:
         variable_example = next(iter(api_data['variables'].values()))
-    dpath.util.new(spec, 'definitions/Variable/example', variable_example)
+    dpath.new(spec, 'definitions/Variable/example', variable_example)
 
     if tax_benefit_system.open_api_config.get('simulation_example'):
         simulation_example = tax_benefit_system.open_api_config['simulation_example']
-        dpath.util.new(spec, 'definitions/SituationInput/example', simulation_example)
-        dpath.util.new(spec, 'definitions/SituationOutput/example', handlers.calculate(tax_benefit_system, deepcopy(simulation_example)))  # calculate has side-effects
-        dpath.util.new(spec, 'definitions/Trace/example', handlers.trace(tax_benefit_system, simulation_example))
+        dpath.new(spec, 'definitions/SituationInput/example', simulation_example)
+        dpath.new(spec, 'definitions/SituationOutput/example', handlers.calculate(tax_benefit_system, deepcopy(simulation_example)))  # calculate has side-effects
+        dpath.new(spec, 'definitions/Trace/example', handlers.trace(tax_benefit_system, simulation_example))
     else:
         message = "No simulation example has been defined for this tax and benefit system. If you are the maintainer of {}, you can define an example by following this documentation: https://openfisca.org/doc/openfisca-web-api/config-openapi.html".format(country_package_name)
-        dpath.util.new(spec, 'definitions/SituationInput/example', message)
-        dpath.util.new(spec, 'definitions/SituationOutput/example', message)
-        dpath.util.new(spec, 'definitions/Trace/example', message)
+        dpath.new(spec, 'definitions/SituationInput/example', message)
+        dpath.new(spec, 'definitions/SituationOutput/example', message)
+        dpath.new(spec, 'definitions/Trace/example', message)
     return spec
 
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '34.7.1',
+    version = '34.7.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 # functional and integration breaks caused by external code updates.
 
 general_requirements = [
-    'dpath == 2.0.1',
+    'dpath == 1.5.0',
     'pytest >= 4.4.1, < 6.0.0',  # For openfisca test
     'numpy >= 1.11, < 1.18',
     'psutil >= 5.4.7, < 6.0.0',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 # functional and integration breaks caused by external code updates.
 
 general_requirements = [
-    'dpath == 1.5.0',
+    'dpath >= 1.5.0, < 2.0.0',
     'pytest >= 4.4.1, < 6.0.0',  # For openfisca test
     'numpy >= 1.11, < 1.18',
     'psutil >= 5.4.7, < 6.0.0',

--- a/tests/web_api/test_calculate.py
+++ b/tests/web_api/test_calculate.py
@@ -288,6 +288,7 @@ def test_str_variable():
 
     assert response.status_code == OK
 
+
 def test_periods():
     simulation_json = json.dumps({
         "persons": {
@@ -311,8 +312,8 @@ def test_periods():
 
     response_json = json.loads(response.data.decode('utf-8'))
 
-    yearly_variable = dpath.get(response_json, 'households/_/housing_tax') # web api year is an int
+    yearly_variable = dpath.get(response_json, 'households/_/housing_tax')  # web api year is an int
     assert yearly_variable == {'2017': 200.0}
-    
-    monthly_variable = dpath.get(response_json, 'households/_/housing_occupancy_status') # web api month is a string
+
+    monthly_variable = dpath.get(response_json, 'households/_/housing_occupancy_status')  # web api month is a string
     assert monthly_variable == {'2017-01': 'tenant'}

--- a/tests/web_api/test_calculate.py
+++ b/tests/web_api/test_calculate.py
@@ -6,7 +6,7 @@ from http.client import BAD_REQUEST, OK, NOT_FOUND
 from copy import deepcopy
 
 import pytest
-import dpath.util
+import dpath
 
 from openfisca_country_template.situation_examples import couple
 
@@ -104,12 +104,12 @@ def test_basic_calculation():
     response = post_json(simulation_json)
     assert response.status_code == OK
     response_json = json.loads(response.data.decode('utf-8'))
-    assert dpath.util.get(response_json, 'persons/bill/basic_income/2017-12') == 600  # Universal basic income
-    assert dpath.util.get(response_json, 'persons/bill/income_tax/2017-12') == 300  # 15% of the salary
-    assert dpath.util.get(response_json, 'persons/bill/age/2017-12') == 37  # 15% of the salary
-    assert dpath.util.get(response_json, 'persons/bob/basic_income/2017-12') == 600
-    assert dpath.util.get(response_json, 'persons/bob/social_security_contribution/2017-12') == 816  # From social_security_contribution.yaml test
-    assert dpath.util.get(response_json, 'households/first_household/housing_tax/2017') == 3000
+    assert dpath.get(response_json, 'persons/bill/basic_income/2017-12') == 600  # Universal basic income
+    assert dpath.get(response_json, 'persons/bill/income_tax/2017-12') == 300  # 15% of the salary
+    assert dpath.get(response_json, 'persons/bill/age/2017-12') == 37  # 15% of the salary
+    assert dpath.get(response_json, 'persons/bob/basic_income/2017-12') == 600
+    assert dpath.get(response_json, 'persons/bob/social_security_contribution/2017-12') == 816  # From social_security_contribution.yaml test
+    assert dpath.get(response_json, 'households/first_household/housing_tax/2017') == 3000
 
 
 def test_enums_sending_identifier():
@@ -136,7 +136,7 @@ def test_enums_sending_identifier():
     response = post_json(simulation_json)
     assert response.status_code == OK
     response_json = json.loads(response.data.decode('utf-8'))
-    assert dpath.util.get(response_json, 'households/_/housing_tax/2017') == 0
+    assert dpath.get(response_json, 'households/_/housing_tax/2017') == 0
 
 
 def test_enum_output():
@@ -157,7 +157,7 @@ def test_enum_output():
     response = post_json(simulation_json)
     assert response.status_code == OK
     response_json = json.loads(response.data.decode('utf-8'))
-    assert dpath.util.get(response_json, "households/_/housing_occupancy_status/2017-01") == "tenant"
+    assert dpath.get(response_json, "households/_/housing_occupancy_status/2017-01") == "tenant"
 
 
 def test_enum_wrong_value():
@@ -179,7 +179,7 @@ def test_enum_wrong_value():
     assert response.status_code == BAD_REQUEST
     response_json = json.loads(response.data.decode('utf-8'))
     message = "Possible values are ['owner', 'tenant', 'free_lodger', 'homeless']"
-    text = dpath.util.get(response_json, "households/_/housing_occupancy_status/2017-01")
+    text = dpath.get(response_json, "households/_/housing_occupancy_status/2017-01")
     assert message in text
 
 
@@ -206,7 +206,7 @@ def test_encoding_variable_value():
     assert response.status_code == BAD_REQUEST, response.data.decode('utf-8')
     response_json = json.loads(response.data.decode('utf-8'))
     message = "'Locataire ou sous-locataire d‘un logement loué vide non-HLM' is not a known value for 'housing_occupancy_status'. Possible values are "
-    text = dpath.util.get(response_json, 'households/_/housing_occupancy_status/2017-07')
+    text = dpath.get(response_json, 'households/_/housing_occupancy_status/2017-07')
     assert message in text
 
 

--- a/tests/web_api/test_calculate.py
+++ b/tests/web_api/test_calculate.py
@@ -287,3 +287,32 @@ def test_str_variable():
     response = subject.post('/calculate', data = simulation_json, content_type = 'application/json')
 
     assert response.status_code == OK
+
+def test_periods():
+    simulation_json = json.dumps({
+        "persons": {
+            "bill": {}
+            },
+        "households": {
+            "_": {
+                "parents": ["bill"],
+                "housing_tax": {
+                    "2017": None
+                    },
+                "housing_occupancy_status": {
+                    "2017-01": None
+                    }
+                }
+            }
+        })
+
+    response = post_json(simulation_json)
+    assert response.status_code == OK
+
+    response_json = json.loads(response.data.decode('utf-8'))
+
+    yearly_variable = dpath.get(response_json, 'households/_/housing_tax') # web api year is an int
+    assert yearly_variable == {'2017': 200.0}
+    
+    monthly_variable = dpath.get(response_json, 'households/_/housing_occupancy_status') # web api month is a string
+    assert monthly_variable == {'2017-01': 'tenant'}

--- a/tests/web_api/test_spec.py
+++ b/tests/web_api/test_spec.py
@@ -3,7 +3,7 @@
 import json
 from http.client import OK
 
-import dpath.util
+import dpath
 from . import subject
 
 
@@ -36,21 +36,21 @@ def test_paths():
 
 
 def test_entity_definition():
-    assert 'parents' in dpath.util.get(body, 'definitions/Household/properties')
-    assert 'children' in dpath.util.get(body, 'definitions/Household/properties')
-    assert 'salary' in dpath.util.get(body, 'definitions/Person/properties')
-    assert 'rent' in dpath.util.get(body, 'definitions/Household/properties')
-    assert 'number' == dpath.util.get(body, 'definitions/Person/properties/salary/additionalProperties/type')
+    assert 'parents' in dpath.get(body, 'definitions/Household/properties')
+    assert 'children' in dpath.get(body, 'definitions/Household/properties')
+    assert 'salary' in dpath.get(body, 'definitions/Person/properties')
+    assert 'rent' in dpath.get(body, 'definitions/Household/properties')
+    assert 'number' == dpath.get(body, 'definitions/Person/properties/salary/additionalProperties/type')
 
 
 def test_situation_definition():
     situation_input = body['definitions']['SituationInput']
     situation_output = body['definitions']['SituationOutput']
     for situation in situation_input, situation_output:
-        assert 'households' in dpath.util.get(situation, '/properties')
-        assert 'persons' in dpath.util.get(situation, '/properties')
-        assert "#/definitions/Household" == dpath.util.get(situation, '/properties/households/additionalProperties/$ref')
-        assert "#/definitions/Person" == dpath.util.get(situation, '/properties/persons/additionalProperties/$ref')
+        assert 'households' in dpath.get(situation, '/properties')
+        assert 'persons' in dpath.get(situation, '/properties')
+        assert "#/definitions/Household" == dpath.get(situation, '/properties/households/additionalProperties/$ref')
+        assert "#/definitions/Person" == dpath.get(situation, '/properties/persons/additionalProperties/$ref')
 
 
 def test_host():


### PR DESCRIPTION
#### Technical changes

- Revert dpath bump introduced by #940 
  - Fix bug in period interpretation by Web API (openfisca/openfisca-france#1413)

Use dpath `1.5.0` library `dpath.new` in [/calculate](https://github.com/openfisca/openfisca-core/blob/7fe1e45662fb1f5a238f05cc4c9db4adc9cd2c03/openfisca_web_api/handlers.py#L32) endpoint.

> To see the dpath `2.0.1` library `dpath.util.new` behaviour in [dpath documentation](https://github.com/akesterson/dpath-python), see this example: `dpath.util.new(x, 'a/b/e/f/h/13', 'Wow this is a big array, it sure is lonely in here by myself')`