### PR TITLE
Upgrade numpy dependency to 1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+# 35.0.0 [#954](https://github.com/openfisca/openfisca-core/pull/954)
+
+#### Breaking changes
+
+- Update Numpy version's upper bound to 1.18
+  - Numpy 1.18 [expires a list of old deprecations](https://numpy.org/devdocs/release/1.18.0-notes.html#expired-deprecations) that might be used in openfisca country models.
+
+#### Migration details
+
+You might need to change your code if any of the [Numpy expired deprecations](https://numpy.org/devdocs/release/1.18.0-notes.html#expired-deprecations) is used in your model formulas.
+
+Here is a subset of the deprecations that you might find in your model with some checks and migration steps (where `np` stands for `numpy`):
+
+* `Removed deprecated support for boolean and empty condition lists in np.select.`
+  * Before `np.select([], [])` result was `0` (for a `default` argument value set to `0`).
+    * Now, we have to check for empty conditions and, return `0` or the defined default argument value when we want to keep the same behavior.
+  * Before, integer conditions where transformed to booleans.
+    * For example, `np.select([0, 1, 0], ['a', 'b', 'c'])` result was `array('b', dtype='<U21')`. Now, we have to update such code to: `np.select(np.array([0, 1, 0]).astype(bool), ['a', 'b', 'c'])`.
+* `np.linspace parameter num must be an integer.`
+  * No surprise here, update the `num` parameter in [np.linspace](https://numpy.org/doc/1.18/reference/generated/numpy.linspace.html) in order to get an integer.
+* `Array order only accepts ‘C’, ‘F’, ‘A’, and ‘K’.`
+  * Check that [numpy.array](https://numpy.org/doc/1.18/reference/generated/numpy.array.html) `order` argument gets one of the allowed values listed above.
+* `UFuncs with multiple outputs must use a tuple for the out kwarg.`
+  * Update the output type of any used [universal function](https://numpy.org/doc/1.18/reference/ufuncs.html) to get a tuple.
+
 ### 34.7.7 [#951](https://github.com/openfisca/openfisca-core/pull/951)
 
 #### Technical changes

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ uninstall:
 
 install:
 	pip install --upgrade pip twine wheel
-	pip install --editable .[dev] --upgrade
+	pip install --editable .[dev] --upgrade --use-deprecated=legacy-resolver
 
 clean:
 	rm -rf build dist

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you want to contribute to OpenFisca-Core itself, welcome! To install it local
 ```bash
 git clone https://github.com/openfisca/openfisca-core.git
 cd openfisca-core
-pip install --editable .[dev]
+pip install --editable .[dev] --use-deprecated=legacy-resolver
 ```
 
 ## Testing
@@ -110,7 +110,7 @@ The OpenFisca Web API comes with an [optional tracker](https://github.com/openfi
 The tracker is not installed by default. To install it, run:
 
 ```sh
-pip install openfisca_core[tracker]  # Or `pip install --editable ".[tracker]"` for an editable installation
+pip install openfisca_core[tracker] --use-deprecated=legacy-resolver # Or `pip install --editable ".[tracker]"` for an editable installation
 ```
 
 

--- a/openfisca_core/formula_helpers.py
+++ b/openfisca_core/formula_helpers.py
@@ -40,6 +40,8 @@ def switch(conditions, value_by_condition):
         >>> switch(np.array([1, 1, 1, 2]), {1: 80, 2: 90})
         array([80, 80, 80, 90])
     '''
+    assert len(value_by_condition) > 0, \
+        "switch must be called with at least one value"
     condlist = [
         conditions == condition
         for condition in value_by_condition.keys()

--- a/openfisca_core/simulation_builder.py
+++ b/openfisca_core/simulation_builder.py
@@ -195,7 +195,10 @@ class SimulationBuilder(object):
         if np.issubdtype(roles_array.dtype, np.integer):
             group_population.members_role = np.array(flattened_roles)[roles_array]
         else:
-            group_population.members_role = np.select([roles_array == role.key for role in flattened_roles], flattened_roles)
+            if len(flattened_roles) == 0:
+                group_population.members_role = np.int64(0)
+            else:
+                group_population.members_role = np.select([roles_array == role.key for role in flattened_roles], flattened_roles)
 
     def build(self, tax_benefit_system):
         return Simulation(tax_benefit_system, self.populations)

--- a/openfisca_core/tools/simulation_dumper.py
+++ b/openfisca_core/tools/simulation_dumper.py
@@ -83,8 +83,8 @@ def _dump_entity(population, directory):
         encoded_roles = np.int64(0)
     else:
         encoded_roles = np.select(
-            [population.members_role == role for role in population.entity.flattened_roles],
-            [role.key for role in population.entity.flattened_roles],
+            [population.members_role == role for role in flattened_roles],
+            [role.key for role in flattened_roles],
             )
     np.save(os.path.join(path, "members_role.npy"), encoded_roles)
 
@@ -100,10 +100,15 @@ def _restore_entity(population, directory):
     population.members_position = np.load(os.path.join(path, "members_position.npy"))
     population.members_entity_id = np.load(os.path.join(path, "members_entity_id.npy"))
     encoded_roles = np.load(os.path.join(path, "members_role.npy"))
-    population.members_role = np.select(
-        [encoded_roles == role.key for role in population.entity.flattened_roles],
-        [role for role in population.entity.flattened_roles],
-        )
+
+    flattened_roles = population.entity.flattened_roles
+    if len(flattened_roles) == 0:
+        population.members_role = np.int64(0)
+    else:
+        population.members_role = np.select(
+            [encoded_roles == role.key for role in flattened_roles],
+            [role for role in flattened_roles],
+            )
     person_count = len(population.members_entity_id)
     population.count = max(population.members_entity_id) + 1
     return person_count

--- a/openfisca_core/tools/simulation_dumper.py
+++ b/openfisca_core/tools/simulation_dumper.py
@@ -77,10 +77,15 @@ def _dump_entity(population, directory):
 
     np.save(os.path.join(path, "members_position.npy"), population.members_position)
     np.save(os.path.join(path, "members_entity_id.npy"), population.members_entity_id)
-    encoded_roles = np.select(
-        [population.members_role == role for role in population.entity.flattened_roles],
-        [role.key for role in population.entity.flattened_roles],
-        )
+
+    flattened_roles = population.entity.flattened_roles
+    if len(flattened_roles) == 0:
+        encoded_roles = np.int64(0)
+    else:
+        encoded_roles = np.select(
+            [population.members_role == role for role in population.entity.flattened_roles],
+            [role.key for role in population.entity.flattened_roles],
+            )
     np.save(os.path.join(path, "members_role.npy"), encoded_roles)
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 general_requirements = [
     'dpath >= 1.5.0, < 2.0.0',
     'pytest >= 4.4.1, < 6.0.0',  # For openfisca test
-    'numpy >= 1.11, < 1.18',
+    'numpy >= 1.11, < 1.19',
     'psutil >= 5.4.7, < 6.0.0',
     'PyYAML >= 3.10',
     'sortedcontainers == 2.2.2',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '34.7.7',
+    version = '35.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
Fixes #924

⚠️ As this is possibly a breaking change that affects every formula, this PR should be checked with at least one country model updated to numpy 1.18 as well (and the country-template is too simple to be a good example of the effect of this update 🙂).

---

`select` deprecations were described in [this comment](https://github.com/openfisca/openfisca-core/issues/924#issuecomment-615512006)

Add checks at `select` routine usage when a call to the function using `select` might lead to an empty condition.

No update on conditions types as we already used booleans.

---

#### Breaking changes

- Bump `numpy` dependency to `1.18`

