### PR TITLE
Fix warnings on openfisca test command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### TODO
+
+#### Technical changes
+
+- Fix `PytestDeprecationWarning` on `openfisca test` command
+
 ### 34.7.4 [#955](https://github.com/openfisca/openfisca-core/pull/955)
 
 #### Technical changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### TODO
+### 34.7.5 [#958](https://github.com/openfisca/openfisca-core/pull/958)
 
 #### Technical changes
 

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -5,7 +5,7 @@ import sys
 import os
 import traceback
 import textwrap
-from typing import Dict
+from typing import Dict, List
 
 import pytest
 
@@ -80,7 +80,7 @@ def run_tests(tax_benefit_system, paths, options = None):
 
 class YamlFile(pytest.File):
 
-    def __init__(self, path, parent, tax_benefit_system, options):
+    def __init__(self, path, fspath, parent, tax_benefit_system, options):
         super(YamlFile, self).__init__(path, parent)
         self.tax_benefit_system = tax_benefit_system
         self.options = options
@@ -96,7 +96,7 @@ class YamlFile(pytest.File):
             raise ValueError(message)
 
         if not isinstance(tests, list):
-            tests = [tests]
+            tests: List[Dict] = [tests]
         for test in tests:
             if not self.should_ignore(test):
                 yield YamlItem('', self, self.tax_benefit_system, test, self.options)
@@ -112,6 +112,9 @@ class YamlFile(pytest.File):
 
 
 class YamlItem(pytest.Item):
+    """
+    Terminal nodes of the test collection tree.
+    """
 
     def __init__(self, name, parent, baseline_tax_benefit_system, test, options):
         super(YamlItem, self).__init__(name, parent)
@@ -241,8 +244,14 @@ class OpenFiscaPlugin(object):
         self.options = options
 
     def pytest_collect_file(self, parent, path):
+        """
+        Called by pytest for all plugins.
+        :return: The collector for test methods.
+        """
         if path.ext in [".yaml", ".yml"]:
-            return YamlFile(path, parent, self.tax_benefit_system, self.options)
+            return YamlFile.from_parent(parent, path = path, fspath = path,
+                tax_benefit_system = self.tax_benefit_system,
+                options = self.options)
 
 
 def _get_tax_benefit_system(baseline, reforms, extensions):

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -101,7 +101,7 @@ class YamlFile(pytest.File):
         for test in tests:
             if not self.should_ignore(test):
                 yield YamlItem.from_parent(self,
-                    name = '', 
+                    name = '',
                     baseline_tax_benefit_system = self.tax_benefit_system,
                     test = test, options = self.options)
 

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -97,9 +97,13 @@ class YamlFile(pytest.File):
 
         if not isinstance(tests, list):
             tests: List[Dict] = [tests]
+
         for test in tests:
             if not self.should_ignore(test):
-                yield YamlItem('', self, self.tax_benefit_system, test, self.options)
+                yield YamlItem.from_parent(self,
+                    name = '', 
+                    baseline_tax_benefit_system = self.tax_benefit_system,
+                    test = test, options = self.options)
 
     def should_ignore(self, test):
         name_filter = self.options.get('name_filter')

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '34.7.4',
+    version = '34.7.5',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
Fixes openfisca/country-template#89

#### Technical changes

- Fix `PytestDeprecationWarning` on `openfisca test` command

---
Bug description:
 
[pytest 5.4.0](https://docs.pytest.org/en/stable/changelog.html#pytest-5-4-0-2020-03-12) deprecates using direct constructors for test nodes. 
This feature is called by the `test_runner` that collects openfisca yaml tests.
So, before this fix, a user calling `openfisca test` (on the country-template for example) gets two warnings:
```
.../openfisca_core/tools/test_runner.py:245: X tests with warnings
  .../openfisca_core/tools/test_runner.py:245: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent, self.tax_benefit_system, self.options)

.../openfisca_core/tools/test_runner.py:102: Y tests with warnings
  .../openfisca_core/tools/test_runner.py:102: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    yield YamlItem('', self, self.tax_benefit_system, test, self.options)
```  

---
Additional documentation:
* on [pytest deprecation](https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent)
* on [yaml files collection](https://docs.pytest.org/en/stable/example/nonpython.html#non-python-tests) with pytest