### PR TITLE
Add dependencies endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 34.8.0 [#964](https://github.com/openfisca/openfisca-core/pull/9646464646464)
+
+
+#### Technical changes
+
+- Added new _dependencies_ API end point to find the dependent input variables of a variable
+- Added a new property in variables.py to enable this.
+- Clarified API documentation for _trace_ endpoint
+
 ### 34.7.7 [#951](https://github.com/openfisca/openfisca-core/pull/951)
 
 #### Technical changes

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ uninstall:
 
 install:
 	pip install --upgrade pip twine wheel
-	pip install --editable .[dev] --upgrade
+	# pip install --editable .[dev] --upgrade
+	pip install -e '.[dev]' --upgrade --use-deprecated=legacy-resolver
 
 clean:
 	rm -rf build dist

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -40,17 +40,12 @@ class Entity(object):
             raise ValueError("{} is not a valid role".format(role))
 
     def get_variable(self, variable_name, check_existence = False):
+        if not self._tax_benefit_system:
+            raise ValueError("No tax_benefit_system set. Please set it using set_tax_benefit_system")
         return self._tax_benefit_system.get_variable(variable_name, check_existence)
 
     def check_variable_defined_for_entity(self, variable_name):
-        try:
-            variable_entity = self.get_variable(variable_name, check_existence = True).entity
-        except AttributeError as e:
-            import sys
-            import traceback
-            traceback.print_tb(sys.exc_info()[2])
-            print(e)
-            raise ValueError("FIXME: tax_benefit_system is null")
+        variable_entity = self.get_variable(variable_name, check_existence = True).entity
         # Should be this:
         # if variable_entity is not self:
         if variable_entity.key != self.key:

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -43,7 +43,14 @@ class Entity(object):
         return self._tax_benefit_system.get_variable(variable_name, check_existence)
 
     def check_variable_defined_for_entity(self, variable_name):
-        variable_entity = self.get_variable(variable_name, check_existence = True).entity
+        try:
+            variable_entity = self.get_variable(variable_name, check_existence = True).entity
+        except AttributeError as e:
+            import sys
+            import traceback
+            traceback.print_tb(sys.exc_info()[2])
+            print(e)
+            raise ValueError("FIXME: tax_benefit_system is null")
         # Should be this:
         # if variable_entity is not self:
         if variable_entity.key != self.key:

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -48,6 +48,9 @@ class Entity(object):
         variable_entity = self.get_variable(variable_name, check_existence = True).entity
         # Should be this:
         # if variable_entity is not self:
+        print("---" + variable_name + "---")
+        print(variable_entity.key)
+        print(self.key)
         if variable_entity.key != self.key:
             message = linesep.join([
                 "You tried to compute the variable '{0}' for the entity '{1}';".format(variable_name, self.plural),

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -48,9 +48,6 @@ class Entity(object):
         variable_entity = self.get_variable(variable_name, check_existence = True).entity
         # Should be this:
         # if variable_entity is not self:
-        print("---" + variable_name + "---")
-        print(variable_entity.key)
-        print(self.key)
         if variable_entity.key != self.key:
             message = linesep.join([
                 "You tried to compute the variable '{0}' for the entity '{1}';".format(variable_name, self.plural),

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -9,11 +9,10 @@ from typing import Optional
 import numpy as np
 from sortedcontainers.sorteddict import SortedDict
 from datetime import date
-from copy import deepcopy
 
 from openfisca_core import periods
 from openfisca_core.entities import Entity
-from openfisca_core import errors 
+from openfisca_core import errors
 from openfisca_core.indexed_enums import Enum, EnumArray, ENUM_ARRAY_DTYPE
 from openfisca_core.periods import DAY, MONTH, YEAR, ETERNITY
 from openfisca_core.tools import eval_expression
@@ -208,10 +207,10 @@ class Variable(object):
         if self.is_input_variable() or self._deps:
             return self._deps
         code = self.get_formula().__code__
-        consts = deepcopy(code.co_consts)
+        consts = code.co_consts
         for con in consts:
             if not isinstance(con, str):
-               continue 
+                continue
             try:
                 self.entity.check_variable_defined_for_entity(con)
             except errors.VariableNotFound:

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -187,6 +187,38 @@ class Variable(object):
                 .format(self.name, ', '.join(sorted(unexpected_attrs.keys()))))
 
         self.is_neutralized = False
+        self._deps = []
+
+    # ----- properties ----- #
+    @property
+    def dependencies(self):
+        """
+        Returns the variables this variable depends on. For this to work
+        the formula must use constant strings as the first input to entity when
+        retrieving the variable.
+
+        Please be mindful that this function simply checks all the constant strings defined
+        in the formula, so avoid using a constant string that collides with a variable
+        name, as it'll lead to incorrect dependencies being reported.
+
+        Input variables return an empty list.
+        """
+        if is_input_variable() or self._deps:
+            return self._deps
+        code = self.get_formula().__code__
+        consts = code.co_consts
+        for c in consts:
+            if not isinstance(c, str):
+                pass
+            if self.entity.check_variable_defined_for_entity(c):
+                self._deps.append(self.entity.get_variable(c))
+        return self._deps
+             
+
+
+        
+
+
 
     # ----- Setters used to build the variable ----- #
 

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -9,9 +9,11 @@ from typing import Optional
 import numpy as np
 from sortedcontainers.sorteddict import SortedDict
 from datetime import date
+from copy import deepcopy
 
 from openfisca_core import periods
 from openfisca_core.entities import Entity
+from openfisca_core import errors 
 from openfisca_core.indexed_enums import Enum, EnumArray, ENUM_ARRAY_DTYPE
 from openfisca_core.periods import DAY, MONTH, YEAR, ETERNITY
 from openfisca_core.tools import eval_expression
@@ -203,22 +205,20 @@ class Variable(object):
 
         Input variables return an empty list.
         """
-        if is_input_variable() or self._deps:
+        if self.is_input_variable() or self._deps:
             return self._deps
         code = self.get_formula().__code__
-        consts = code.co_consts
-        for c in consts:
-            if not isinstance(c, str):
-                pass
-            if self.entity.check_variable_defined_for_entity(c):
-                self._deps.append(self.entity.get_variable(c))
+        consts = deepcopy(code.co_consts)
+        for con in consts:
+            if not isinstance(con, str):
+               continue 
+            try:
+                self.entity.check_variable_defined_for_entity(con)
+            except errors.VariableNotFound:
+                continue
+            self._deps.append(self.entity.get_variable(con))
+
         return self._deps
-             
-
-
-        
-
-
 
     # ----- Setters used to build the variable ----- #
 

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -212,7 +212,8 @@ class Variable(object):
             if not isinstance(con, str):
                 continue
             try:
-                self.entity.check_variable_defined_for_entity(con)
+                self.entity.get_variable(con,
+                            check_existence = True).entity
             except errors.VariableNotFound:
                 continue
             self._deps.append(self.entity.get_variable(con))

--- a/openfisca_web_api/app.py
+++ b/openfisca_web_api/app.py
@@ -143,6 +143,21 @@ def create_app(tax_benefit_system,
             abort(make_response(jsonify({"error": "'" + e[1] + "' is not a valid ASCII value."}), 400))
         return jsonify(result)
 
+    @app.route('/dependencies', methods=['POST'])
+    def dependencies():
+        tax_benefit_system = data['tax_benefit_system']
+        request.on_json_loading_failed = handle_invalid_json
+        input_data = request.get_json()
+        try:
+            result = handlers.dependencies(tax_benefit_system, input_data)
+        except SituationParsingError as e:
+            abort(make_response(jsonify(e.error), e.code or 400))
+        except UnicodeEncodeError as e:
+            abort(make_response(jsonify({"error": "'" + e[1] + "' is not a valid ASCII value."}), 400))
+        return jsonify(result)
+
+
+
     @app.route('/trace', methods=['POST'])
     def trace():
         tax_benefit_system = data['tax_benefit_system']

--- a/openfisca_web_api/app.py
+++ b/openfisca_web_api/app.py
@@ -156,8 +156,6 @@ def create_app(tax_benefit_system,
             abort(make_response(jsonify({"error": "'" + e[1] + "' is not a valid ASCII value."}), 400))
         return jsonify(result)
 
-
-
     @app.route('/trace', methods=['POST'])
     def trace():
         tax_benefit_system = data['tax_benefit_system']

--- a/openfisca_web_api/handlers.py
+++ b/openfisca_web_api/handlers.py
@@ -39,7 +39,7 @@ def calculate(tax_benefit_system, input_data):
 
 
 def dependencies(tax_benefit_system, input_data):
-    simulation = SimulationBuilder().build_from_entities(tax_benefit_system, input_data)
+    SimulationBuilder().build_from_entities(tax_benefit_system, input_data)
     requested_computations = dpath.util.search(input_data,
             '*/*/*/*', afilter = lambda t: t is None, yielded = True)
     dep_vars = defaultdict(int)

--- a/openfisca_web_api/handlers.py
+++ b/openfisca_web_api/handlers.py
@@ -48,20 +48,20 @@ def dependencies(tax_benefit_system, input_data):
         path = computation[0]
         entity_plural, entity_id, variable_name, period = path.split('/')
         variable = tax_benefit_system.get_variable(variable_name)
-        variable.entity.set_tax_benefit_system(tax_benefit_system)
-        get_dependencies(dep_vars, variable)
+        get_dependencies(dep_vars, variable, tax_benefit_system)
     return dep_vars
 
 
-def get_dependencies(dep_vars, variable):
+def get_dependencies(dep_vars, variable, tax_benefit_system):
     """
     recursively find input variables for variables with formulas.
     """
+    variable.entity.set_tax_benefit_system(tax_benefit_system)
     for dep in variable.dependencies:
         if dep.is_input_variable():
             dep_vars[dep.name] += 1
         else:
-            get_dependencies(dep_vars, dep)
+            get_dependencies(dep_vars, dep, tax_benefit_system)
 
 
 def trace(tax_benefit_system, input_data):

--- a/openfisca_web_api/openAPI.yml
+++ b/openfisca_web_api/openAPI.yml
@@ -30,6 +30,39 @@ tags:
   - name: "Calculations"
   - name: "Documentation"
 paths:
+  /dependencies:
+    post:
+      summary: "Find the dependent input variables of an OpenFisca Variable "
+      tags:
+        - Calculations
+      operationId: "calculate"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+      - in: "body"
+        name: "Situation"
+        description: 'Describe the situation (persons and entities). Add the variable you wish to calculate in the proper entity, with null as the value. Learn more in our official documentation: https://openfisca.org/doc/openfisca-web-api/input-output-data.html'
+        required: true
+        schema:
+          $ref: '#/definitions/SituationInput'
+      responses:
+        200:
+          description: "The calculation result is sent back in the response body"
+          headers:
+            $ref: '#/commons/Headers'
+          schema:
+            $ref: '#/definitions/SituationOutput'
+        404:
+          description: "A variable mentioned in the input situation does not exist in the loaded tax and benefit system. Details are sent back in the response body"
+          headers:
+            $ref: '#/commons/Headers'
+        400:
+          description: "The request is invalid. Details about the error are sent back in the response body"
+          headers:
+            $ref: '#/commons/Headers'
+
   /calculate:
     post:
       summary: "Run a simulation"

--- a/openfisca_web_api/openAPI.yml
+++ b/openfisca_web_api/openAPI.yml
@@ -35,7 +35,7 @@ paths:
       summary: "Find the dependent input variables of an OpenFisca Variable. This simply looks for constant strings and checks if they are variables in the entity. It will not work if you construct the strings programatically."
       tags:
         - Calculations
-      operationId: "calculate"
+      operationId: "dependencies"
       consumes:
         - "application/json"
       produces:
@@ -43,7 +43,7 @@ paths:
       parameters:
       - in: "body"
         name: "Situation"
-        description: 'Describe the situation (persons and entities). Add the variable you wish to calculate in the proper entity, with null as the value. Learn more in our official documentation: https://openfisca.org/doc/openfisca-web-api/input-output-data.html'
+        description: 'Describe the situation (persons and entities). Add the variable you wish to get the dependencies of in the entity, with null as the value. Learn more in our official documentation: https://openfisca.org/doc/openfisca-web-api/input-output-data.html'
         required: true
         schema:
           $ref: '#/definitions/SituationInput'

--- a/openfisca_web_api/openAPI.yml
+++ b/openfisca_web_api/openAPI.yml
@@ -32,7 +32,7 @@ tags:
 paths:
   /dependencies:
     post:
-      summary: "Find the dependent input variables of an OpenFisca Variable "
+      summary: "Find the dependent input variables of an OpenFisca Variable. This simply looks for constant strings and checks if they are variables in the entity. It will not work if you construct the strings programatically."
       tags:
         - Calculations
       operationId: "calculate"
@@ -192,7 +192,7 @@ paths:
             $ref: "#/definitions/Entities"
   /trace:
     post:
-      summary: "Explore a simulation's steps in details."
+      summary: "Return every variable accessed/executed in order to calculate this simulation."
       tags:
         - Calculations
       operationId: "trace"

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ dev_requirements = [
     'flake8-print >= 3.1.0, < 4.0.0',
     'pytest-cov >= 2.6.1, < 3.0.0',
     'mypy >= 0.701, < 0.800',
-    'openfisca-country-template >= 3.10.0, < 4.0.0'
+    'openfisca-country-template >= 3.10.0, < 4.0.0',
     'openfisca-extension-template >= 1.2.0rc0, < 2.0.0'
     ] + api_requirements
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ dev_requirements = [
     'flake8-print >= 3.1.0, < 4.0.0',
     'pytest-cov >= 2.6.1, < 3.0.0',
     'mypy >= 0.701, < 0.800',
-    'country-template',
+    'openfisca-country-template >= 3.10.0, < 4.0.0'
     'openfisca-extension-template >= 1.2.0rc0, < 2.0.0'
     ] + api_requirements
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ dev_requirements = [
     'flake8-print >= 3.1.0, < 4.0.0',
     'pytest-cov >= 2.6.1, < 3.0.0',
     'mypy >= 0.701, < 0.800',
-    'openfisca-country-template >= 3.10.0, < 4.0.0',
+    'country-template',
     'openfisca-extension-template >= 1.2.0rc0, < 2.0.0'
     ] + api_requirements
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '34.7.8',
+    version = '34.8.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ dev_requirements = [
     'flake8-print >= 3.1.0, < 4.0.0',
     'pytest-cov >= 2.6.1, < 3.0.0',
     'mypy >= 0.701, < 0.800',
-    'openfisca-country-template >= 3.10.0, < 4.0.0',
+    'openfisca-country-template-draft >= 3.10.0, < 4.11.0',
     'openfisca-extension-template >= 1.2.0rc0, < 2.0.0'
     ] + api_requirements
 

--- a/tests/web_api/test_dependencies.py
+++ b/tests/web_api/test_dependencies.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 
-import os
 import json
-from http.client import BAD_REQUEST, OK, NOT_FOUND
+import os
+from http.client import BAD_REQUEST, NOT_FOUND, OK
+
+import dpath
 
 import pytest
-import dpath
 
 from . import subject
 
@@ -107,3 +108,57 @@ def test_basic_variable_deps():
     assert dpath.get(response_json, 'birth') == 3
     assert dpath.get(response_json, 'housing_occupancy_status') == 1
     assert dpath.get(response_json, 'salary') == 4
+
+
+def test_parenting_payment():
+    simulation_json = json.dumps({
+        "persons": {
+            "Phil": {
+                "birth": {
+                    "1981-10": "1981-10-01"
+                    },
+                "salary": {
+                    "2020-12": 200
+                    }
+                },
+            "Saz": {
+                "birth": {
+                    "1980-10": "1980-10-01"
+                    },
+                "salary": {
+                    "2020-12": 210
+                    }
+                },
+            "Caz": {
+                "birth": {
+                    "2010-10": "2010-10-01"
+                    }
+                },
+            "Eille": {
+                "birth": {
+                    "2012-10": "2012-10-01"
+                    }
+                },
+            "Nimasay": {
+                "birth": {
+                    "2018-10": "2018-10-01"
+                    },
+                }
+            },
+        "households": {
+            "first_household": {
+                "parents": ['Phil', 'Saz'],
+                "children": ['Caz', 'Eille', 'Nimasay'],
+                "parenting_allowance": {
+                    "2020": None
+                    },
+                },
+            }
+        })
+
+    response = post_json(simulation_json)
+    assert response.status_code == OK
+    response_json = json.loads(response.data.decode('utf-8'))
+    # response_json = {'salary': 1, 'birth': 1}
+    assert dpath.get(response_json, 'salary') == 1
+    assert dpath.get(response_json, 'birth') == 1

--- a/tests/web_api/test_dependencies.py
+++ b/tests/web_api/test_dependencies.py
@@ -3,12 +3,9 @@
 import os
 import json
 from http.client import BAD_REQUEST, OK, NOT_FOUND
-from copy import deepcopy
 
 import pytest
 import dpath
-
-from openfisca_country_template.situation_examples import couple
 
 from . import subject
 
@@ -110,36 +107,3 @@ def test_basic_variable_deps():
     assert dpath.get(response_json, 'birth') == 3
     assert dpath.get(response_json, 'housing_occupancy_status') == 1
     assert dpath.get(response_json, 'salary') == 4
-
-
-"""
-def test_basic_variable_deps():
-    simulation_json = json.dumps({
-    {
-      "persons": {
-            "joe": {
-                    "basic_income": {
-                            "2020-1": None
-                    },
-                    "housing_allowance": {
-                            "2020-1": None
-                    }
-            },
-            "titled_properties": {
-            },
-            "families": {
-            }
-    }}})
-
-    response = post_json(simulation_json)
-    assert response.status_code == OK
-    response_json = json.loads(response.data.decode('utf-8'))
-    assert dpath.get(response_json, 'persons/bill/basic_income/2017-12') == 600  # Universal basic income
-    assert dpath.get(response_json, 'persons/bill/income_tax/2017-12') == 300  # 15% of the salary
-    assert dpath.get(response_json, 'persons/bill/age/2017-12') == 37  # 15% of the salary
-    assert dpath.get(response_json, 'persons/bob/basic_income/2017-12') == 600
-    assert dpath.get(response_json, 'persons/bob/social_security_contribution/2017-12') == 816  # From social_security_contribution.yaml test
-    assert dpath.get(response_json, 'households/first_household/housing_tax/2017') == 3000
-
-"""
-

--- a/tests/web_api/test_dependencies.py
+++ b/tests/web_api/test_dependencies.py
@@ -28,28 +28,6 @@ def check_response(data, expected_error_code, path_to_check, content_to_check):
         assert content_to_check in content
 
 
-@pytest.mark.parametrize("test", [
-    ('{"a" : "x", "b"}', BAD_REQUEST, 'error', 'Invalid JSON'),
-    ('["An", "array"]', BAD_REQUEST, 'error', 'Invalid type'),
-    ('{"persons": {}}', BAD_REQUEST, 'persons', 'At least one person'),
-    ('{"persons": {"bob": {}}, "unknown_entity": {}}', BAD_REQUEST, 'unknown_entity', 'entities are not found',),
-    ('{"persons": {"bob": {}}, "households": {"dupont": {"parents": {}}}}', BAD_REQUEST, 'households/dupont/parents', 'type',),
-    ('{"persons": {"bob": {"unknown_variable": {}}}}', NOT_FOUND, 'persons/bob/unknown_variable', 'You tried to calculate or to set',),
-    ('{"persons": {"bob": {"housing_allowance": {}}}}', BAD_REQUEST, 'persons/bob/housing_allowance', "You tried to compute the variable 'housing_allowance' for the entity 'persons'",),
-    ('{"persons": {"bob": {"salary": 4000 }}}', BAD_REQUEST, 'persons/bob/salary', 'period',),
-    ('{"persons": {"bob": {"salary": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/salary/2017-01', 'expected type number',),
-    ('{"persons": {"bob": {"salary": {"2017-01": {}} }}}', BAD_REQUEST, 'persons/bob/salary/2017-01', 'expected type number',),
-    ('{"persons": {"bob": {"age": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/age/2017-01', 'expected type integer',),
-    ('{"persons": {"bob": {"birth": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/birth/2017-01', 'Can\'t deal with date',),
-    ('{"persons": {"bob": {}}, "households": {"household": {"parents": ["unexpected_person_id"]}}}', BAD_REQUEST, 'households/household/parents', 'has not been declared in persons',),
-    ('{"persons": {"bob": {}}, "households": {"household": {"parents": ["bob", "bob"]}}}', BAD_REQUEST, 'households/household/parents', 'has been declared more than once',),
-    ('{"persons": {"bob": {}}, "households": {"household": {"parents": ["bob", {}]}}}', BAD_REQUEST, 'households/household/parents/1', 'Invalid type',),
-    ('{"persons": {"bob": {"salary": {"invalid period": 2000 }}}}', BAD_REQUEST, 'persons/bob/salary', 'Expected a period',),
-    ('{"persons": {"bob": {"salary": {"invalid period": null }}}}', BAD_REQUEST, 'persons/bob/salary', 'Expected a period',),
-    ('{"persons": {"bob": {"basic_income": {"2017": 2000 }}}, "households": {"household": {"parents": ["bob"]}}}', BAD_REQUEST, 'persons/bob/basic_income/2017', '"basic_income" can only be set for one month',),
-    ('{"persons": {"bob": {"salary": {"ETERNITY": 2000 }}}, "households": {"household": {"parents": ["bob"]}}}', BAD_REQUEST, 'persons/bob/salary/ETERNITY', 'salary is only defined for months',),
-    ('{"persons": {"alice": {}, "bob": {}, "charlie": {}}, "households": {"_": {"parents": ["alice", "bob", "charlie"]}}}', BAD_REQUEST, 'households/_/parents', 'at most 2 parents in a household',),
-    ])
 def test_responses(test):
     check_response(*test)
 

--- a/tests/web_api/test_dependencies.py
+++ b/tests/web_api/test_dependencies.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+
+import os
+import json
+from http.client import BAD_REQUEST, OK, NOT_FOUND
+from copy import deepcopy
+
+import pytest
+import dpath
+
+from openfisca_country_template.situation_examples import couple
+
+from . import subject
+
+
+def post_json(data = None, file = None):
+    if file:
+        file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'assets', file)
+        with open(file_path, 'r') as file:
+            data = file.read()
+    return subject.post('/dependencies', data = data, content_type = 'application/json')
+
+
+def check_response(data, expected_error_code, path_to_check, content_to_check):
+    response = post_json(data)
+    assert response.status_code == expected_error_code
+    json_response = json.loads(response.data.decode('utf-8'))
+    if path_to_check:
+        content = dpath.util.get(json_response, path_to_check)
+        assert content_to_check in content
+
+
+@pytest.mark.parametrize("test", [
+    ('{"a" : "x", "b"}', BAD_REQUEST, 'error', 'Invalid JSON'),
+    ('["An", "array"]', BAD_REQUEST, 'error', 'Invalid type'),
+    ('{"persons": {}}', BAD_REQUEST, 'persons', 'At least one person'),
+    ('{"persons": {"bob": {}}, "unknown_entity": {}}', BAD_REQUEST, 'unknown_entity', 'entities are not found',),
+    ('{"persons": {"bob": {}}, "households": {"dupont": {"parents": {}}}}', BAD_REQUEST, 'households/dupont/parents', 'type',),
+    ('{"persons": {"bob": {"unknown_variable": {}}}}', NOT_FOUND, 'persons/bob/unknown_variable', 'You tried to calculate or to set',),
+    ('{"persons": {"bob": {"housing_allowance": {}}}}', BAD_REQUEST, 'persons/bob/housing_allowance', "You tried to compute the variable 'housing_allowance' for the entity 'persons'",),
+    ('{"persons": {"bob": {"salary": 4000 }}}', BAD_REQUEST, 'persons/bob/salary', 'period',),
+    ('{"persons": {"bob": {"salary": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/salary/2017-01', 'expected type number',),
+    ('{"persons": {"bob": {"salary": {"2017-01": {}} }}}', BAD_REQUEST, 'persons/bob/salary/2017-01', 'expected type number',),
+    ('{"persons": {"bob": {"age": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/age/2017-01', 'expected type integer',),
+    ('{"persons": {"bob": {"birth": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/birth/2017-01', 'Can\'t deal with date',),
+    ('{"persons": {"bob": {}}, "households": {"household": {"parents": ["unexpected_person_id"]}}}', BAD_REQUEST, 'households/household/parents', 'has not been declared in persons',),
+    ('{"persons": {"bob": {}}, "households": {"household": {"parents": ["bob", "bob"]}}}', BAD_REQUEST, 'households/household/parents', 'has been declared more than once',),
+    ('{"persons": {"bob": {}}, "households": {"household": {"parents": ["bob", {}]}}}', BAD_REQUEST, 'households/household/parents/1', 'Invalid type',),
+    ('{"persons": {"bob": {"salary": {"invalid period": 2000 }}}}', BAD_REQUEST, 'persons/bob/salary', 'Expected a period',),
+    ('{"persons": {"bob": {"salary": {"invalid period": null }}}}', BAD_REQUEST, 'persons/bob/salary', 'Expected a period',),
+    ('{"persons": {"bob": {"basic_income": {"2017": 2000 }}}, "households": {"household": {"parents": ["bob"]}}}', BAD_REQUEST, 'persons/bob/basic_income/2017', '"basic_income" can only be set for one month',),
+    ('{"persons": {"bob": {"salary": {"ETERNITY": 2000 }}}, "households": {"household": {"parents": ["bob"]}}}', BAD_REQUEST, 'persons/bob/salary/ETERNITY', 'salary is only defined for months',),
+    ('{"persons": {"alice": {}, "bob": {}, "charlie": {}}, "households": {"_": {"parents": ["alice", "bob", "charlie"]}}}', BAD_REQUEST, 'households/_/parents', 'at most 2 parents in a household',),
+    ])
+def test_responses(test):
+    check_response(*test)
+
+
+def test_basic_variable_deps():
+    simulation_json = json.dumps({
+        "persons": {
+            "bill": {
+                "birth": {
+                    "2017-12": "1980-01-01"
+                    },
+                "age": {
+                    "2017-12": None
+                    },
+                "salary": {
+                    "2017-12": 2000
+                    },
+                "basic_income": {
+                    "2017-12": None
+                    },
+                "income_tax": {
+                    "2017-12": None
+                    }
+                },
+            "bob": {
+                "salary": {
+                    "2017-12": 15000
+                    },
+                "basic_income": {
+                    "2017-12": None
+                    },
+                "social_security_contribution": {
+                    "2017-12": None
+                    }
+                },
+            },
+        "households": {
+            "first_household": {
+                "parents": ['bill', 'bob'],
+                "housing_tax": {
+                    "2017": None
+                    },
+                "accommodation_size": {
+                    "2017-01": 300
+                    }
+                },
+            }
+        })
+
+    response = post_json(simulation_json)
+    assert response.status_code == OK
+    response_json = json.loads(response.data.decode('utf-8'))
+    # response_json = {'accommodation_size': 1, 'birth': 3, 'housing_occupancy_status': 1, 'salary': 4}
+
+    assert dpath.get(response_json, 'accommodation_size') == 1
+    assert dpath.get(response_json, 'birth') == 3
+    assert dpath.get(response_json, 'housing_occupancy_status') == 1
+    assert dpath.get(response_json, 'salary') == 4
+
+
+"""
+def test_basic_variable_deps():
+    simulation_json = json.dumps({
+    {
+      "persons": {
+            "joe": {
+                    "basic_income": {
+                            "2020-1": None
+                    },
+                    "housing_allowance": {
+                            "2020-1": None
+                    }
+            },
+            "titled_properties": {
+            },
+            "families": {
+            }
+    }}})
+
+    response = post_json(simulation_json)
+    assert response.status_code == OK
+    response_json = json.loads(response.data.decode('utf-8'))
+    assert dpath.get(response_json, 'persons/bill/basic_income/2017-12') == 600  # Universal basic income
+    assert dpath.get(response_json, 'persons/bill/income_tax/2017-12') == 300  # 15% of the salary
+    assert dpath.get(response_json, 'persons/bill/age/2017-12') == 37  # 15% of the salary
+    assert dpath.get(response_json, 'persons/bob/basic_income/2017-12') == 600
+    assert dpath.get(response_json, 'persons/bob/social_security_contribution/2017-12') == 816  # From social_security_contribution.yaml test
+    assert dpath.get(response_json, 'households/first_household/housing_tax/2017') == 3000
+
+"""
+

--- a/tests/web_api/test_parameters.py
+++ b/tests/web_api/test_parameters.py
@@ -78,7 +78,8 @@ def test_parameter_node():
         )
     assert parameter['subparams'] == {
         'housing_allowance': {'description': 'Housing allowance amount (as a fraction of the rent)'},
-        'basic_income': {'description': 'Amount of the basic income'}
+        'basic_income': {'description': 'Amount of the basic income'},
+        'parenting_allowance': {'description': 'parameters relating to parenting payment'}
         }, parameter['subparams']
 
 

--- a/tests/web_api/test_spec.py
+++ b/tests/web_api/test_spec.py
@@ -8,6 +8,8 @@ from . import subject
 
 
 def assert_items_equal(x, y):
+    print(sorted(x))
+    print(sorted(y))
     assert sorted(x) == sorted(y)
 
 
@@ -22,9 +24,9 @@ body = json.loads(openAPI_response.data.decode('utf-8'))
 
 
 def test_paths():
-    assert_items_equal(
-        body['paths'],
-        ["/parameter/{parameterID}",
+    res = list(body['paths'].keys())
+    res.sort()
+    expected = ["/parameter/{parameterID}",
         "/parameters",
         "/variable/{variableID}",
         "/variables",
@@ -33,7 +35,11 @@ def test_paths():
         "/calculate",
         "/dependencies",
         "/spec"]
-        )
+    expected.sort()
+    print(res)
+    print(expected)
+
+    assert_items_equal(res, expected)
 
 
 def test_entity_definition():

--- a/tests/web_api/test_spec.py
+++ b/tests/web_api/test_spec.py
@@ -8,8 +8,6 @@ from . import subject
 
 
 def assert_items_equal(x, y):
-    print(sorted(x))
-    print(sorted(y))
     assert sorted(x) == sorted(y)
 
 
@@ -36,9 +34,6 @@ def test_paths():
         "/dependencies",
         "/spec"]
     expected.sort()
-    print(res)
-    print(expected)
-
     assert_items_equal(res, expected)
 
 

--- a/tests/web_api/test_spec.py
+++ b/tests/web_api/test_spec.py
@@ -31,6 +31,7 @@ def test_paths():
         "/entities",
         "/trace",
         "/calculate",
+        "/dependencies",
         "/spec"]
         )
 


### PR DESCRIPTION
#### Purpose

This new endpoint allows a user to find the dependent input variables to a variable. It's useful if you want to calculate a variable, and need to know what inputs you need. It allows you to find the answer to that question without having to manually go through all the variables (and their dependencies) until you get to the inputs.

It's also useful for gathering statistics about the use of input variables. If I want to design a form to get information from a user to assess their eligibility for a series of benefits, I could use this to find which input variables are used most often across different formulas, and put those at the start of the form. This could avoid having to ask the user too many questions, as you could design the form to exit early if the user isn't eligible.

I made it particularly for the Canadian project, where they wanted to get a list of input variables, and sort them based on use. You could do it in the front-end, but you'd have to parse python to do so. It makes more sense in the backend. It would have also been useful for NSW Community Gaming project, where we had to do this by hand to make the form.

#### New features

- New dependencies api end point that finds the dependent input variables of a variable.
- New property in variables.py to enable this.

#### Technical changes

- Made the API documentation for the trace endpoint a little clearer.