### PR TITLE
Add dependencies endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 35.1.0 [#964](https://github.com/openfisca/openfisca-core/pull/964)
+
+#### Technical changes
+
+- Added new _dependencies_ API end point to find the dependent input variables of a variable
+- Added a new property in variables.py to enable this.
+- Clarified API documentation for _trace_ endpoint
+
+# 35.0.1 [#968](https://github.com/openfisca/openfisca-core/pull/968)
+
 ### 35.0.4 [#965](https://github.com/openfisca/openfisca-core/pull/965)
 
 #### Technical changes
@@ -21,6 +31,7 @@
 - Update dependency: `flask-cors` (`Flask` extension for Cross Origin Resouce Sharing)
 
 ### 35.0.1 [#968](https://github.com/openfisca/openfisca-core/pull/968)
+
 
 #### Technical changes
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ uninstall:
 
 install:
 	pip install --upgrade pip twine wheel
-	pip install --editable .[dev] --upgrade --use-deprecated=legacy-resolver
+	pip install -e '.[dev]' --upgrade --use-deprecated=legacy-resolver
 
 clean:
 	rm -rf build dist

--- a/openfisca_core/entities.py
+++ b/openfisca_core/entities.py
@@ -40,6 +40,8 @@ class Entity(object):
             raise ValueError("{} is not a valid role".format(role))
 
     def get_variable(self, variable_name, check_existence = False):
+        if not self._tax_benefit_system:
+            raise ValueError("No tax_benefit_system set. Please set it using set_tax_benefit_system")
         return self._tax_benefit_system.get_variable(variable_name, check_existence)
 
     def check_variable_defined_for_entity(self, variable_name):

--- a/openfisca_web_api/app.py
+++ b/openfisca_web_api/app.py
@@ -143,6 +143,19 @@ def create_app(tax_benefit_system,
             abort(make_response(jsonify({"error": "'" + e[1] + "' is not a valid ASCII value."}), 400))
         return jsonify(result)
 
+    @app.route('/dependencies', methods=['POST'])
+    def dependencies():
+        tax_benefit_system = data['tax_benefit_system']
+        request.on_json_loading_failed = handle_invalid_json
+        input_data = request.get_json()
+        try:
+            result = handlers.dependencies(tax_benefit_system, input_data)
+        except SituationParsingError as e:
+            abort(make_response(jsonify(e.error), e.code or 400))
+        except UnicodeEncodeError as e:
+            abort(make_response(jsonify({"error": "'" + e[1] + "' is not a valid ASCII value."}), 400))
+        return jsonify(result)
+
     @app.route('/trace', methods=['POST'])
     def trace():
         tax_benefit_system = data['tax_benefit_system']

--- a/openfisca_web_api/handlers.py
+++ b/openfisca_web_api/handlers.py
@@ -4,6 +4,7 @@ import dpath
 
 from openfisca_core.simulation_builder import SimulationBuilder
 from openfisca_core.indexed_enums import Enum
+from collections import defaultdict
 
 
 def calculate(tax_benefit_system, input_data):
@@ -16,6 +17,7 @@ def calculate(tax_benefit_system, input_data):
         path = computation[0]
         entity_plural, entity_id, variable_name, period = path.split('/')
         variable = tax_benefit_system.get_variable(variable_name)
+
         result = simulation.calculate(variable_name, period)
         population = simulation.get_population(entity_plural)
         entity_index = population.get_index(entity_id)
@@ -36,6 +38,32 @@ def calculate(tax_benefit_system, input_data):
     return input_data
 
 
+def dependencies(tax_benefit_system, input_data):
+    SimulationBuilder().build_from_entities(tax_benefit_system, input_data)
+    requested_computations = dpath.util.search(input_data,
+            '*/*/*/*', afilter = lambda t: t is None, yielded = True)
+    dep_vars = defaultdict(int)
+
+    for computation in requested_computations:
+        path = computation[0]
+        entity_plural, entity_id, variable_name, period = path.split('/')
+        variable = tax_benefit_system.get_variable(variable_name)
+        get_dependencies(dep_vars, variable, tax_benefit_system)
+    return dep_vars
+
+
+def get_dependencies(dep_vars, variable, tax_benefit_system):
+    """
+    recursively find input variables for variables with formulas.
+    """
+    variable.entity.set_tax_benefit_system(tax_benefit_system)
+    for dep in variable.dependencies:
+        if dep.is_input_variable():
+            dep_vars[dep.name] += 1
+        else:
+            get_dependencies(dep_vars, dep, tax_benefit_system)
+
+
 def trace(tax_benefit_system, input_data):
     simulation = SimulationBuilder().build_from_entities(tax_benefit_system, input_data)
     simulation.trace = True
@@ -47,7 +75,6 @@ def trace(tax_benefit_system, input_data):
         entity_plural, entity_id, variable_name, period = path.split('/')
         requested_calculations.append(f"{variable_name}<{str(period)}>")
         simulation.calculate(variable_name, period)
-
     trace = simulation.tracer.get_serialized_flat_trace()
 
     return {

--- a/openfisca_web_api/openAPI.yml
+++ b/openfisca_web_api/openAPI.yml
@@ -30,6 +30,39 @@ tags:
   - name: "Calculations"
   - name: "Documentation"
 paths:
+  /dependencies:
+    post:
+      summary: "Find the dependent input variables of an OpenFisca Variable. This simply looks for constant strings and checks if they are variables in the entity. It will not work if you construct the strings programatically."
+      tags:
+        - Calculations
+      operationId: "dependencies"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+      - in: "body"
+        name: "Situation"
+        description: 'Describe the situation (persons and entities). Add the variable you wish to get the dependencies of in the entity, with null as the value. Learn more in our official documentation: https://openfisca.org/doc/openfisca-web-api/input-output-data.html'
+        required: true
+        schema:
+          $ref: '#/definitions/SituationInput'
+      responses:
+        200:
+          description: "The calculation result is sent back in the response body"
+          headers:
+            $ref: '#/commons/Headers'
+          schema:
+            $ref: '#/definitions/SituationOutput'
+        404:
+          description: "A variable mentioned in the input situation does not exist in the loaded tax and benefit system. Details are sent back in the response body"
+          headers:
+            $ref: '#/commons/Headers'
+        400:
+          description: "The request is invalid. Details about the error are sent back in the response body"
+          headers:
+            $ref: '#/commons/Headers'
+
   /calculate:
     post:
       summary: "Run a simulation"
@@ -159,7 +192,7 @@ paths:
             $ref: "#/definitions/Entities"
   /trace:
     post:
-      summary: "Explore a simulation's steps in details."
+      summary: "Return every variable accessed/executed in order to calculate this simulation."
       tags:
         - Calculations
       operationId: "trace"

--- a/setup.py
+++ b/setup.py
@@ -31,13 +31,13 @@ dev_requirements = [
     'flake8-print >= 3.1.0, < 4.0.0',
     'pytest-cov >= 2.6.1, < 3.0.0',
     'mypy >= 0.701, < 0.800',
-    'openfisca-country-template >= 3.10.0, < 4.0.0',
+    'openfisca-country-template >= 3.12.2, < 4.0.0',
     'openfisca-extension-template >= 1.2.0rc0, < 2.0.0'
     ] + api_requirements
 
 setup(
     name = 'OpenFisca-Core',
-    version = '35.0.4',
+    version = '35.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/web_api/test_dependencies.py
+++ b/tests/web_api/test_dependencies.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+
+import json
+import os
+from http.client import BAD_REQUEST, NOT_FOUND, OK
+
+import dpath
+
+import pytest
+
+from . import subject
+
+
+def post_json(data = None, file = None):
+    if file:
+        file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'assets', file)
+        with open(file_path, 'r') as file:
+            data = file.read()
+    return subject.post('/dependencies', data = data, content_type = 'application/json')
+
+
+def check_response(data, expected_error_code, path_to_check, content_to_check):
+    response = post_json(data)
+    assert response.status_code == expected_error_code
+    json_response = json.loads(response.data.decode('utf-8'))
+    if path_to_check:
+        content = dpath.util.get(json_response, path_to_check)
+        assert content_to_check in content
+
+
+@pytest.mark.parametrize("test", [
+    ('{"a" : "x", "b"}', BAD_REQUEST, 'error', 'Invalid JSON'),
+    ('["An", "array"]', BAD_REQUEST, 'error', 'Invalid type'),
+    ('{"persons": {}}', BAD_REQUEST, 'persons', 'At least one person'),
+    ('{"persons": {"bob": {}}, "unknown_entity": {}}', BAD_REQUEST, 'unknown_entity', 'entities are not found',),
+    ('{"persons": {"bob": {}}, "households": {"dupont": {"parents": {}}}}', BAD_REQUEST, 'households/dupont/parents', 'type',),
+    ('{"persons": {"bob": {"unknown_variable": {}}}}', NOT_FOUND, 'persons/bob/unknown_variable', 'You tried to calculate or to set',),
+    ('{"persons": {"bob": {"housing_allowance": {}}}}', BAD_REQUEST, 'persons/bob/housing_allowance', "You tried to compute the variable 'housing_allowance' for the entity 'persons'",),
+    ('{"persons": {"bob": {"salary": 4000 }}}', BAD_REQUEST, 'persons/bob/salary', 'period',),
+    ('{"persons": {"bob": {"salary": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/salary/2017-01', 'expected type number',),
+    ('{"persons": {"bob": {"salary": {"2017-01": {}} }}}', BAD_REQUEST, 'persons/bob/salary/2017-01', 'expected type number',),
+    ('{"persons": {"bob": {"age": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/age/2017-01', 'expected type integer',),
+    ('{"persons": {"bob": {"birth": {"2017-01": "toto"} }}}', BAD_REQUEST, 'persons/bob/birth/2017-01', 'Can\'t deal with date',),
+    ('{"persons": {"bob": {}}, "households": {"household": {"parents": ["unexpected_person_id"]}}}', BAD_REQUEST, 'households/household/parents', 'has not been declared in persons',),
+    ('{"persons": {"bob": {}}, "households": {"household": {"parents": ["bob", "bob"]}}}', BAD_REQUEST, 'households/household/parents', 'has been declared more than once',),
+    ('{"persons": {"bob": {}}, "households": {"household": {"parents": ["bob", {}]}}}', BAD_REQUEST, 'households/household/parents/1', 'Invalid type',),
+    ('{"persons": {"bob": {"salary": {"invalid period": 2000 }}}}', BAD_REQUEST, 'persons/bob/salary', 'Expected a period',),
+    ('{"persons": {"bob": {"salary": {"invalid period": null }}}}', BAD_REQUEST, 'persons/bob/salary', 'Expected a period',),
+    ('{"persons": {"bob": {"basic_income": {"2017": 2000 }}}, "households": {"household": {"parents": ["bob"]}}}', BAD_REQUEST, 'persons/bob/basic_income/2017', '"basic_income" can only be set for one month',),
+    ('{"persons": {"bob": {"salary": {"ETERNITY": 2000 }}}, "households": {"household": {"parents": ["bob"]}}}', BAD_REQUEST, 'persons/bob/salary/ETERNITY', 'salary is only defined for months',),
+    ('{"persons": {"alice": {}, "bob": {}, "charlie": {}}, "households": {"_": {"parents": ["alice", "bob", "charlie"]}}}', BAD_REQUEST, 'households/_/parents', 'at most 2 parents in a household',),
+    ])
+def test_responses(test):
+    check_response(*test)
+
+
+def test_basic_variable_deps():
+    simulation_json = json.dumps({
+        "persons": {
+            "bill": {
+                "birth": {
+                    "2017-12": "1980-01-01"
+                    },
+                "age": {
+                    "2017-12": None
+                    },
+                "salary": {
+                    "2017-12": 2000
+                    },
+                "basic_income": {
+                    "2017-12": None
+                    },
+                "income_tax": {
+                    "2017-12": None
+                    }
+                },
+            "bob": {
+                "salary": {
+                    "2017-12": 15000
+                    },
+                "basic_income": {
+                    "2017-12": None
+                    },
+                "social_security_contribution": {
+                    "2017-12": None
+                    }
+                },
+            },
+        "households": {
+            "first_household": {
+                "parents": ['bill', 'bob'],
+                "housing_tax": {
+                    "2017": None
+                    },
+                "accommodation_size": {
+                    "2017-01": 300
+                    }
+                },
+            }
+        })
+
+    response = post_json(simulation_json)
+    assert response.status_code == OK
+    response_json = json.loads(response.data.decode('utf-8'))
+    # response_json = {'accommodation_size': 1, 'birth': 3, 'housing_occupancy_status': 1, 'salary': 4}
+
+    assert dpath.get(response_json, 'accommodation_size') == 1
+    assert dpath.get(response_json, 'birth') == 3
+    assert dpath.get(response_json, 'housing_occupancy_status') == 1
+    assert dpath.get(response_json, 'salary') == 4
+
+
+def test_parenting_payment():
+    simulation_json = json.dumps({
+        "persons": {
+            "Phil": {
+                "birth": {
+                    "1981-10": "1981-10-01"
+                    },
+                "salary": {
+                    "2020-12": 200
+                    }
+                },
+            "Saz": {
+                "birth": {
+                    "1980-10": "1980-10-01"
+                    },
+                "salary": {
+                    "2020-12": 210
+                    }
+                },
+            "Caz": {
+                "birth": {
+                    "2010-10": "2010-10-01"
+                    }
+                },
+            "Eille": {
+                "birth": {
+                    "2012-10": "2012-10-01"
+                    }
+                },
+            "Nimasay": {
+                "birth": {
+                    "2018-10": "2018-10-01"
+                    },
+                }
+            },
+        "households": {
+            "first_household": {
+                "parents": ['Phil', 'Saz'],
+                "children": ['Caz', 'Eille', 'Nimasay'],
+                "parenting_allowance": {
+                    "2020": None
+                    },
+                },
+            }
+        })
+
+    response = post_json(simulation_json)
+    assert response.status_code == OK
+    response_json = json.loads(response.data.decode('utf-8'))
+    # response_json = {'salary': 1, 'birth': 1}
+    assert dpath.get(response_json, 'salary') == 1
+    assert dpath.get(response_json, 'birth') == 1

--- a/tests/web_api/test_parameters.py
+++ b/tests/web_api/test_parameters.py
@@ -78,7 +78,8 @@ def test_parameter_node():
         )
     assert parameter['subparams'] == {
         'housing_allowance': {'description': 'Housing allowance amount (as a fraction of the rent)'},
-        'basic_income': {'description': 'Amount of the basic income'}
+        'basic_income': {'description': 'Amount of the basic income'},
+        'parenting_allowance': {'description': 'parameters relating to parenting payment'}
         }, parameter['subparams']
 
 

--- a/tests/web_api/test_spec.py
+++ b/tests/web_api/test_spec.py
@@ -22,17 +22,19 @@ body = json.loads(openAPI_response.data.decode('utf-8'))
 
 
 def test_paths():
-    assert_items_equal(
-        body['paths'],
-        ["/parameter/{parameterID}",
+    res = list(body['paths'].keys())
+    res.sort()
+    expected = ["/parameter/{parameterID}",
         "/parameters",
         "/variable/{variableID}",
         "/variables",
         "/entities",
         "/trace",
         "/calculate",
+        "/dependencies",
         "/spec"]
-        )
+    expected.sort()
+    assert_items_equal(res, expected)
 
 
 def test_entity_definition():


### PR DESCRIPTION
### Purpose

This new endpoint allows a user to find the dependent input variables to a variable. It's useful if you want to calculate a variable, and need to know what inputs you need. It allows you to find the answer to that question without having to manually go through all the variables (and their dependencies) until you get to the inputs.

It's also useful for gathering statistics about the use of input variables. If I want to design a form to get information from a user to assess their eligibility for a series of benefits, I could use this to find which input variables are used most often across different formulas, and put those at the start of the form. This could avoid having to ask the user too many questions, as you could design the form to exit early if the user isn't eligible.

I made it particularly for the Canadian project, where they wanted to get a list of input variables, and sort them based on use. You could do it in the front-end, but you'd have to parse python to do so. It makes more sense in the backend. It would have also been useful for NSW Community Gaming project, where we had to do this by hand to make the form.
### New features

    New dependencies api end point that finds the dependent input variables of a variable.
    New property in variables.py to enable this.

### Technical changes

    Made the API documentation for the trace endpoint a little clearer.
