### PR TITLE
Fix web api test on /parameter endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### [#974](https://github.com/openfisca/openfisca-core/pull/974)
+### 35.0.5 [#974](https://github.com/openfisca/openfisca-core/pull/974)
 
 #### Technical changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### [#974](https://github.com/openfisca/openfisca-core/pull/974)
+
+#### Technical changes
+
+- Fix web api test for a parameter node request with `/parameter` endpoint.
+- Details:
+  - Untie the test from `OpenFisca-Country-Template` parameters list.
+
 ### 35.0.4 [#965](https://github.com/openfisca/openfisca-core/pull/965)
 
 #### Technical changes

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '35.0.4',
+    version = '35.0.5',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/web_api/test_parameters.py
+++ b/tests/web_api/test_parameters.py
@@ -77,15 +77,13 @@ def test_parameter_node():
         "\nsuch as food and shelter.\n(See https://en.wikipedia.org/wiki/Welfare)"
         )
 
-    tbs_benefits = tax_benefit_system.parameters.benefits
-    benefits_names = tbs_benefits.children.keys()
-    assert parameter['subparams'].keys() == benefits_names, parameter['subparams'].keys()
+    model_benefits = tax_benefit_system.parameters.benefits
+    assert parameter['subparams'].keys() == model_benefits.children.keys(), parameter['subparams'].keys()
 
-    benefit_example = next(iter(benefits_names))
-    model_benefit_example = tbs_benefits.children[benefit_example]
-    api_benefit_example = parameter['subparams'][benefit_example]
-    assert 'description' in api_benefit_example
-    assert api_benefit_example['description'] == getattr(model_benefit_example, "description", None)
+    assert 'description' in parameter['subparams']['basic_income']
+    assert parameter['subparams']['basic_income']['description'] == getattr(
+        model_benefits.basic_income, "description", None
+        ), parameter['subparams']['basic_income']['description']
 
 
 def test_stopped_parameter_values():

--- a/tests/web_api/test_parameters.py
+++ b/tests/web_api/test_parameters.py
@@ -5,7 +5,7 @@ import json
 import re
 
 import pytest
-from . import subject
+from . import tax_benefit_system, subject
 
 # /parameters
 
@@ -76,10 +76,16 @@ def test_parameter_node():
         "\nbut usually it is intended to ensure that everyone can meet their basic human needs "
         "\nsuch as food and shelter.\n(See https://en.wikipedia.org/wiki/Welfare)"
         )
-    assert parameter['subparams'] == {
-        'housing_allowance': {'description': 'Housing allowance amount (as a fraction of the rent)'},
-        'basic_income': {'description': 'Amount of the basic income'}
-        }, parameter['subparams']
+
+    tbs_benefits = tax_benefit_system.parameters.benefits
+    benefits_names = tbs_benefits.children.keys()
+    assert parameter['subparams'].keys() == benefits_names, parameter['subparams'].keys()
+
+    benefit_example = next(iter(benefits_names))
+    model_benefit_example = tbs_benefits.children[benefit_example]
+    api_benefit_example = parameter['subparams'][benefit_example]
+    assert 'description' in api_benefit_example
+    assert api_benefit_example['description'] == getattr(model_benefit_example, "description", None)
 
 
 def test_stopped_parameter_values():


### PR DESCRIPTION
#### Technical changes

- Fix web api test for a parameter node request with `/parameter` endpoint.
- Details:
   - Untie the test from `OpenFisca-Country-Template` parameters list.

---

Dear reviewers, you will find a first commit that fixed the test without naming any specific `country-template` parameter. In the last changes, you will find the same checks with `basic_income` parameter and, even if it ties a bit the test to the `country-template` model, it seemed better (similar to other tests, easier to read). But we can rollback if you prefer.

Besides, as this PR doesn't affect functional changes, we shouldn't need to bump the package revision but it seemed better to name the version that fixes the tests.