### PR TITLE
Allow array parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 35.2.0 [#982](https://github.com/openfisca/openfisca-core/pull/982)
+## 35.2.0 [#982](https://github.com/openfisca/openfisca-core/pull/982)
 
 #### Technical changes
 
@@ -12,7 +12,7 @@
 
 - Fix false negative web API test following an update in the country template used for testing.
 
-### 35.1.0 [#973](https://github.com/openfisca/openfisca-core/pull/973)
+## 35.1.0 [#973](https://github.com/openfisca/openfisca-core/pull/973)
 
 #### Technical changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 35.2.0 [#982](https://github.com/openfisca/openfisca-core/pull/982)
+
+#### Technical changes
+
+- Allow parameters to be arrays.
+
 ### 35.1.1 [#981](https://github.com/openfisca/openfisca-core/pull/981)
 
 #### Technical changes

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -10,7 +10,6 @@ import logging
 import os
 import sys
 import traceback
-import typing
 
 import yaml
 import numpy as np
@@ -37,7 +36,7 @@ FILE_EXTENSIONS = {'.yaml', '.yml'}
 # 'unit' and 'reference' are only listed here for backward compatibility.
 #  It is now recommended to include them in metadata, until a common consensus emerges.
 COMMON_KEYS = {'description', 'metadata', 'unit', 'reference', 'documentation'}
-ALLOWED_PARAM_TYPES = (float, int, bool, type(None), typing.List)
+ALLOWED_PARAM_TYPES = (float, int, bool, type(None), List)
 
 
 def date_constructor(loader, node):

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -10,6 +10,7 @@ import logging
 import os
 import sys
 import traceback
+import typing
 
 import yaml
 import numpy as np
@@ -36,7 +37,7 @@ FILE_EXTENSIONS = {'.yaml', '.yml'}
 # 'unit' and 'reference' are only listed here for backward compatibility.
 #  It is now recommended to include them in metadata, until a common consensus emerges.
 COMMON_KEYS = {'description', 'metadata', 'unit', 'reference', 'documentation'}
-ALLOWED_PARAM_TYPES = (float, int, bool, type(None))
+ALLOWED_PARAM_TYPES = (float, int, bool, type(None), typing.List)
 
 
 def date_constructor(loader, node):

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -852,7 +852,7 @@ def load_parameter_file(file_path, name = ''):
     :returns: An instance of :any:`ParameterNode` or :any:`Scale` or :any:`Parameter`.
     """
     if not os.path.exists(file_path):
-        raise ValueError("{} doest not exist".format(file_path))
+        raise ValueError("{} does not exist".format(file_path))
     if os.path.isdir(file_path):
         return ParameterNode(name, directory_path = file_path)
     data = _load_yaml_file(file_path)

--- a/openfisca_core/parameters.py
+++ b/openfisca_core/parameters.py
@@ -319,7 +319,7 @@ class ParameterAtInstant(object):
                 )
         if not isinstance(value, ALLOWED_PARAM_TYPES):
             raise ParameterParsingError(
-                "Invalid value in {} : {}".format(self.name, value),
+                "Value in {} has type {}, which is not one of the allowed types ({}): {}".format(self.name, type(value), ALLOWED_PARAM_TYPES, value),
                 self.file_path
                 )
 

--- a/openfisca_web_api/openAPI.yml
+++ b/openfisca_web_api/openAPI.yml
@@ -303,10 +303,11 @@ definitions:
       format: "float"
 
   Values:
+    description: All keys are ISO dates. Values can be numbers, booleans, or arrays of a single type (number, boolean or string).
     type: "object"
-    additionalProperties:
-      type: "number"
-      format: "float"
+    additionalProperties: true
+#    propertyNames:  # this keyword is part of JSON Schema but is not supported in OpenAPI Specification at the time of writing, see https://swagger.io/docs/specification/data-models/keywords/#unsupported
+#      pattern: "^[12][0-9]{3}-[01][0-9]-[0-3][0-9]$"  # all keys are ISO dates
 
   Entities:
     type: "object"

--- a/openfisca_web_api/openAPI.yml
+++ b/openfisca_web_api/openAPI.yml
@@ -34,12 +34,12 @@ paths:
     post:
       summary: "Run a simulation"
       tags:
-        - Calculations
+      - Calculations
       operationId: "calculate"
       consumes:
-        - "application/json"
+      - "application/json"
       produces:
-        - "application/json"
+      - "application/json"
       parameters:
       - in: "body"
         name: "Situation"
@@ -65,11 +65,11 @@ paths:
   /parameters:
     get:
       tags:
-        - "Parameters"
+      - "Parameters"
       summary: "List all available parameters"
       operationId: "getParameters"
       produces:
-        - "application/json"
+      - "application/json"
       responses:
         200:
           description: "The list of parameters is sent back in the response body"
@@ -161,12 +161,12 @@ paths:
     post:
       summary: "Explore a simulation's steps in details."
       tags:
-        - Calculations
+      - Calculations
       operationId: "trace"
       consumes:
-        - "application/json"
+      - "application/json"
       produces:
-        - "application/json"
+      - "application/json"
       parameters:
       - in: "body"
         name: "Situation"
@@ -193,10 +193,10 @@ paths:
     get:
       summary: Provide the API documentation in an OpenAPI format
       tags:
-        - Documentation
+      - Documentation
       operationId: spec
       produces:
-        - application/json
+      - application/json
       responses:
         200:
           description: The API documentation is sent back in the response body

--- a/openfisca_web_api/openAPI.yml
+++ b/openfisca_web_api/openAPI.yml
@@ -43,25 +43,25 @@ paths:
       parameters:
       - in: "body"
         name: "Situation"
-        description: 'Describe the situation (persons and entities). Add the variable you wish to calculate in the proper entity, with null as the value. Learn more in our official documentation: https://openfisca.org/doc/openfisca-web-api/input-output-data.html'
+        description: "Describe the situation (persons and entities). Add the variable you wish to calculate in the proper entity, with null as the value. Learn more in our official documentation: https://openfisca.org/doc/openfisca-web-api/input-output-data.html"
         required: true
         schema:
-          $ref: '#/definitions/SituationInput'
+          $ref: "#/definitions/SituationInput"
       responses:
         200:
           description: "The calculation result is sent back in the response body"
           headers:
-            $ref: '#/commons/Headers'
+            $ref: "#/commons/Headers"
           schema:
-            $ref: '#/definitions/SituationOutput'
+            $ref: "#/definitions/SituationOutput"
         404:
           description: "A variable mentioned in the input situation does not exist in the loaded tax and benefit system. Details are sent back in the response body"
           headers:
-            $ref: '#/commons/Headers'
+            $ref: "#/commons/Headers"
         400:
           description: "The request is invalid. Details about the error are sent back in the response body"
           headers:
-            $ref: '#/commons/Headers'
+            $ref: "#/commons/Headers"
   /parameters:
     get:
       tags:
@@ -74,9 +74,9 @@ paths:
         200:
           description: "The list of parameters is sent back in the response body"
           headers:
-            $ref: '#/commons/Headers'
+            $ref: "#/commons/Headers"
           schema:
-            $ref: '#/definitions/Parameters'
+            $ref: "#/definitions/Parameters"
   /parameter/{parameterID}:
     get:
       tags:
@@ -95,13 +95,13 @@ paths:
         200:
           description: "The requested parameter's information is sent back in the response body"
           headers:
-            $ref: '#/commons/Headers'
+            $ref: "#/commons/Headers"
           schema:
             $ref: "#/definitions/Parameter"
         404:
           description: "The requested parameter does not exist"
           headers:
-            $ref: '#/commons/Headers'
+            $ref: "#/commons/Headers"
   /variables:
     get:
       tags:
@@ -114,7 +114,7 @@ paths:
         200:
           description: "The list of variables is sent back in the response body"
           headers:
-            $ref: '#/commons/Headers'
+            $ref: "#/commons/Headers"
           schema:
             $ref: "#/definitions/Variables"
   /variable/{variableID}:
@@ -135,13 +135,13 @@ paths:
         200:
           description: "The requested variable's information is sent back in the response body"
           headers:
-            $ref: '#/commons/Headers'
+            $ref: "#/commons/Headers"
           schema:
             $ref: "#/definitions/Variable"
         404:
           description: "The requested variable does not exist"
           headers:
-            $ref: '#/commons/Headers'
+            $ref: "#/commons/Headers"
   /entities:
     get:
       tags:
@@ -154,7 +154,7 @@ paths:
         200:
           description: "The list of the entities as well as their information is sent back in the response body"
           headers:
-            $ref: '#/commons/Headers'
+            $ref: "#/commons/Headers"
           schema:
             $ref: "#/definitions/Entities"
   /trace:
@@ -170,25 +170,25 @@ paths:
       parameters:
       - in: "body"
         name: "Situation"
-        description: 'Describe the situation (persons and entities). Add the variable you wish to calculate in the proper entity, with null as the value.'
+        description: "Describe the situation (persons and entities). Add the variable you wish to calculate in the proper entity, with null as the value."
         required: true
         schema:
-          $ref: '#/definitions/SituationInput'
+          $ref: "#/definitions/SituationInput"
       responses:
         200:
           description: "The calculation details are sent back in the response body"
           headers:
-            $ref: '#/commons/Headers'
+            $ref: "#/commons/Headers"
           schema:
-            $ref: '#/definitions/Trace'
+            $ref: "#/definitions/Trace"
         404:
           description: "A variable mentioned in the input situation does not exist in the loaded tax and benefit system. Details are sent back in the response body"
           headers:
-            $ref: '#/commons/Headers'
+            $ref: "#/commons/Headers"
         400:
           description: "The request is invalid. Details about the error are sent back in the response body"
           headers:
-            $ref: '#/commons/Headers'
+            $ref: "#/commons/Headers"
   /spec:
     get:
       summary: Provide the API documentation in an OpenAPI format
@@ -201,14 +201,14 @@ paths:
         200:
           description: The API documentation is sent back in the response body
           headers:
-            $ref: '#/commons/Headers'
+            $ref: "#/commons/Headers"
 
 definitions:
   Parameter:
     type: "object"
     properties:
       values:
-        $ref: '#/definitions/Values'
+        $ref: "#/definitions/Values"
       brackets:
         type: "object"
         additionalProperties:
@@ -219,7 +219,7 @@ definitions:
           type: "object"
           properties:
             definition:
-              type: 'string'
+              type: "string"
       metadata:
         type: "object"
       description:
@@ -237,9 +237,9 @@ definitions:
       type: "object"
       properties:
         description:
-          type: 'string'
+          type: "string"
         href:
-          type: 'string'
+          type: "string"
 
   Variable:
     type: "object"
@@ -284,9 +284,9 @@ definitions:
       type: "object"
       properties:
         description:
-          type: 'string'
+          type: "string"
         href:
-          type: 'string'
+          type: "string"
 
   Formula:
     type: "object"

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '35.1.1',
+    version = '35.2.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/parameter_validation/array_type.yaml
+++ b/tests/core/parameter_validation/array_type.yaml
@@ -1,0 +1,6 @@
+description: Array types should be allowed.
+values:
+  2013-01-01:
+    value: [ FR ]
+  2018-06-01:
+    value: [ ES, FR, IT, NZ ]

--- a/tests/core/parameter_validation/test_parameter_validation.py
+++ b/tests/core/parameter_validation/test_parameter_validation.py
@@ -8,7 +8,7 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 year = 2016
 
 
-def check(file_name, keywords):
+def check_fails_with_message(file_name, keywords):
     path = os.path.join(BASE_DIR, file_name) + '.yaml'
     try:
         load_parameter_file(path, file_name)
@@ -37,7 +37,12 @@ def check(file_name, keywords):
     ])
 def test_parsing_errors(test):
     with pytest.raises(ParameterParsingError):
-        check(*test)
+        check_fails_with_message(*test)
+
+
+def test_array_type():
+    path = os.path.join(BASE_DIR, 'array_type.yaml')
+    load_parameter_file(path, 'array_type')
 
 
 def test_filesystem_hierarchy():

--- a/tests/core/parameter_validation/test_parameter_validation.py
+++ b/tests/core/parameter_validation/test_parameter_validation.py
@@ -22,7 +22,7 @@ def check(file_name, keywords):
 @pytest.mark.parametrize("test", [
     ('indentation', {'Invalid YAML', 'indentation.yaml', 'line 2', 'mapping values are not allowed'}),
     ('wrong_scale', {'Unexpected property', 'scale[1]', 'treshold'}),
-    ('wrong_value', {'Invalid value', 'wrong_value[2015-12-01]', '1A'}),
+    ('wrong_value', {'not one of the allowed types', 'wrong_value[2015-12-01]', '1A'}),
     ('unexpected_key_in_parameter', {'Unexpected property', 'unexpected_key'}),
     ('wrong_type_in_parameter', {'must be of type object'}),
     ('wrong_type_in_value_history', {'must be of type object'}),


### PR DESCRIPTION
#### Technical changes

- Support arrays as parameters.
- Improves wrong parameter types error message.

- - -

This was added to move more constants into parameters. For example, in OpenFisca-France: https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py#L3-L35

- - -

TODO :

- [x] Add Web API tests.
- [x] Update [documentation](https://openfisca.org/doc/key-concepts/parameters.html) which currently states that parameters are “numeric parameters”.