### PR TITLE
In SimulationBuilder, repair expansion of axes on a variable given as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 35.3.3 [#994](https://github.com/openfisca/openfisca-core/pull/994)
+
+#### Bug fix
+
+- Repair expansion of axes on a variable given as input
+  - When expanding axes, the expected behavour is to override any input value for the requested variable and period
+  - As longs as we passed some input for a variable on a period, it was not being overrode, creating a NumPy's error (boradcasting)
+  - By additionally checking that an input was given, now we make that the array has the correct shape by constructing it with NumPy's tile with a shape equal to the number of the axis expansion count requested.
+
 ### 35.3.2 [#992](https://github.com/openfisca/openfisca-core/pull/992)
 
 #### Technical improvements
@@ -24,7 +33,7 @@
 
 #### Bug fix
 
-- [Web API] Gracefully handle unexpected errors 
+- [Web API] Gracefully handle unexpected errors
   - The exception signature expected by the internal server error handler was not the good one
   - Henceforth no response was being given to the user, when a 500 with an explanation was expected
 

--- a/openfisca_core/simulations/simulation_builder.py
+++ b/openfisca_core/simulations/simulation_builder.py
@@ -513,6 +513,8 @@ class SimulationBuilder:
                 array = self.get_input(axis_name, str(axis_period))
                 if array is None:
                     array = variable.default_array(axis_count * axis_entity_step_size)
+                elif array.size == axis_entity_step_size:
+                    array = numpy.tile(array, axis_count)
                 array[axis_index:: axis_entity_step_size] = numpy.linspace(
                     axis['min'],
                     axis['max'],
@@ -546,6 +548,8 @@ class SimulationBuilder:
                     array = self.get_input(axis_name, str(axis_period))
                     if array is None:
                         array = variable.default_array(cell_count * axis_entity_step_size)
+                    elif array.size == axis_entity_step_size:
+                        array = numpy.tile(array, cell_count)
                     array[axis_index:: axis_entity_step_size] = axis['min'] \
                         + mesh.reshape(cell_count) * (axis['max'] - axis['min']) / (axis_count - 1)
                     self.input_buffer[axis_name][str(axis_period)] = array

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '35.3.2',
+    version = '35.3.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_axes.py
+++ b/tests/core/test_axes.py
@@ -159,6 +159,21 @@ def test_add_perpendicular_axes(simulation_builder, persons):
     assert simulation_builder.get_input('pension', '2018-11') == approx([0, 0, 0, 2000, 2000, 2000])
 
 
+def test_add_perpendicular_axis_on_an_existing_variable_with_input(simulation_builder, persons):
+    simulation_builder.add_person_entity(persons, {
+        'Alicia': {
+            'salary': {'2018-11': 1000},
+            'pension': {'2018-11': 1000},
+            },
+        },)
+    simulation_builder.register_variable('salary', persons)
+    simulation_builder.register_variable('pension', persons)
+    simulation_builder.add_parallel_axis({'count': 3, 'name': 'salary', 'min': 0, 'max': 3000, 'period': '2018-11'})
+    simulation_builder.add_perpendicular_axis({'count': 2, 'name': 'pension', 'min': 0, 'max': 2000, 'period': '2018-11'})
+    simulation_builder.expand_axes()
+    assert simulation_builder.get_input('salary', '2018-11') == approx([0, 1500, 3000, 0, 1500, 3000])
+    assert simulation_builder.get_input('pension', '2018-11') == approx([0, 0, 0, 2000, 2000, 2000])
+
 # Integration test
 
 

--- a/tests/core/test_axes.py
+++ b/tests/core/test_axes.py
@@ -131,6 +131,17 @@ def test_add_perpendicular_axes(simulation_builder, persons):
     assert simulation_builder.get_input('salary', '2018-11') == approx([0, 1500, 3000, 0, 1500, 3000])
     assert simulation_builder.get_input('pension', '2018-11') == approx([0, 0, 0, 2000, 2000, 2000])
 
+
+def test_axis_on_existing_variable(simulation_builder, persons):
+    simulation_builder.register_variable('salary', persons)
+    simulation_builder.add_person_entity(persons, {
+        'Alicia': {},
+        'Javier': {'salary': {'2018-11': 1000}},
+        })
+    simulation_builder.add_parallel_axis({'count': 10, 'name': 'salary', 'index': 0, 'min': 0, 'max': 3000, 'period': '2018-11'})
+    simulation_builder.expand_axes()
+
+
 # Integration test
 
 


### PR DESCRIPTION
#### Bug fix

- Repair expansion of axes on a variable given as input
  - When expanding axes, the expected behavour is to override any input value for the requested variable and period
  - As longs as we passed some input for a variable on a period, it was not being overrode, creating a NumPy's error (boradcasting)
  - By additionally checking that an input was given, now we make that the array has the correct shape by constructing it with NumPy's tile with a shape equal to the number of the axis expansion count requested.

---

Updated by @maukoquiroga the 10/04/2021.