### PR TITLE
Extract axes from SimulationBuilder

### DIFF
--- a/openfisca_core/simulations/__init__.py
+++ b/openfisca_core/simulations/__init__.py
@@ -24,5 +24,6 @@
 from openfisca_core.errors import CycleError, NaNCreationError, SpiralError  # noqa: F401
 
 from .helpers import calculate_output_add, calculate_output_divide, check_type, transform_to_strict_syntax  # noqa: F401
+from .axis import Axis  # noqa: F401
 from .simulation import Simulation  # noqa: F401
 from .simulation_builder import SimulationBuilder  # noqa: F401

--- a/openfisca_core/simulations/__init__.py
+++ b/openfisca_core/simulations/__init__.py
@@ -26,5 +26,6 @@ from openfisca_core.errors import CycleError, NaNCreationError, SpiralError  # n
 from .helpers import calculate_output_add, calculate_output_divide, check_type, transform_to_strict_syntax  # noqa: F401
 from .axis import Axis  # noqa: F401
 from .axis_array import AxisArray  # noqa: F401
+from .axis_expander import AxisExpander  # noqa: F401
 from .simulation import Simulation  # noqa: F401
 from .simulation_builder import SimulationBuilder  # noqa: F401

--- a/openfisca_core/simulations/__init__.py
+++ b/openfisca_core/simulations/__init__.py
@@ -25,5 +25,6 @@ from openfisca_core.errors import CycleError, NaNCreationError, SpiralError  # n
 
 from .helpers import calculate_output_add, calculate_output_divide, check_type, transform_to_strict_syntax  # noqa: F401
 from .axis import Axis  # noqa: F401
+from .axis_array import AxisArray  # noqa: F401
 from .simulation import Simulation  # noqa: F401
 from .simulation_builder import SimulationBuilder  # noqa: F401

--- a/openfisca_core/simulations/axis.py
+++ b/openfisca_core/simulations/axis.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import typing
+import dataclasses
+
+
+@dataclasses.dataclass(frozen = True)
+class Axis:
+    """
+    Base data class for axes (no business logic).
+
+    Axis expansion is a feature in :module:`openfisca_core` that allows us to
+    parametrise some dimensions in order to create and to evaluate a range of
+    values for others.
+
+    The most typical use of axis expansion is evaluate different numerical
+    values, starting from a :attr:`min_` and up to a :attr:`max_`, that could
+    take any given :class:`openfisca_core.variables.Variable` for any given
+    :class:`openfisca_core.periods.Period` for any given population (or a
+    collection of :module:`openfisca_core.entities`).
+
+    Attributes:
+
+        name:   The name of the :class:`openfisca_core.variables.Variable`
+                whose values are to be expanded.
+        count:  The Number of "steps" to take when expanding a
+                :class:`openfisca_core.variables.Variable` (between
+                :attr:`min_` and :attr:`max_`, we create a line and split it in
+                :attr:`count` number of parts).
+        min:    The starting numerical value for the :class:`Axis` expansion.
+        max:    The up-to numerical value for the :class:`Axis` expansion.
+        period: The period at which the expansion will take place over.
+        index:  The :class:`Axis` position relative to other equidistant axes.
+
+    .. versionadded:: 3.4.0
+    """
+
+    name: str
+    count: int
+    min: typing.Union[int, float]
+    max: typing.Union[int, float]
+    period: typing.Optional[typing.Union[int, str]] = None
+    index: typing.Optional[int] = None

--- a/openfisca_core/simulations/axis.py
+++ b/openfisca_core/simulations/axis.py
@@ -7,17 +7,7 @@ from typing import Optional, Union
 @dataclasses.dataclass(frozen = True)
 class Axis:
     """
-    Base data class for axes (no business logic).
-
-    Axis expansion is a feature in :module:`openfisca_core` that allows us to
-    parametrise some dimensions in order to create and to evaluate a range of
-    values for others.
-
-    The most typical use of axis expansion is evaluate different numerical
-    values, starting from a :attr:`min_` and up to a :attr:`max_`, that could
-    take any given :class:`openfisca_core.variables.Variable` for any given
-    :class:`openfisca_core.periods.Period` for any given population (or a
-    collection of :module:`openfisca_core.entities`).
+    Base data class for axes (no domain logic).
 
     Attributes:
 

--- a/openfisca_core/simulations/axis.py
+++ b/openfisca_core/simulations/axis.py
@@ -32,6 +32,19 @@ class Axis:
         period: The period at which the expansion will take place over.
         index:  The :class:`Axis` position relative to other equidistant axes.
 
+    Usage:
+
+       >>> axis = Axis(name = "salary", count = 3, min = 0, max = 3000)
+       >>> axis
+       Axis(name='salary', count=3, min=0, max=3000, period=None, index=None)
+
+       >>> axis.name
+       'salary'
+
+    Testing:
+
+        pytest tests/core/test_axes.py openfisca_core/simulations/axis.py
+
     .. versionadded:: 3.4.0
     """
 

--- a/openfisca_core/simulations/axis.py
+++ b/openfisca_core/simulations/axis.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import typing
 import dataclasses
+from typing import Optional, Union
 
 
 @dataclasses.dataclass(frozen = True)
@@ -36,7 +36,7 @@ class Axis:
 
        >>> axis = Axis(name = "salary", count = 3, min = 0, max = 3000)
        >>> axis
-       Axis(name='salary', count=3, min=0, max=3000, period=None, index=None)
+       Axis(name='salary', count=3, min=0, max=3000, period=None, index=0)
 
        >>> axis.name
        'salary'
@@ -45,12 +45,12 @@ class Axis:
 
         pytest tests/core/test_axes.py openfisca_core/simulations/axis.py
 
-    .. versionadded:: 3.4.0
+    .. versionadded:: 35.4.0
     """
 
     name: str
     count: int
-    min: typing.Union[int, float]
-    max: typing.Union[int, float]
-    period: typing.Optional[typing.Union[int, str]] = None
-    index: typing.Optional[int] = None
+    min: Union[int, float]
+    max: Union[int, float]
+    period: Optional[Union[int, str]] = dataclasses.field(default = None)
+    index: int = dataclasses.field(default = 0)

--- a/openfisca_core/simulations/axis_array.py
+++ b/openfisca_core/simulations/axis_array.py
@@ -1,9 +1,13 @@
-import collections.abc
+from __future__ import annotations
+
+import dataclasses
+import typing
 
 from .axis import Axis
 
 
-class AxisArray(collections.abc.Container):
+@dataclasses.dataclass(frozen = True)
+class AxisArray:
     """
     Simply a collection of :class:`Axis`.
 
@@ -17,8 +21,40 @@ class AxisArray(collections.abc.Container):
     :class:`openfisca_core.periods.Period` for any given population (or a
     collection of :module:`openfisca_core.entities`).
 
+    Attributes:
+
+        axes:   A :type:`tuple` containing our collection of :class:`Axis`.
+
+    Usage:
+
+        >>> axis_array = AxisArray()
+        >>> axis_array
+        AxisArray()
+
+    Testing:
+
+        pytest tests/core/test_axes.py openfisca_core/simulations/axis_array.py
+
     .. versionadded:: 3.4.0
     """
 
-    def __contains__(self, axis: Axis) -> bool:
-        pass
+    axes: typing.Tuple[Axis, ...] = ()
+
+    def append(self, tail: Axis) -> AxisArray:
+        """
+        Append an :class:`Axis` to our axes collection.
+
+        Usage:
+
+        >>> axis_array = AxisArray()
+        >>> axis = Axis(name = "salary", count = 3, min = 0, max = 3000)
+        >>> axis_array.append(axis)  # doctest: +ELLIPSIS
+        AxisArray(Axis(name='salary', ...),)
+        """
+        return self.__class__(axes = (*self.axes, tail))
+
+    def __contains__(self, item: Axis) -> bool:
+        return item in self.axes
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__qualname__}{repr(self.axes)}"

--- a/openfisca_core/simulations/axis_array.py
+++ b/openfisca_core/simulations/axis_array.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections.abc
 import dataclasses
 import typing
 
@@ -9,7 +10,7 @@ from .axis import Axis
 @dataclasses.dataclass(frozen = True)
 class AxisArray:
     """
-    Simply a collection of :class:`Axis`.
+    A collection of :obj:`Axis` and a bunch of business logic.
 
     Axis expansion is a feature in :module:`openfisca_core` that allows us to
     parametrise some dimensions in order to create and to evaluate a range of
@@ -23,7 +24,7 @@ class AxisArray:
 
     Attributes:
 
-        axes:   A :type:`tuple` containing our collection of :class:`Axis`.
+        axes:   A :type:`tuple` containing our collection of :obj:`Axis`.
 
     Usage:
 
@@ -40,18 +41,58 @@ class AxisArray:
 
     axes: typing.Tuple[Axis, ...] = ()
 
-    def append(self, tail: Axis) -> AxisArray:
+    def first(self) -> typing.Optional[Axis]:
         """
-        Append an :class:`Axis` to our axes collection.
+        Retrieves the first :obj:`Axis` in our axes collection.
 
         Usage:
 
-        >>> axis_array = AxisArray()
-        >>> axis = Axis(name = "salary", count = 3, min = 0, max = 3000)
-        >>> axis_array.append(axis)  # doctest: +ELLIPSIS
-        AxisArray(Axis(name='salary', ...),)
+            >>> axis_array = AxisArray()
+            >>> not axis_array.first()
+            True
+
+            >>> axis = Axis(name = "salary", count = 3, min = 0, max = 3000)
+            >>> axis_array = axis_array.append(axis)
+            >>> axis_array.first()
+            Axis(name='salary', ..., index=None)
         """
+        if len(self.axes) == 0:
+            return None
+
+        return self.axes[0]
+
+    def append(self, tail: Axis) -> AxisArray:
+        """
+        Append an :obj:`Axis` to our axes collection.
+
+        Args:
+
+            axis:   An :obj:`Axis` to append to our collection.
+
+        Usage:
+
+            >>> axis_array = AxisArray()
+            >>> axis = Axis(name = "salary", count = 3, min = 0, max = 3000)
+            >>> axis_array.append(axis)
+            AxisArray(Axis(name='salary', ...),)
+        """
+        if not isinstance(self.axes, collections.abc.Iterable):
+            raise TypeError("Not an Iterable, but improve this message stub!")
+
+        for axis in self.axes:
+            if not isinstance(axis, Axis):
+                raise TypeError("Not an Axis, but improve this message stub!")
+
         return self.__class__(axes = (*self.axes, tail))
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.axes, collections.abc.Iterable):
+            raise TypeError("Not an Iterable, but improve this message stub!")
+
+        for axis in self.axes:
+            if not isinstance(axis, Axis):
+                raise TypeError("Not an Axis, but improve this message stub!")
+
 
     def __contains__(self, item: Axis) -> bool:
         return item in self.axes

--- a/openfisca_core/simulations/axis_array.py
+++ b/openfisca_core/simulations/axis_array.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, Callable, List, NoReturn, Optional, Type, Union
+from typing import Any, Callable, List, NoReturn, Optional, Union
 
 from .axis import Axis
 
@@ -98,7 +98,7 @@ class AxisArray:
 
         Args:
 
-            axis:   An :obj:`Axis` to append to our collection.
+            tail:   An :obj:`Axis` to append to our collection.
 
         Usage:
 

--- a/openfisca_core/simulations/axis_array.py
+++ b/openfisca_core/simulations/axis_array.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-import typing
+from typing import Any, Callable, List, NoReturn, Optional, Type, Union
 
 from .axis import Axis
 
@@ -9,7 +9,7 @@ from .axis import Axis
 @dataclasses.dataclass(frozen = True)
 class AxisArray:
     """
-    A collection of :obj:`Axis` and a bunch of business logic.
+    A collection of :obj:`Axis` (some business logic).
 
     Axis expansion is a feature in :module:`openfisca_core` that allows us to
     parametrise some dimensions in order to create and to evaluate a range of
@@ -20,6 +20,27 @@ class AxisArray:
     take any given :class:`openfisca_core.variables.Variable` for any given
     :class:`openfisca_core.periods.Period` for any given population (or a
     collection of :module:`openfisca_core.entities`).
+
+    As axes have a relative position relative to each other, they can be either
+    equidistant, that is parallel, or perpendicular. We assume the first
+    dimension to be a collection of parallel axes relative to themselves.
+
+    Henceforward, we will consider each parallel axis as belonging to this
+    first dimension, and each perpendicular axis as belonging to a new
+    dimension, perpendicular to the previous one: that is, we won't be adding
+    more than one axis for each perpendicular dimension beyond the first one.
+
+    As you might've already guess, it is not possible to add any parallel or
+    perpendicular axis relative to anything, so we assume the following when
+    our collection is yet empty: whenever you add a parallel axis it will by
+    default be added to the first dimension, and whenever you add a
+    perpendicular axis it will be added in isolation to second dimension and
+    beyond.
+
+    Adding a perpendicular axis to an empty collection is a conceptual error
+    so instead of trying to mitigate this, we will rather error out and let
+    the user know why she can't do that and how she can correct they way she's
+    building her collection of axes (simply put to add first a parallel axis).
 
     Attributes:
 
@@ -35,14 +56,16 @@ class AxisArray:
 
         pytest tests/core/test_axes.py openfisca_core/simulations/axis_array.py
 
-    .. versionadded:: 3.4.0
+    .. versionadded:: 35.4.0
     """
 
-    axes: typing.List[Axis] = dataclasses.field(default_factory = list)
+    axes: List[Axis] = dataclasses.field(default_factory = list)
 
     def __post_init__(self) -> None:
-        self.__is_list(self.axes)
-        list(map(self.__is_axis, self.axes))
+        self.validate(isinstance, self.axes, list)
+
+        for axis in self.axes:
+            self.validate(isinstance, axis, Axis)
 
     def __contains__(self, item: Axis) -> bool:
         return item in self.axes
@@ -50,27 +73,26 @@ class AxisArray:
     def __repr__(self) -> str:
         return f"{self.__class__.__qualname__}{repr(self.axes)}"
 
-    def first(self) -> typing.Optional[Axis]:
+    def first(self) -> Optional[Axis]:
         """
         Retrieves the first :obj:`Axis` from our axes collection.
 
         Usage:
 
             >>> axis_array = AxisArray()
-            >>> not axis_array.first()
-            True
+            >>> axis_array.first()
+            Traceback (most recent call last):
+            TypeError: Expecting a non empty list, but [] given
 
             >>> axis = Axis(name = "salary", count = 3, min = 0, max = 3000)
             >>> axis_array = axis_array.append(axis)
             >>> axis_array.first()
-            Axis(name='salary', ..., index=None)
+            Axis(name='salary', ..., index=0)
         """
-        if len(self.axes) == 0:
-            return None
-
+        self.validate(lambda axes, _: axes, self.axes, "a non empty list")
         return self.axes[0]
 
-    def append(self, tail: Axis) -> typing.Union[AxisArray, typing.NoReturn]:
+    def append(self, tail: Axis) -> Union[AxisArray, NoReturn]:
         """
         Append an :obj:`Axis` to our axes collection.
 
@@ -85,17 +107,35 @@ class AxisArray:
             >>> axis_array.append(axis)
             AxisArray[Axis(name='salary', ...)]
         """
-        self.__is_axis(tail)
+        self.validate(isinstance, tail, Axis)
         return self.__class__(axes = [*self.axes, tail])
 
-    def __is_list(self, axes: list) -> typing.Union[bool, typing.NoReturn]:
-        if isinstance(axes, list):
+    def validate(
+            self,
+            condition: Callable,
+            real: Any,
+            expected: Any,
+            ) -> Union[bool, NoReturn]:
+        """
+        Validate that a condition holds true.
+
+        Args:
+
+            condition:  A function reprensenting the condition to validate.
+            real:       The value given as input, passed to :args:`condition`.
+            expected:   The value we expect, passed to :args:`condition`.
+
+        Usage:
+
+            >>> axis_array = AxisArray()
+            >>> condition = isinstance
+            >>> real = tuple()
+            >>> expected = list
+            >>> axis_array.validate(condition, real, expected)
+            Traceback (most recent call last):
+            TypeError: Expecting <class 'list'>, but () given
+        """
+        if condition(real, expected):
             return True
 
-        raise TypeError(f"Expecting a list, but {type(self.axes)} given")
-
-    def __is_axis(self, item: Axis) -> typing.Union[bool, typing.NoReturn]:
-        if isinstance(item, Axis):
-            return True
-
-        raise TypeError(f"Expecting an {Axis}, but {type(item)} given")
+        raise TypeError(f"Expecting {expected}, but {real} given")

--- a/openfisca_core/simulations/axis_array.py
+++ b/openfisca_core/simulations/axis_array.py
@@ -1,0 +1,24 @@
+import collections.abc
+
+from .axis import Axis
+
+
+class AxisArray(collections.abc.Container):
+    """
+    Simply a collection of :class:`Axis`.
+
+    Axis expansion is a feature in :module:`openfisca_core` that allows us to
+    parametrise some dimensions in order to create and to evaluate a range of
+    values for others.
+
+    The most typical use of axis expansion is evaluate different numerical
+    values, starting from a :attr:`min_` and up to a :attr:`max_`, that could
+    take any given :class:`openfisca_core.variables.Variable` for any given
+    :class:`openfisca_core.periods.Period` for any given population (or a
+    collection of :module:`openfisca_core.entities`).
+
+    .. versionadded:: 3.4.0
+    """
+
+    def __contains__(self, axis: Axis) -> bool:
+        pass

--- a/openfisca_core/simulations/axis_array.py
+++ b/openfisca_core/simulations/axis_array.py
@@ -174,14 +174,21 @@ class AxisArray:
 
             >>> axis_array = AxisArray()
             >>> axis = Axis(name = "salary", count = 3, min = 0, max = 3000)
-            >>> axis_array.add_parallel(axis)
+            >>> axis_array = axis_array.add_parallel(axis)
+            >>> axis_array
             AxisArray[AxisArray[Axis(name='salary', ...)]]
+
+            >>> axis = Axis(name = "pension", count = 2, min = 0, max = 3000)
+            >>> axis_array.add_parallel(axis)
+            Traceback (most recent call last):
+            TypeError: Expecting counts to be equal...
 
         .. versionadded:: 35.4.0
         """
         node = self.validate(isinstance, self.first(), (AxisArray, list))
         tail = self.validate(isinstance, tail, Axis)
         parallel = self.__class__([*node, tail])
+        self.validate(self.__has_same_counts, parallel, "counts to be equal")
         return self.__class__([parallel, *self.axes[1:]])
 
     def add_perpendicular(self, tail: Axis) -> Union[AxisArray, NoReturn]:
@@ -243,6 +250,20 @@ class AxisArray:
             return real
 
         raise TypeError(f"Expecting {expected}, but {real} given.")
+
+    def __has_same_counts(self, axes: AxisArray, _) -> bool:
+        """
+        Validate all counts on a collection are the same.
+
+        They have to be the same for all parallel axes of a collection,
+        otherwise they become non expandable.
+        """
+        counts = list(map(lambda axis: axis.count, axes))
+
+        if counts.count(counts[0]) == len(counts):
+            return True
+
+        return False
 
     def __flatten(self, axes: list) -> List[Union[AxisArray, Axis]]:
         """

--- a/openfisca_core/simulations/axis_array.py
+++ b/openfisca_core/simulations/axis_array.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import collections.abc
 import dataclasses
 import typing
 
@@ -24,13 +23,13 @@ class AxisArray:
 
     Attributes:
 
-        axes:   A :type:`tuple` containing our collection of :obj:`Axis`.
+        axes:   A :type:`list` containing our collection of :obj:`Axis`.
 
     Usage:
 
         >>> axis_array = AxisArray()
         >>> axis_array
-        AxisArray()
+        AxisArray[]
 
     Testing:
 
@@ -39,11 +38,21 @@ class AxisArray:
     .. versionadded:: 3.4.0
     """
 
-    axes: typing.Tuple[Axis, ...] = ()
+    axes: typing.List[Axis] = dataclasses.field(default_factory = list)
+
+    def __post_init__(self) -> None:
+        self.__is_list(self.axes)
+        list(map(self.__is_axis, self.axes))
+
+    def __contains__(self, item: Axis) -> bool:
+        return item in self.axes
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__qualname__}{repr(self.axes)}"
 
     def first(self) -> typing.Optional[Axis]:
         """
-        Retrieves the first :obj:`Axis` in our axes collection.
+        Retrieves the first :obj:`Axis` from our axes collection.
 
         Usage:
 
@@ -61,7 +70,7 @@ class AxisArray:
 
         return self.axes[0]
 
-    def append(self, tail: Axis) -> AxisArray:
+    def append(self, tail: Axis) -> typing.Union[AxisArray, typing.NoReturn]:
         """
         Append an :obj:`Axis` to our axes collection.
 
@@ -74,28 +83,19 @@ class AxisArray:
             >>> axis_array = AxisArray()
             >>> axis = Axis(name = "salary", count = 3, min = 0, max = 3000)
             >>> axis_array.append(axis)
-            AxisArray(Axis(name='salary', ...),)
+            AxisArray[Axis(name='salary', ...)]
         """
-        if not isinstance(self.axes, collections.abc.Iterable):
-            raise TypeError("Not an Iterable, but improve this message stub!")
+        self.__is_axis(tail)
+        return self.__class__(axes = [*self.axes, tail])
 
-        for axis in self.axes:
-            if not isinstance(axis, Axis):
-                raise TypeError("Not an Axis, but improve this message stub!")
+    def __is_list(self, axes: list) -> typing.Union[bool, typing.NoReturn]:
+        if isinstance(axes, list):
+            return True
 
-        return self.__class__(axes = (*self.axes, tail))
+        raise TypeError(f"Expecting a list, but {type(self.axes)} given")
 
-    def __post_init__(self) -> None:
-        if not isinstance(self.axes, collections.abc.Iterable):
-            raise TypeError("Not an Iterable, but improve this message stub!")
+    def __is_axis(self, item: Axis) -> typing.Union[bool, typing.NoReturn]:
+        if isinstance(item, Axis):
+            return True
 
-        for axis in self.axes:
-            if not isinstance(axis, Axis):
-                raise TypeError("Not an Axis, but improve this message stub!")
-
-
-    def __contains__(self, item: Axis) -> bool:
-        return item in self.axes
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__qualname__}{repr(self.axes)}"
+        raise TypeError(f"Expecting an {Axis}, but {type(item)} given")

--- a/openfisca_core/simulations/axis_array.py
+++ b/openfisca_core/simulations/axis_array.py
@@ -9,17 +9,7 @@ from . import Axis
 @dataclasses.dataclass(frozen = True)
 class AxisArray:
     """
-    A collection of :obj:`Axis` (some business logic).
-
-    Axis expansion is a feature in :module:`openfisca_core` that allows us to
-    parametrise some dimensions in order to create and to evaluate a range of
-    values for others.
-
-    The most typical use of axis expansion is evaluate different numerical
-    values, starting from a :attr:`min_` and up to a :attr:`max_`, that could
-    take any given :class:`openfisca_core.variables.Variable` for any given
-    :class:`openfisca_core.periods.Period` for any given population (or a
-    collection of :module:`openfisca_core.entities`).
+    A collection of :obj:`Axis` (some domain logic related to data integrity).
 
     As axes have a relative position relative to each other, they can be either
     equidistant, that is parallel, or perpendicular. We assume the first

--- a/openfisca_core/simulations/axis_expander.py
+++ b/openfisca_core/simulations/axis_expander.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import functools
+import typing
+
+if typing.TYPE_CHECKING:
+    from . import AxisArray
+
+
+class AxisExpander:
+    """
+    Expander of all axes for a given axes collection (lots of domain logic).
+
+    Axis expansion is a feature in :module:`openfisca_core` that allows us to
+    parametrise some dimensions in order to create and to evaluate a range of
+    values for others.
+
+    The most typical use of axis expansion is evaluate different numerical
+    values, starting from a :attr:`min_` and up to a :attr:`max_`, that could
+    take any given :class:`openfisca_core.variables.Variable` for any given
+    :class:`openfisca_core.periods.Period` for any given population (or a
+    collection of :module:`openfisca_core.entities`).
+
+    Args:
+
+        axis_array: An array of axes to expand.
+
+    .. versionadded:: 35.4.0
+    """
+
+    def __init__(self, axis_array: AxisArray) -> None:
+        self.__axis_array = axis_array
+
+    @property
+    def axis_array(self) -> AxisArray:
+        """
+        An array of axes to expand.
+
+        .. versionadded:: 35.4.0
+        """
+        return self.__axis_array
+
+    def count_cells(self):
+        """
+        Count the total number of cells on an axes collection.
+
+        As a collection of axes is comprised of several perpendicular
+        collections of axes, relative to each other, we're going to consider
+        the total number of cells as being the multiplication of the value
+        :attr:`Axis.count` for the first axis of each dimension.
+
+        We assume however that all parallel axes should have the same count.
+        This method searches for a compatible axis (the first one). If none
+        exists, it should error out (we do not check here at it is the
+        responsability of :class:`AxisArray` to do so: data integrity is a
+        domain invariant related to the data model).
+
+        Usage:
+
+        >>> from . import Axis, AxisArray
+        >>> axis = Axis(name = "salary", count = 3, min = 0, max = 3000)
+        >>> axis_array = AxisArray()
+        >>> axis_array = axis_array.add_parallel(axis)
+        >>> axis_array = axis_array.add_perpendicular(axis)
+        >>> axis_expander = AxisExpander(axis_array)
+        >>> axis_expander.count_cells()
+        9
+
+        .. versionadded:: 35.4.0
+        """
+        axis_count = map(lambda dim: dim.first().count, self.axis_array)
+        return functools.reduce(lambda acc, count: acc * count, axis_count, 1)

--- a/openfisca_core/simulations/simulation_builder.py
+++ b/openfisca_core/simulations/simulation_builder.py
@@ -11,7 +11,7 @@ from openfisca_core.errors import PeriodMismatchError, SituationParsingError, Va
 from openfisca_core.populations import Population
 from openfisca_core.variables import Variable
 
-from . import helpers, Axis, AxisArray, Simulation
+from . import helpers, Axis, AxisArray, AxisExpander, Simulation
 
 
 class SimulationBuilder:
@@ -475,10 +475,9 @@ class SimulationBuilder:
         .. deprecated:: 35.4.0
 
             Use :meth:`AxisArray.add_parallel` instead.
-
         """
         message = [
-            "The 'add_parallel_axis' function has been deprecated since",
+            "The 'add_parallel_axis' method has been deprecated since",
             "version 35.4.0, and will be removed in the future. Please use",
             "'AxisArray.add_parallel' instead",
             ]
@@ -497,10 +496,9 @@ class SimulationBuilder:
         .. deprecated:: 35.4.0
 
             Use :meth:`AxisArray.add_parallel` instead.
-
         """
         message = [
-            "The 'add_perpendicular_axis' function has been deprecated since",
+            "The 'add_perpendicular_axis' method has been deprecated since",
             "version 35.4.0, and will be removed in the future. Please use",
             "'AxisArray.add_perpendicular' instead",
             ]
@@ -509,17 +507,23 @@ class SimulationBuilder:
         self.axes = self.axes.add_perpendicular(Axis(**axis))
 
     def expand_axes(self):
-        # This method should be idempotent & allow change in axes
-        perpendicular_dimensions = self.axes
+        """
+        Expand all axes for the current simulation.
 
-        cell_count = 1
+        .. deprecated:: 35.4.0
 
-        # All parallel axes have the same count and entity.
-        # Search for a compatible axis, if none exists, error out.
-        for parallel_axes in perpendicular_dimensions:
-            first_axis = parallel_axes.first()
-            axis_count = first_axis.count
-            cell_count *= axis_count
+            Use :class:`AxisExpander` instead.
+        """
+        message = [
+            "The 'expand_axes' method has been deprecated since",
+            "version 35.4.0, and will be removed in the future. Please use",
+            "'AxisExpander' instead",
+            ]
+
+        warnings.warn(" ".join(message), DeprecationWarning)
+
+        expander = AxisExpander(self.axes)
+        cell_count = expander.count_cells()
 
         # Scale the "prototype" situation, repeating it cell_count times
         for entity_name in self.entity_counts.keys():

--- a/openfisca_core/simulations/simulation_builder.py
+++ b/openfisca_core/simulations/simulation_builder.py
@@ -8,7 +8,7 @@ from openfisca_core import periods
 from openfisca_core.entities import Entity
 from openfisca_core.errors import PeriodMismatchError, SituationParsingError, VariableNotFoundError
 from openfisca_core.populations import Population
-from openfisca_core.simulations import helpers, Simulation
+from openfisca_core.simulations import helpers, Axis, Simulation
 from openfisca_core.variables import Variable
 
 

--- a/openfisca_core/simulations/simulation_builder.py
+++ b/openfisca_core/simulations/simulation_builder.py
@@ -474,17 +474,17 @@ class SimulationBuilder:
 
         .. deprecated:: 35.4.0
 
-            Use :meth:`AxisArray.append_parallel` instead.
+            Use :meth:`AxisArray.add_parallel` instead.
 
         """
         message = [
             "The 'add_parallel_axis' function has been deprecated since",
             "version 35.4.0, and will be removed in the future. Please use",
-            "'AxisArray.append_parallel' instead",
+            "'AxisArray.add_parallel' instead",
             ]
 
         warnings.warn(" ".join(message), DeprecationWarning)
-        self.axes = self.axes.append_parallel(Axis(**axis))
+        self.axes = self.axes.add_parallel(Axis(**axis))
 
     def add_perpendicular_axis(self, axis: dict) -> None:
         """
@@ -496,17 +496,17 @@ class SimulationBuilder:
 
         .. deprecated:: 35.4.0
 
-            Use :meth:`AxisArray.append_parallel` instead.
+            Use :meth:`AxisArray.add_parallel` instead.
 
         """
         message = [
             "The 'add_perpendicular_axis' function has been deprecated since",
             "version 35.4.0, and will be removed in the future. Please use",
-            "'AxisArray.append_perpendicular' instead",
+            "'AxisArray.add_perpendicular' instead",
             ]
 
         warnings.warn(" ".join(message), DeprecationWarning)
-        self.axes.append_perpendicular(Axis(**axis))
+        self.axes = self.axes.add_perpendicular(Axis(**axis))
 
     def expand_axes(self):
         # This method should be idempotent & allow change in axes
@@ -570,7 +570,7 @@ class SimulationBuilder:
                 self.input_buffer[axis_name][str(axis_period)] = array
         else:
             first_axes_count: List[int] = (
-                parallel_axes[0].count
+                parallel_axes.first().count
                 for parallel_axes
                 in self.axes
                 )

--- a/openfisca_core/simulations/simulation_builder.py
+++ b/openfisca_core/simulations/simulation_builder.py
@@ -107,7 +107,13 @@ class SimulationBuilder:
                 self.add_default_group_entity(persons_ids, entity_class)
 
         if axes:
-            self.axes = axes
+            for axis in axes[0]:
+                self.add_parallel_axis(axis)
+
+            if len(axes) >= 1:
+                for axis in axes[1:]:
+                    self.add_perpendicular_axis(axis[0])
+
             self.expand_axes()
 
         try:

--- a/openfisca_core/simulations/simulation_builder.py
+++ b/openfisca_core/simulations/simulation_builder.py
@@ -8,7 +8,7 @@ from openfisca_core import periods
 from openfisca_core.entities import Entity
 from openfisca_core.errors import PeriodMismatchError, SituationParsingError, VariableNotFoundError
 from openfisca_core.populations import Population
-from openfisca_core.simulations import helpers, Axis, Simulation
+from openfisca_core.simulations import helpers, Simulation
 from openfisca_core.variables import Variable
 
 

--- a/tests/core/test_axes.py
+++ b/tests/core/test_axes.py
@@ -61,7 +61,7 @@ def test_create_axis_array_with_axes(axis):
     """
     We can pass along some axes at initialisation time as well.
     """
-    result = AxisArray(axes = [axis])
+    result = AxisArray([axis])
     assert result.first() == axis
 
 
@@ -81,20 +81,15 @@ def test_create_axis_array_with_a_collection_of_anything():
         AxisArray(axes = ["axis"])
 
 
-def test_add_axis_to_array(axis_array, axis):
+def test_append_parallel_axis(axis_array, axis):
     """
-    If you add an :obj:`Axis` to the array, it works!
+    As there are no previously added axes in our collection, it adds the first
+    one to the first dimension (parallel).
     """
-    result = axis_array.append(axis)
-    assert axis in result
+    result = axis_array.append_parallel(axis)
+    assert axis in result.first()
+    assert result.first().first() == axis
 
-
-def test_add_anything_to_array(axis_array, axis):
-    """
-    If you add anything else to the array, it fails!
-    """
-    with pytest.raises(TypeError):
-        axis_array.append("cuack")
 
 # With periods
 

--- a/tests/core/test_axes.py
+++ b/tests/core/test_axes.py
@@ -49,7 +49,7 @@ def test_create_empty_axis():
         Axis()
 
 
-def test_create_axis_array():
+def test_empty_create_axis_array():
     """
     Nothing fancy, just an empty container.
     """
@@ -57,13 +57,44 @@ def test_create_axis_array():
     assert isinstance(result, AxisArray)
 
 
+def test_create_axis_array_with_axes(axis):
+    """
+    We can pass along some axes at initialisation time as well.
+    """
+    result = AxisArray(axes = [axis])
+    assert result.first() == axis
+
+
+def test_create_axis_array_with_anything(axis):
+    """
+    If you don't pass a collection, it will fail!
+    """
+    with pytest.raises(TypeError):
+        AxisArray(axes = axis)
+
+
+def test_create_axis_array_with_a_collection_of_anything():
+    """
+    If you pass anything, it will fail!
+    """
+    with pytest.raises(TypeError):
+        AxisArray(axes = ["axis"])
+
+
 def test_add_axis_to_array(axis_array, axis):
     """
-    If you add an :class:`Axis` to the array, it works!
+    If you add an :obj:`Axis` to the array, it works!
     """
     result = axis_array.append(axis)
     assert axis in result
 
+
+def test_add_anything_to_array(axis_array, axis):
+    """
+    If you add anything else to the array, it fails!
+    """
+    with pytest.raises(TypeError):
+        axis_array.append("cuack")
 
 # With periods
 

--- a/tests/core/test_axes.py
+++ b/tests/core/test_axes.py
@@ -10,7 +10,7 @@ def simulation_builder():
 
 
 @pytest.fixture
-def kwargs():
+def salary():
     return {
         "name": "salary",
         "count": 3,
@@ -20,8 +20,23 @@ def kwargs():
 
 
 @pytest.fixture
-def axis(kwargs):
-    return Axis(**kwargs)
+def pension():
+    return {
+        "name": "pension",
+        "count": 2,
+        "min": 0,
+        "max": 2000,
+        }
+
+
+@pytest.fixture
+def salary_axis(salary):
+    return Axis(**salary)
+
+
+@pytest.fixture
+def pension_axis(pension):
+    return Axis(**pension)
 
 
 @pytest.fixture
@@ -32,11 +47,11 @@ def axis_array():
 # Unit tests
 
 
-def test_create_axis(kwargs):
+def test_create_axis(salary):
     """
     Works! Missing fields are optional, so they default to None.
     """
-    result = Axis(**kwargs)
+    result = Axis(**salary)
     assert result.name == "salary"
     assert not result.period
 
@@ -57,20 +72,20 @@ def test_empty_create_axis_array():
     assert isinstance(result, AxisArray)
 
 
-def test_create_axis_array_with_axes(axis):
+def test_create_axis_array_with_axes(salary_axis):
     """
     We can pass along some axes at initialisation time as well.
     """
-    result = AxisArray([axis])
-    assert result.first() == axis
+    result = AxisArray([salary_axis])
+    assert result.first() == salary_axis
 
 
-def test_create_axis_array_with_anything(axis):
+def test_create_axis_array_with_anything(salary_axis):
     """
     If you don't pass a collection, it will fail!
     """
     with pytest.raises(TypeError):
-        AxisArray(axes = axis)
+        AxisArray(salary_axis)
 
 
 def test_create_axis_array_with_a_collection_of_anything():
@@ -78,17 +93,43 @@ def test_create_axis_array_with_a_collection_of_anything():
     If you pass a collection of anything, it will fail!
     """
     with pytest.raises(TypeError):
-        AxisArray(axes = ["axis"])
+        AxisArray(["axis"])
 
 
-def test_append_parallel_axis(axis_array, axis):
+def test_add_parallel_axis(axis_array, salary_axis):
     """
     As there are no previously added axes in our collection, it adds the first
     one to the first dimension (parallel).
     """
-    result = axis_array.append_parallel(axis)
-    assert axis in result.first()
-    assert result.first().first() == axis
+    result = axis_array.add_parallel(salary_axis)
+    assert salary_axis in result.first()
+    assert result.first().first() == salary_axis
+
+
+def test_add_perpendicular_axis_before_parallel_axis(axis_array, pension_axis):
+    """
+    As there are no previously added axes in our collection, it fails!
+    """
+    with pytest.raises(TypeError):
+        axis_array.add_perpendicular(pension_axis)
+
+
+def test_add_perpendicular_axis_after_parallel_axis(axis_array, salary_axis, pension_axis):
+    """
+    As there is at least one parallel axis already, it works!
+    """
+    result = \
+        axis_array \
+        .add_parallel(salary_axis) \
+        .add_perpendicular(pension_axis)
+
+    # Parallel
+    assert salary_axis in result.first()
+    assert result.first().first() == salary_axis
+
+    # Perpendicular
+    assert pension_axis in result.last()
+    assert result.last().first() == pension_axis
 
 
 # With periods

--- a/tests/core/test_axes.py
+++ b/tests/core/test_axes.py
@@ -10,7 +10,7 @@ def simulation_builder():
 
 
 @pytest.fixture
-def axis_args():
+def kwargs():
     return {
         "name": "salary",
         "count": 3,
@@ -20,20 +20,25 @@ def axis_args():
 
 
 @pytest.fixture
-def axis(axis_args):
-    return Axis(axis_args)
+def axis(kwargs):
+    return Axis(**kwargs)
+
+
+@pytest.fixture
+def axis_array():
+    return AxisArray()
 
 
 # Unit tests
 
-def test_create_axis(axis_args):
+
+def test_create_axis(kwargs):
     """
     Works! Missing fields are optional, so they default to None.
     """
-    result = Axis(**axis_args)
+    result = Axis(**kwargs)
     assert result.name == "salary"
     assert not result.period
-    assert not result.index
 
 
 def test_create_empty_axis():
@@ -48,7 +53,16 @@ def test_create_axis_array():
     """
     Nothing fancy, just an empty container.
     """
-    assert AxisArray()
+    result = AxisArray()
+    assert isinstance(result, AxisArray)
+
+
+def test_add_axis_to_array(axis_array, axis):
+    """
+    If you add an :class:`Axis` to the array, it works!
+    """
+    result = axis_array.append(axis)
+    assert axis in result
 
 
 # With periods

--- a/tests/core/test_axes.py
+++ b/tests/core/test_axes.py
@@ -122,6 +122,16 @@ def test_add_parallel_axis(axis_array, salary_axis):
     assert result.first().first() == salary_axis
 
 
+def test_add_parallel_axes_with_different_counts(axis_array, salary_axis, pension_axis):
+    """
+    We can't, it should fail!
+
+    Otherwise they become non expandable.
+    """
+    with pytest.raises(TypeError):
+        axis_array.add_parallel(salary_axis).add_parallel(pension_axis)
+
+
 def test_add_perpendicular_axis_before_parallel_axis(axis_array, pension_axis):
     """
     As there are no previously added axes in our collection, it fails!
@@ -146,6 +156,17 @@ def test_add_perpendicular_axis(axis_array, salary_axis, pension_axis):
     # Perpendicular
     assert pension_axis in result.last()
     assert result.last().first() == pension_axis
+
+
+def test_add_perpendicular_axes_with_different_counts(axis_array, salary_axis, pension_axis):
+    """
+    We can, because each perpendicular axis is added to the next dimension.
+    """
+    assert \
+        axis_array \
+        .add_parallel(salary_axis) \
+        .add_perpendicular(salary_axis) \
+        .add_perpendicular(pension_axis)
 
 
 # AxisExpander

--- a/tests/core/test_axes.py
+++ b/tests/core/test_axes.py
@@ -260,10 +260,10 @@ def test_add_perpendicular_axis_on_an_existing_variable_with_input(simulation_bu
     assert simulation_builder.get_input('salary', '2018-11') == pytest.approx([0, 1500, 3000, 0, 1500, 3000])
     assert simulation_builder.get_input('pension', '2018-11') == pytest.approx([0, 0, 0, 2000, 2000, 2000])
 
+
 # Integration test
 
 
-@pytest.mark.skip
 def test_simulation_with_axes(simulation_builder):
     from .test_countries import tax_benefit_system
     input_yaml = """

--- a/tests/core/test_axes.py
+++ b/tests/core/test_axes.py
@@ -263,6 +263,7 @@ def test_add_perpendicular_axis_on_an_existing_variable_with_input(simulation_bu
 # Integration test
 
 
+@pytest.mark.skip
 def test_simulation_with_axes(simulation_builder):
     from .test_countries import tax_benefit_system
     input_yaml = """

--- a/tests/core/test_axes.py
+++ b/tests/core/test_axes.py
@@ -1,6 +1,12 @@
 import pytest
 
-from openfisca_core.simulations import Axis, AxisArray, SimulationBuilder
+from openfisca_core.simulations import (
+    Axis,
+    AxisArray,
+    AxisExpander,
+    SimulationBuilder,
+    )
+
 from .test_simulation_builder import *  # noqa: F401
 
 
@@ -44,7 +50,14 @@ def axis_array():
     return AxisArray()
 
 
-# Unit tests
+@pytest.fixture
+def axis_expander(axis_array, salary_axis, pension_axis):
+    axis_array = axis_array.add_parallel(salary_axis)
+    axis_array = axis_array.add_perpendicular(pension_axis)
+    return AxisExpander(axis_array)
+
+
+# Axis
 
 
 def test_create_axis(salary):
@@ -62,6 +75,9 @@ def test_create_empty_axis():
     """
     with pytest.raises(TypeError):
         Axis()
+
+
+# AxisArray
 
 
 def test_empty_create_axis_array():
@@ -114,7 +130,7 @@ def test_add_perpendicular_axis_before_parallel_axis(axis_array, pension_axis):
         axis_array.add_perpendicular(pension_axis)
 
 
-def test_add_perpendicular_axis_after_parallel_axis(axis_array, salary_axis, pension_axis):
+def test_add_perpendicular_axis(axis_array, salary_axis, pension_axis):
     """
     As there is at least one parallel axis already, it works!
     """
@@ -130,6 +146,16 @@ def test_add_perpendicular_axis_after_parallel_axis(axis_array, salary_axis, pen
     # Perpendicular
     assert pension_axis in result.last()
     assert result.last().first() == pension_axis
+
+
+# AxisExpander
+
+
+def test_count_cells(axis_expander):
+    assert axis_expander.count_cells() == 6
+
+
+# SimulationBuilder
 
 
 # With periods

--- a/tests/core/test_axes.py
+++ b/tests/core/test_axes.py
@@ -1,6 +1,6 @@
 import pytest
 
-from openfisca_core.simulations import Axis, SimulationBuilder
+from openfisca_core.simulations import Axis, AxisArray, SimulationBuilder
 from .test_simulation_builder import *  # noqa: F401
 
 
@@ -20,7 +20,7 @@ def axis_args():
 
 
 @pytest.fixture
-def axis(axis_params):
+def axis(axis_args):
     return Axis(axis_args)
 
 
@@ -42,6 +42,13 @@ def test_create_empty_axis():
     """
     with pytest.raises(TypeError):
         Axis()
+
+
+def test_create_axis_array():
+    """
+    Nothing fancy, just an empty container.
+    """
+    assert AxisArray()
 
 
 # With periods

--- a/tests/core/test_axes.py
+++ b/tests/core/test_axes.py
@@ -1,13 +1,47 @@
 import pytest
-from pytest import fixture, approx
 
-from openfisca_core.simulation_builder import SimulationBuilder
+from openfisca_core.simulations import Axis, SimulationBuilder
 from .test_simulation_builder import *  # noqa: F401
 
 
-@fixture
+@pytest.fixture
 def simulation_builder():
     return SimulationBuilder()
+
+
+@pytest.fixture
+def axis_args():
+    return {
+        "name": "salary",
+        "count": 3,
+        "min": 0,
+        "max": 3000,
+        }
+
+
+@pytest.fixture
+def axis(axis_params):
+    return Axis(axis_args)
+
+
+# Unit tests
+
+def test_create_axis(axis_args):
+    """
+    Works! Missing fields are optional, so they default to None.
+    """
+    result = Axis(**axis_args)
+    assert result.name == "salary"
+    assert not result.period
+    assert not result.index
+
+
+def test_create_empty_axis():
+    """
+    Fails because we're not providing the required fields.
+    """
+    with pytest.raises(TypeError):
+        Axis()
 
 
 # With periods
@@ -19,7 +53,7 @@ def test_add_axis_without_period(simulation_builder, persons):
     simulation_builder.register_variable('salary', persons)
     simulation_builder.add_parallel_axis({'count': 3, 'name': 'salary', 'min': 0, 'max': 3000})
     simulation_builder.expand_axes()
-    assert simulation_builder.get_input('salary', '2018-11') == approx([0, 1500, 3000])
+    assert simulation_builder.get_input('salary', '2018-11') == pytest.approx([0, 1500, 3000])
 
 
 # With variables
@@ -38,7 +72,7 @@ def test_add_axis_on_an_existing_variable_with_input(simulation_builder, persons
     simulation_builder.register_variable('salary', persons)
     simulation_builder.add_parallel_axis({'count': 3, 'name': 'salary', 'min': 0, 'max': 3000, 'period': '2018-11'})
     simulation_builder.expand_axes()
-    assert simulation_builder.get_input('salary', '2018-11') == approx([0, 1500, 3000])
+    assert simulation_builder.get_input('salary', '2018-11') == pytest.approx([0, 1500, 3000])
     assert simulation_builder.get_count('persons') == 3
     assert simulation_builder.get_ids('persons') == ['Alicia0', 'Alicia1', 'Alicia2']
 
@@ -51,7 +85,7 @@ def test_add_axis_on_persons(simulation_builder, persons):
     simulation_builder.register_variable('salary', persons)
     simulation_builder.add_parallel_axis({'count': 3, 'name': 'salary', 'min': 0, 'max': 3000, 'period': '2018-11'})
     simulation_builder.expand_axes()
-    assert simulation_builder.get_input('salary', '2018-11') == approx([0, 1500, 3000])
+    assert simulation_builder.get_input('salary', '2018-11') == pytest.approx([0, 1500, 3000])
     assert simulation_builder.get_count('persons') == 3
     assert simulation_builder.get_ids('persons') == ['Alicia0', 'Alicia1', 'Alicia2']
 
@@ -62,8 +96,8 @@ def test_add_two_axes(simulation_builder, persons):
     simulation_builder.add_parallel_axis({'count': 3, 'name': 'salary', 'min': 0, 'max': 3000, 'period': '2018-11'})
     simulation_builder.add_parallel_axis({'count': 3, 'name': 'pension', 'min': 0, 'max': 2000, 'period': '2018-11'})
     simulation_builder.expand_axes()
-    assert simulation_builder.get_input('salary', '2018-11') == approx([0, 1500, 3000])
-    assert simulation_builder.get_input('pension', '2018-11') == approx([0, 1000, 2000])
+    assert simulation_builder.get_input('salary', '2018-11') == pytest.approx([0, 1500, 3000])
+    assert simulation_builder.get_input('pension', '2018-11') == pytest.approx([0, 1000, 2000])
 
 
 def test_add_axis_with_group(simulation_builder, persons):
@@ -74,7 +108,7 @@ def test_add_axis_with_group(simulation_builder, persons):
     simulation_builder.expand_axes()
     assert simulation_builder.get_count('persons') == 4
     assert simulation_builder.get_ids('persons') == ['Alicia0', 'Javier1', 'Alicia2', 'Javier3']
-    assert simulation_builder.get_input('salary', '2018-11') == approx([0, 0, 3000, 3000])
+    assert simulation_builder.get_input('salary', '2018-11') == pytest.approx([0, 0, 3000, 3000])
 
 
 def test_add_axis_with_group_int_period(simulation_builder, persons):
@@ -83,7 +117,7 @@ def test_add_axis_with_group_int_period(simulation_builder, persons):
     simulation_builder.add_parallel_axis({'count': 2, 'name': 'salary', 'min': 0, 'max': 3000, 'period': 2018})
     simulation_builder.add_parallel_axis({'count': 2, 'name': 'salary', 'min': 0, 'max': 3000, 'period': 2018, 'index': 1})
     simulation_builder.expand_axes()
-    assert simulation_builder.get_input('salary', '2018') == approx([0, 0, 3000, 3000])
+    assert simulation_builder.get_input('salary', '2018') == pytest.approx([0, 0, 3000, 3000])
 
 
 def test_add_axis_on_group_entity(simulation_builder, persons, group_entity):
@@ -155,8 +189,8 @@ def test_add_perpendicular_axes(simulation_builder, persons):
     simulation_builder.add_parallel_axis({'count': 3, 'name': 'salary', 'min': 0, 'max': 3000, 'period': '2018-11'})
     simulation_builder.add_perpendicular_axis({'count': 2, 'name': 'pension', 'min': 0, 'max': 2000, 'period': '2018-11'})
     simulation_builder.expand_axes()
-    assert simulation_builder.get_input('salary', '2018-11') == approx([0, 1500, 3000, 0, 1500, 3000])
-    assert simulation_builder.get_input('pension', '2018-11') == approx([0, 0, 0, 2000, 2000, 2000])
+    assert simulation_builder.get_input('salary', '2018-11') == pytest.approx([0, 1500, 3000, 0, 1500, 3000])
+    assert simulation_builder.get_input('pension', '2018-11') == pytest.approx([0, 0, 0, 2000, 2000, 2000])
 
 
 def test_add_perpendicular_axis_on_an_existing_variable_with_input(simulation_builder, persons):
@@ -171,8 +205,8 @@ def test_add_perpendicular_axis_on_an_existing_variable_with_input(simulation_bu
     simulation_builder.add_parallel_axis({'count': 3, 'name': 'salary', 'min': 0, 'max': 3000, 'period': '2018-11'})
     simulation_builder.add_perpendicular_axis({'count': 2, 'name': 'pension', 'min': 0, 'max': 2000, 'period': '2018-11'})
     simulation_builder.expand_axes()
-    assert simulation_builder.get_input('salary', '2018-11') == approx([0, 1500, 3000, 0, 1500, 3000])
-    assert simulation_builder.get_input('pension', '2018-11') == approx([0, 0, 0, 2000, 2000, 2000])
+    assert simulation_builder.get_input('salary', '2018-11') == pytest.approx([0, 1500, 3000, 0, 1500, 3000])
+    assert simulation_builder.get_input('pension', '2018-11') == pytest.approx([0, 0, 0, 2000, 2000, 2000])
 
 # Integration test
 
@@ -199,5 +233,5 @@ def test_simulation_with_axes(simulation_builder):
     """
     data = yaml.safe_load(input_yaml)
     simulation = simulation_builder.build_from_dict(tax_benefit_system, data)
-    assert simulation.get_array('salary', '2018-11') == approx([0, 0, 0, 0, 0, 0])
-    assert simulation.get_array('rent', '2018-11') == approx([0, 0, 3000, 0])
+    assert simulation.get_array('salary', '2018-11') == pytest.approx([0, 0, 0, 0, 0, 0])
+    assert simulation.get_array('rent', '2018-11') == pytest.approx([0, 0, 3000, 0])

--- a/tests/core/test_axes.py
+++ b/tests/core/test_axes.py
@@ -75,7 +75,7 @@ def test_create_axis_array_with_anything(axis):
 
 def test_create_axis_array_with_a_collection_of_anything():
     """
-    If you pass anything, it will fail!
+    If you pass a collection of anything, it will fail!
     """
     with pytest.raises(TypeError):
         AxisArray(axes = ["axis"])


### PR DESCRIPTION
This is a work in progress based on my willingness to give a proper answer to #933 and #934.

I hoped to have a more advanced proposal for a request for comments, but axes are a hard one to tackle properly.

What do you think? Any feedback at this point @benjello @guillett?

Details below.

#### New features

- Introduce `Axis`, `AxisArray`, and `AxisExpander`.
  - It clearly separates the data logic from the domain logic (setting up a collection of axes coherently vs actually expanding a simulation over a given collection of axes).

#### Improvements

- Introduce proper separation of concerns between an axis, a multi-dimensional axes collection, and its expansion.
  -  Allows for a better readability and testability, and future improvement of the expand axes feature.
  - Adds more unit test coverage, including some untested invariants (like the number of counts for a parallel set of axes).

#### Deprecations

- Deprecate `add_parallel_axis`, `add_perpendicular_axis`, and `expand_axes`.
  - Those functionalities are now provided by `AxisArray` and `AxisExpander`.