### PR TITLE
Feature  single amount tax scale interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 35.4.0 [#994](https://github.com/openfisca/openfisca-core/pull/994)
+
+#### New features
+
+- Introduce ability to interpolate between values in a SingleAmountTaxScale
+
+#### Usage notes
+
+- Interpolation is performed within the `SingleAmountTaxScale.calc()` function if the keyword argument `interpolate=True` is provided
+
 ### 35.3.3 [#994](https://github.com/openfisca/openfisca-core/pull/994)
 
 #### Bug fix

--- a/openfisca_core/taxscales/single_amount_tax_scale.py
+++ b/openfisca_core/taxscales/single_amount_tax_scale.py
@@ -13,12 +13,25 @@ class SingleAmountTaxScale(AmountTaxScaleLike):
             self,
             tax_base: typing.Union[numpy.ndarray[int], numpy.ndarray[float]],
             right: bool = False,
+            interpolate: bool = False,
             ) -> numpy.ndarray[float]:
         """
         Matches the input amount to a set of brackets and returns the single cell value
         that fits within that bracket.
+
+        :arguments:
+        - `interpolate` (bool): if True, returns the linear interpolated value
+                                between the nearest two thresholds.
+
         """
-        guarded_thresholds = numpy.array([-numpy.inf] + self.thresholds + [numpy.inf])
-        bracket_indices = numpy.digitize(tax_base, guarded_thresholds, right = right)
-        guarded_amounts = numpy.array([0] + self.amounts + [0])
-        return guarded_amounts[bracket_indices - 1]
+        if interpolate:
+            thresholds = self.thresholds
+            amounts = self.amounts
+            result = numpy.interp(tax_base, thresholds, amounts)
+            return result
+
+        else:
+            guarded_thresholds = numpy.array([-numpy.inf] + self.thresholds + [numpy.inf])
+            bracket_indices = numpy.digitize(tax_base, guarded_thresholds, right = right)
+            guarded_amounts = numpy.array([0] + self.amounts + [0])
+            return guarded_amounts[bracket_indices - 1]

--- a/openfisca_core/taxscales/single_amount_tax_scale.py
+++ b/openfisca_core/taxscales/single_amount_tax_scale.py
@@ -14,6 +14,8 @@ class SingleAmountTaxScale(AmountTaxScaleLike):
             tax_base: typing.Union[numpy.ndarray[int], numpy.ndarray[float]],
             right: bool = False,
             interpolate: bool = False,
+            interp_right: typing.Union[numpy.ndarray[int], numpy.ndarray[float], None] = None,
+            interp_left: typing.Union[numpy.ndarray[int], numpy.ndarray[float], None] = None,
             ) -> numpy.ndarray[float]:
         """
         Matches the input amount to a set of brackets and returns the single cell value
@@ -22,12 +24,14 @@ class SingleAmountTaxScale(AmountTaxScaleLike):
         :arguments:
         - `interpolate` (bool): if True, returns the linear interpolated value
                                 between the nearest two thresholds.
+        - `interp_right` (int, float): value returned in `tax_base` is greater than the highest threshold value
+        - `interp_left` (int, float): value returned in `tax_base` is less than the lowest threshold value
 
         """
         if interpolate:
             thresholds = self.thresholds
             amounts = self.amounts
-            result = numpy.interp(tax_base, thresholds, amounts)
+            result = numpy.interp(tax_base, thresholds, amounts, left=interp_left, right=interp_right)
             return result
 
         else:

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '35.3.3',
+    version = '35.4.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/tax_scales/test_single_amount_tax_scale.py
+++ b/tests/core/tax_scales/test_single_amount_tax_scale.py
@@ -37,6 +37,28 @@ def test_calc():
     tools.assert_near(result, [0, 0.23, 0.29])
 
 
+def test_calc_interpolate():
+    tax_base = numpy.array([2.5, 5, 7, 10])
+    tax_scale = taxscales.SingleAmountTaxScale()
+    tax_scale.add_bracket(0, 0)
+    tax_scale.add_bracket(5, 50)
+    tax_scale.add_bracket(10, 200)
+
+    result = tax_scale.calc(tax_base, interpolate=True)
+
+    tools.assert_near(result, [25, 50, 110, 200])
+
+
+def test_calc_interpolate_with_unitary_bracket():
+    tax_base = numpy.array([2.5, 5, 7, 10])
+    tax_scale = taxscales.SingleAmountTaxScale()
+    tax_scale.add_bracket(5, 50)
+
+    result = tax_scale.calc(tax_base, interpolate=True)
+
+    tools.assert_near(result, [50, 50, 50, 50])
+
+
 def test_to_dict():
     tax_scale = taxscales.SingleAmountTaxScale()
     tax_scale.add_bracket(6, 0.23)


### PR DESCRIPTION
#### New features

- Introduce ability to interpolate between values in a SingleAmountTaxScale
- Currently we can return the nearest value (floor or ceiling) between two thresholds, based on an 'input_value' using [SingleAmountTaxScale.calc(input_value)](https://github.com/openfisca/openfisca-core/blob/c1acafa93b03eea6eaaaacc1aa4473df921f6515/openfisca_core/taxscales/single_amount_tax_scale.py#L12)
- This PR allows calculating the linear-interpolated value between two thresholds.

  - Behind the scenes it uses [the numpy.interp() function](https://numpy.org/doc/stable/reference/generated/numpy.interp.html)
  - I've passed through the `right=` and `left=` keyword arguments for user flexibility
