### PR TITLE
Change log.warning to warnings.warn to allow users of the package to hide them.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 35.3.4 [#999](https://github.com/openfisca/openfisca-core/pull/999)
+
+#### Technical improvements
+
+- Change logging.warning to warnings.warn to allow users of the package to hide them.
+
 ### 35.3.3 [#994](https://github.com/openfisca/openfisca-core/pull/994)
 
 #### Bug fix

--- a/openfisca_core/experimental/memory_config.py
+++ b/openfisca_core/experimental/memory_config.py
@@ -1,5 +1,6 @@
 import warnings
-from openfisca_core.warnings import OpenFiscaMemoryWarning
+
+from openfisca_core.warnings import MemoryConfigWarning
 
 
 class MemoryConfig:
@@ -13,7 +14,7 @@ class MemoryConfig:
             "You are very welcome to use it and send us precious feedback,",
             "but keep in mind that the way it is used might change without any major version bump."
             ]
-        warnings.warn(" ".join(message), OpenFiscaMemoryWarning)
+        warnings.warn(" ".join(message), MemoryConfigWarning)
 
         self.max_memory_occupation = float(max_memory_occupation)
         if self.max_memory_occupation > 1:

--- a/openfisca_core/experimental/memory_config.py
+++ b/openfisca_core/experimental/memory_config.py
@@ -1,6 +1,12 @@
 import logging
+import warnings
 
 log = logging.getLogger(__name__)
+
+
+class OpenFiscaMemoryWarning(UserWarning):
+    # Custom Warning for MemoryConfig
+    pass
 
 
 class MemoryConfig:
@@ -9,7 +15,12 @@ class MemoryConfig:
       max_memory_occupation,
       priority_variables = None,
       variables_to_drop = None):
-        log.warn("Memory configuration is a feature that is still currently under experimentation. You are very welcome to use it and send us precious feedback, but keep in mind that the way it is used might change without any major version bump.")
+        message = [
+            "Memory configuration is a feature that is still currently under experimentation.",
+            "You are very welcome to use it and send us precious feedback,",
+            "but keep in mind that the way it is used might change without any major version bump."
+            ]
+        warnings.warn(" ".join(message), OpenFiscaMemoryWarning)
 
         self.max_memory_occupation = float(max_memory_occupation)
         if self.max_memory_occupation > 1:

--- a/openfisca_core/experimental/memory_config.py
+++ b/openfisca_core/experimental/memory_config.py
@@ -5,7 +5,9 @@ log = logging.getLogger(__name__)
 
 
 class OpenFiscaMemoryWarning(UserWarning):
-    # Custom Warning for MemoryConfig
+    """
+    Custom warning for MemoryConfig.
+    """
     pass
 
 

--- a/openfisca_core/experimental/memory_config.py
+++ b/openfisca_core/experimental/memory_config.py
@@ -1,14 +1,5 @@
-import logging
 import warnings
-
-log = logging.getLogger(__name__)
-
-
-class OpenFiscaMemoryWarning(UserWarning):
-    """
-    Custom warning for MemoryConfig.
-    """
-    pass
+from openfisca_core.warnings import OpenFiscaMemoryWarning
 
 
 class MemoryConfig:

--- a/openfisca_core/parameters/config.py
+++ b/openfisca_core/parameters/config.py
@@ -2,7 +2,7 @@ import warnings
 import os
 import yaml
 import typing
-from openfisca_core.warnings import OpenFiscaLibyamlWarning
+from openfisca_core.warnings import LibYAMLWarning
 
 
 try:
@@ -14,7 +14,7 @@ except ImportError:
         "Once you have installed libyaml, run 'pip uninstall pyyaml && pip install pyyaml --no-cache-dir'",
         "so that it is used in your Python environment." + os.linesep
         ]
-    warnings.warn(" ".join(message), OpenFiscaLibyamlWarning)
+    warnings.warn(" ".join(message), LibYAMLWarning)
     from yaml import Loader  # type: ignore # (see https://github.com/python/mypy/issues/1153#issuecomment-455802270)
 
 # 'unit' and 'reference' are only listed here for backward compatibility.

--- a/openfisca_core/parameters/config.py
+++ b/openfisca_core/parameters/config.py
@@ -6,7 +6,9 @@ import typing
 
 
 class OpenFiscaLibyamlWarning(UserWarning):
-    # Custom Warning for libyaml not installed
+    """
+    Custom warning for libyaml not installed.
+    """
     pass
 
 

--- a/openfisca_core/parameters/config.py
+++ b/openfisca_core/parameters/config.py
@@ -1,18 +1,9 @@
-import logging
 import warnings
 import os
 import yaml
 import typing
+from openfisca_core.warnings import OpenFiscaLibyamlWarning
 
-
-class OpenFiscaLibyamlWarning(UserWarning):
-    """
-    Custom warning for libyaml not installed.
-    """
-    pass
-
-
-log = logging.getLogger(__name__)
 
 try:
     from yaml import CLoader as Loader

--- a/openfisca_core/parameters/config.py
+++ b/openfisca_core/parameters/config.py
@@ -1,15 +1,27 @@
 import logging
+import warnings
 import os
 import yaml
 import typing
+
+
+class OpenFiscaLibyamlWarning(UserWarning):
+    # Custom Warning for libyaml not installed
+    pass
+
 
 log = logging.getLogger(__name__)
 
 try:
     from yaml import CLoader as Loader
 except ImportError:
-    log.warning(
-        "libyaml is not installed in your environment. This can make OpenFisca slower to start. Once you have installed libyaml, run 'pip uninstall pyyaml && pip install pyyaml --no-cache-dir' so that it is used in your Python environment." + os.linesep)
+    message = [
+        "libyaml is not installed in your environment.",
+        "This can make OpenFisca slower to start.",
+        "Once you have installed libyaml, run 'pip uninstall pyyaml && pip install pyyaml --no-cache-dir'",
+        "so that it is used in your Python environment." + os.linesep
+        ]
+    warnings.warn(" ".join(message), OpenFiscaLibyamlWarning)
     from yaml import Loader  # type: ignore # (see https://github.com/python/mypy/issues/1153#issuecomment-455802270)
 
 # 'unit' and 'reference' are only listed here for backward compatibility.

--- a/openfisca_core/simulations/simulation.py
+++ b/openfisca_core/simulations/simulation.py
@@ -8,7 +8,7 @@ from openfisca_core.errors import CycleError, SpiralError
 from openfisca_core.indexed_enums import Enum, EnumArray
 from openfisca_core.periods import Period
 from openfisca_core.tracers import FullTracer, SimpleTracer, TracingParameterNodeAtInstant
-from openfisca_core.warnings import OpenFiscaTempfileWarning
+from openfisca_core.warnings import TempfileWarning
 
 
 class Simulation:
@@ -78,7 +78,7 @@ class Simulation:
                 ("Intermediate results will be stored on disk in {} in case of memory overflow.").format(self._data_storage_dir),
                 "You should remove this directory once you're done with your simulation."
                 ]
-            warnings.warn(" ".join(message), OpenFiscaTempfileWarning)
+            warnings.warn(" ".join(message), TempfileWarning)
         return self._data_storage_dir
 
     # ----- Calculation methods ----- #

--- a/openfisca_core/simulations/simulation.py
+++ b/openfisca_core/simulations/simulation.py
@@ -1,5 +1,6 @@
 import tempfile
 import logging
+import warnings
 
 import numpy
 
@@ -10,6 +11,11 @@ from openfisca_core.periods import Period
 from openfisca_core.tracers import FullTracer, SimpleTracer, TracingParameterNodeAtInstant
 
 log = logging.getLogger(__name__)
+
+
+class OpenFiscaTempfileWarning(UserWarning):
+    # Custom Warning when using temp file on disk.
+    pass
 
 
 class Simulation:
@@ -75,10 +81,11 @@ class Simulation:
         """
         if self._data_storage_dir is None:
             self._data_storage_dir = tempfile.mkdtemp(prefix = "openfisca_")
-            log.warn((
-                "Intermediate results will be stored on disk in {} in case of memory overflow. "
+            message = [
+                ("Intermediate results will be stored on disk in {} in case of memory overflow.").format(self._data_storage_dir),
                 "You should remove this directory once you're done with your simulation."
-                ).format(self._data_storage_dir))
+                ]
+            warnings.warn(" ".join(message), OpenFiscaTempfileWarning)
         return self._data_storage_dir
 
     # ----- Calculation methods ----- #

--- a/openfisca_core/simulations/simulation.py
+++ b/openfisca_core/simulations/simulation.py
@@ -1,5 +1,4 @@
 import tempfile
-import logging
 import warnings
 
 import numpy
@@ -9,13 +8,7 @@ from openfisca_core.errors import CycleError, SpiralError
 from openfisca_core.indexed_enums import Enum, EnumArray
 from openfisca_core.periods import Period
 from openfisca_core.tracers import FullTracer, SimpleTracer, TracingParameterNodeAtInstant
-
-log = logging.getLogger(__name__)
-
-
-class OpenFiscaTempfileWarning(UserWarning):
-    # Custom Warning when using temp file on disk.
-    pass
+from openfisca_core.warnings import OpenFiscaTempfileWarning
 
 
 class Simulation:

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import logging
 import warnings
 import sys
 import os
@@ -13,13 +12,7 @@ import pytest
 from openfisca_core.tools import assert_near
 from openfisca_core.simulation_builder import SimulationBuilder
 from openfisca_core.errors import SituationParsingError, VariableNotFound
-
-log = logging.getLogger(__name__)
-
-
-class OpenFiscaLibyamlWarning(UserWarning):
-    # Custom Warning for libyaml not installed
-    pass
+from openfisca_core.warnings import OpenFiscaLibyamlWarning
 
 
 def import_yaml():

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import warnings
 import sys
 import os
 import traceback
@@ -16,17 +17,23 @@ from openfisca_core.errors import SituationParsingError, VariableNotFound
 log = logging.getLogger(__name__)
 
 
+class OpenFiscaLibyamlWarning(UserWarning):
+    # Custom Warning for libyaml not installed
+    pass
+
+
 def import_yaml():
     import yaml
     try:
         from yaml import CLoader as Loader
     except ImportError:
-        log.warning(
-            ' '
-            'libyaml is not installed in your environment, this can make your '
-            'test suite slower to run. Once you have installed libyaml, run `pip '
-            'uninstall pyyaml && pip install pyyaml --no-cache-dir` so that it is used in your '
-            'Python environment.')
+        message = [
+            "libyaml is not installed in your environment.",
+            "This can make your test suite slower to run. Once you have installed libyaml, ",
+            "run 'pip uninstall pyyaml && pip install pyyaml --no-cache-dir'",
+            "so that it is used in your Python environment."
+            ]
+        warnings.warn(" ".join(message), OpenFiscaLibyamlWarning)
         from yaml import SafeLoader as Loader
     return yaml, Loader
 

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -12,7 +12,7 @@ import pytest
 from openfisca_core.tools import assert_near
 from openfisca_core.simulation_builder import SimulationBuilder
 from openfisca_core.errors import SituationParsingError, VariableNotFound
-from openfisca_core.warnings import OpenFiscaLibyamlWarning
+from openfisca_core.warnings import LibYAMLWarning
 
 
 def import_yaml():
@@ -26,7 +26,7 @@ def import_yaml():
             "run 'pip uninstall pyyaml && pip install pyyaml --no-cache-dir'",
             "so that it is used in your Python environment."
             ]
-        warnings.warn(" ".join(message), OpenFiscaLibyamlWarning)
+        warnings.warn(" ".join(message), LibYAMLWarning)
         from yaml import SafeLoader as Loader
     return yaml, Loader
 

--- a/openfisca_core/warnings/__init__.py
+++ b/openfisca_core/warnings/__init__.py
@@ -21,6 +21,6 @@
 #
 # See: https://www.python.org/dev/peps/pep-0008/#imports
 
-from .tempfile_warning import OpenFiscaTempfileWarning  # noqa: F401
-from .libyaml_warning import OpenFiscaLibyamlWarning  # noqa: F401
-from .memory_warning import OpenFiscaMemoryWarning  # noqa: F401
+from .libyaml_warning import LibYAMLWarning  # noqa: F401
+from .memory_warning import MemoryConfigWarning  # noqa: F401
+from .tempfile_warning import TempfileWarning  # noqa: F401

--- a/openfisca_core/warnings/__init__.py
+++ b/openfisca_core/warnings/__init__.py
@@ -1,0 +1,26 @@
+# Transitional imports to ensure non-breaking changes.
+# Could be deprecated in the next major release.
+#
+# How imports are being used today:
+#
+#   >>> from openfisca_core.module import symbol
+#
+# The previous example provokes cyclic dependency problems
+# that prevent us from modularizing the different components
+# of the library so to make them easier to test and to maintain.
+#
+# How could them be used after the next major release:
+#
+#   >>> from openfisca_core import module
+#   >>> module.symbol()
+#
+# And for classes:
+#
+#   >>> from openfisca_core.module import Symbol
+#   >>> Symbol()
+#
+# See: https://www.python.org/dev/peps/pep-0008/#imports
+
+from .tempfile_warning import OpenFiscaTempfileWarning  # noqa: F401
+from .libyaml_warning import OpenFiscaLibyamlWarning  # noqa: F401
+from .memory_warning import OpenFiscaMemoryWarning  # noqa: F401

--- a/openfisca_core/warnings/libyaml_warning.py
+++ b/openfisca_core/warnings/libyaml_warning.py
@@ -1,5 +1,5 @@
-class OpenFiscaLibyamlWarning(UserWarning):
+class LibYAMLWarning(UserWarning):
     """
-    Custom warning for libyaml not installed.
+    Custom warning for LibYAML not installed.
     """
     pass

--- a/openfisca_core/warnings/libyaml_warning.py
+++ b/openfisca_core/warnings/libyaml_warning.py
@@ -1,0 +1,5 @@
+class OpenFiscaLibyamlWarning(UserWarning):
+    """
+    Custom warning for libyaml not installed.
+    """
+    pass

--- a/openfisca_core/warnings/memory_warning.py
+++ b/openfisca_core/warnings/memory_warning.py
@@ -1,4 +1,4 @@
-class OpenFiscaMemoryWarning(UserWarning):
+class MemoryConfigWarning(UserWarning):
     """
     Custom warning for MemoryConfig.
     """

--- a/openfisca_core/warnings/memory_warning.py
+++ b/openfisca_core/warnings/memory_warning.py
@@ -1,0 +1,5 @@
+class OpenFiscaMemoryWarning(UserWarning):
+    """
+    Custom warning for MemoryConfig.
+    """
+    pass

--- a/openfisca_core/warnings/tempfile_warning.py
+++ b/openfisca_core/warnings/tempfile_warning.py
@@ -1,0 +1,5 @@
+class OpenFiscaTempfileWarning(UserWarning):
+    """
+    Custom Warning when using temp file on disk.
+    """
+    pass

--- a/openfisca_core/warnings/tempfile_warning.py
+++ b/openfisca_core/warnings/tempfile_warning.py
@@ -1,5 +1,5 @@
-class OpenFiscaTempfileWarning(UserWarning):
+class TempfileWarning(UserWarning):
     """
-    Custom Warning when using temp file on disk.
+    Custom warning when using a tempfile on disk.
     """
     pass

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '35.3.3',
+    version = '35.3.4',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
Fixes #995 

#### Technical changes

- Change logging.warning to warnings.warn to allow users of the package to hide them. See https://github.com/openfisca/openfisca-core/issues/995 for more info.

So the users could hide the warnings like this:

```python
warnings.simplefilter(action="ignore", category=TempfileWarning)
```