### PR TITLE
Validate date validity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 35.4.1 [#1007](https://github.com/openfisca/openfisca-core/pull/1007)
+
+#### Bug fix
+
+- Properly check for date validity in parameters.
+  - Date validity was being checked only partially, allowing parameters with illegal dates such as "2015-13-32".
+  - The changes introduced fix this error and prevent the user when a parameter date is illegal.
+
 ## 35.4.0 [#1010](https://github.com/openfisca/openfisca-core/pull/1010)
 
 #### Technical changes

--- a/openfisca_core/periods/config.py
+++ b/openfisca_core/periods/config.py
@@ -6,7 +6,9 @@ MONTH = 'month'
 YEAR = 'year'
 ETERNITY = 'eternity'
 
-INSTANT_PATTERN = re.compile(r'^\d{4}(?:-\d{1,2}){0,2}$')  # matches '2015', '2015-01', '2015-01-01'
+# Matches "2015", "2015-01", "2015-01-01"
+# Does not match "2015-13", "2015-12-32"
+INSTANT_PATTERN = re.compile(r"^\d{4}(-(0[1-9]|1[012]))?(-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]))?$")
 
 date_by_instant_cache: typing.Dict = {}
 str_by_instant_cache: typing.Dict = {}

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '35.4.0',
+    version = '35.4.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/parameter_validation/test_parameter_validation.py
+++ b/tests/core/parameter_validation/test_parameter_validation.py
@@ -21,6 +21,7 @@ def check_fails_with_message(file_name, keywords):
 
 @pytest.mark.parametrize("test", [
     ('indentation', {'Invalid YAML', 'indentation.yaml', 'line 2', 'mapping values are not allowed'}),
+    ("wrong_date", {"Expected a period", "got: '2006-31-03'"}),
     ('wrong_scale', {'Unexpected property', 'scale[1]', 'treshold'}),
     ('wrong_value', {'not one of the allowed types', 'wrong_value[2015-12-01]', '1A'}),
     ('unexpected_key_in_parameter', {'Unexpected property', 'unexpected_key'}),

--- a/tests/core/parameter_validation/test_parameter_validation.py
+++ b/tests/core/parameter_validation/test_parameter_validation.py
@@ -21,7 +21,7 @@ def check_fails_with_message(file_name, keywords):
 
 @pytest.mark.parametrize("test", [
     ('indentation', {'Invalid YAML', 'indentation.yaml', 'line 2', 'mapping values are not allowed'}),
-    ("wrong_date", {"Expected a period", "got: '2006-31-03'"}),
+    ("wrong_date", {"Error parsing parameter file", "Properties must be valid YYYY-MM-DD instants"}),
     ('wrong_scale', {'Unexpected property', 'scale[1]', 'treshold'}),
     ('wrong_value', {'not one of the allowed types', 'wrong_value[2015-12-01]', '1A'}),
     ('unexpected_key_in_parameter', {'Unexpected property', 'unexpected_key'}),

--- a/tests/core/parameter_validation/wrong_date.yaml
+++ b/tests/core/parameter_validation/wrong_date.yaml
@@ -1,0 +1,4 @@
+description: Some parameter
+values:
+  2006-31-03:
+    value: 1.0

--- a/tests/core/test_periods.py
+++ b/tests/core/test_periods.py
@@ -148,6 +148,11 @@ def test_2_years_size_in_days():
 # Misc
 
 
+def test_wrong_date():
+    with pytest.raises(ValueError):
+        period("2006-31-03")
+
+
 def test_ambiguous_period():
     with pytest.raises(ValueError):
         period('month:2014')


### PR DESCRIPTION
Fixes #1005 

#### Bug fix

- Properly check for date validity in parameters
  - Date validity was being checked only partially, allowing parameters with illegal dates such as "2015-13-32"
  - The changes introduced fix this error and prevent the user when a parameter date is illegal