### PR TITLE
Fix numpy version constraints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 general_requirements = [
     'dpath >= 1.5.0, < 2.0.0',
     'pytest >= 4.4.1, < 6.0.0',  # For openfisca test
-    'numpy >= 1.11, < 1.21',
+    'numpy >= 1.20, < 1.21',
     'psutil >= 5.4.7, < 6.0.0',
     'PyYAML >= 3.10',
     'sortedcontainers == 2.2.2',


### PR DESCRIPTION
When I update working environments without specifying explicit version but avoiding only major version change I get a broken environment with

```
ModuleNotFoundError: No module named 'numpy.typing'
```
since #990

#### Technical changes

Fix numpy version constraints


Can that be a patch version change to `35.3.8` that would be followed by #1010 that would also by a non major version change and that would untied the limit on numpy version ?