### PR TITLE
Add period mismatch error handling to API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 35.4.2 [#1026](https://github.com/openfisca/openfisca-core/pull/1026)
+
+#### Bug fix
+
+- [Web API] Handle a period mismatch error
+  - Period mismatch error was not being handled by the API
+  - Since it's caused by the user, a 400 (bad request error) is to be expected
+  - However, since it was not being handled, a 500 (internal server error) was being given instead
+
 ### 35.4.1 [#1007](https://github.com/openfisca/openfisca-core/pull/1007)
 
 #### Bug fix

--- a/openfisca_web_api/app.py
+++ b/openfisca_web_api/app.py
@@ -4,7 +4,7 @@ import logging
 import os
 import traceback
 
-from openfisca_core.errors import SituationParsingError
+from openfisca_core.errors import SituationParsingError, PeriodMismatchError
 from openfisca_web_api.loader import build_data
 from openfisca_web_api.errors import handle_import_error
 from openfisca_web_api import handlers
@@ -138,7 +138,7 @@ def create_app(tax_benefit_system,
         input_data = request.get_json()
         try:
             result = handlers.calculate(tax_benefit_system, input_data)
-        except SituationParsingError as e:
+        except (SituationParsingError, PeriodMismatchError) as e:
             abort(make_response(jsonify(e.error), e.code or 400))
         except (UnicodeEncodeError, UnicodeDecodeError) as e:
             abort(make_response(jsonify({"error": "'" + e[1] + "' is not a valid ASCII value."}), 400))
@@ -151,7 +151,7 @@ def create_app(tax_benefit_system,
         input_data = request.get_json()
         try:
             result = handlers.trace(tax_benefit_system, input_data)
-        except SituationParsingError as e:
+        except (SituationParsingError, PeriodMismatchError) as e:
             abort(make_response(jsonify(e.error), e.code or 400))
         return jsonify(result)
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '35.4.1',
+    version = '35.4.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/web_api/test_calculate.py
+++ b/tests/web_api/test_calculate.py
@@ -314,6 +314,35 @@ def test_periods(test_client):
     assert monthly_variable == {'2017-01': 'tenant'}
 
 
+def test_handle_period_mismatch_error(test_client):
+
+    variable = "housing_tax"
+    period = "2017-01"
+
+    simulation_json = json.dumps({
+        "persons": {
+            "bill": {}
+            },
+        "households": {
+            "_": {
+                "parents": ["bill"],
+                variable: {
+                    period: 400
+                    },
+                }
+            }
+        })
+
+    response = post_json(test_client, simulation_json)
+    assert response.status_code == client.BAD_REQUEST
+
+    response_json = json.loads(response.data)
+
+    error = dpath.get(response_json, f'households/_/housing_tax/{period}')
+    message = f'Unable to set a value for variable "{variable}" for month-long period "{period}"'
+    assert message in error
+
+
 def test_gracefully_handle_unexpected_errors(test_client):
     """
     Context


### PR DESCRIPTION
Connected to #916 

**Bug fix**:

- [Web API] Handle a period mismatch error:
  - The exception expected by a period mismatch error was not the good one.
  - A period mismatch error renders a 500 internal server error instead of a 400 bad request error since it's caused by the user.
  