### PR TITLE
Add venv and pip commands to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ If you want to contribute to OpenFisca-Core itself, welcome! To install it local
 ```bash
 git clone https://github.com/openfisca/openfisca-core.git
 cd openfisca-core
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -U pip
 pip install --editable .[dev] --use-deprecated=legacy-resolver
 ```
 


### PR DESCRIPTION
#### Documentation changes

This PR adds instructions in the README for creating a python virtual environment and upgrading pip. While these are obvious for seasoned Python programmers, the lack of those instructions may throw off some people who might be willing to contribute to the project.
