### PR TITLE
Allow complete group encapsulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 35.7.0 [#1070](https://github.com/openfisca/openfisca-core/pulls/1070)
+
+#### New Features
+
+- Add group population shortcut to containing groups entities
+
 ## 35.6.0 [#1054](https://github.com/openfisca/openfisca-core/pull/1054)
 
 #### New Features

--- a/openfisca_core/entities/group_entity.py
+++ b/openfisca_core/entities/group_entity.py
@@ -2,8 +2,25 @@ from openfisca_core.entities import Entity, Role
 
 
 class GroupEntity(Entity):
-    """
-    Represents an entity composed of several persons with different roles, on which calculations are run.
+    """Represents an entity containing several other entities with different roles.
+
+    A :class:`.GroupEntity` represents an :class:`.Entity` containing 
+    several other :class:`.Entity` with different :class:`.Role`, and on
+    which calculations can be run.
+
+    Args:
+        key: A key to identify the group entity.
+        plural: The ``key``, pluralised.
+        label: A summary description.
+        doc: A full description.
+        roles: The list of :class:`.Role` of the group entity.
+        containing_entities: The list of keys of group entities whose 
+            members are guaranteed to be a superset of this group's entities.
+
+    .. versionchanged:: 3.7.0     
+        Added ``containing_entities``, that allows the defining of group entities 
+        which entirely contain other group entities.
+
     """
 
     def __init__(self, key, plural, label, doc, roles, containing_entities = ()):

--- a/openfisca_core/entities/group_entity.py
+++ b/openfisca_core/entities/group_entity.py
@@ -6,7 +6,7 @@ class GroupEntity(Entity):
     Represents an entity composed of several persons with different roles, on which calculations are run.
     """
 
-    def __init__(self, key, plural, label, doc, roles):
+    def __init__(self, key, plural, label, doc, roles, containing_entities = []):
         super().__init__(key, plural, label, doc)
         self.roles_description = roles
         self.roles = []
@@ -23,3 +23,4 @@ class GroupEntity(Entity):
                 role.max = len(role.subroles)
         self.flattened_roles = sum([role2.subroles or [role2] for role2 in self.roles], [])
         self.is_person = False
+        self.containing_entities = containing_entities

--- a/openfisca_core/entities/group_entity.py
+++ b/openfisca_core/entities/group_entity.py
@@ -4,7 +4,7 @@ from openfisca_core.entities import Entity, Role
 class GroupEntity(Entity):
     """Represents an entity containing several other entities with different roles.
 
-    A :class:`.GroupEntity` represents an :class:`.Entity` containing 
+    A :class:`.GroupEntity` represents an :class:`.Entity` containing
     several other :class:`.Entity` with different :class:`.Role`, and on
     which calculations can be run.
 
@@ -14,11 +14,11 @@ class GroupEntity(Entity):
         label: A summary description.
         doc: A full description.
         roles: The list of :class:`.Role` of the group entity.
-        containing_entities: The list of keys of group entities whose 
-            members are guaranteed to be a superset of this group's entities.
+        containing_entities: The list of keys of group entities whose
+        members are guaranteed to be a superset of this group's entities.
 
-    .. versionchanged:: 3.7.0     
-        Added ``containing_entities``, that allows the defining of group entities 
+    .. versionchanged:: 3.7.0
+        Added ``containing_entities``, that allows the defining of group entities
         which entirely contain other group entities.
 
     """

--- a/openfisca_core/entities/group_entity.py
+++ b/openfisca_core/entities/group_entity.py
@@ -15,9 +15,9 @@ class GroupEntity(Entity):
         doc: A full description.
         roles: The list of :class:`.Role` of the group entity.
         containing_entities: The list of keys of group entities whose
-        members are guaranteed to be a superset of this group's entities.
+            members are guaranteed to be a superset of this group's entities.
 
-    .. versionchanged:: 3.7.0
+    .. versionchanged:: 35.7.0
         Added ``containing_entities``, that allows the defining of group entities
         which entirely contain other group entities.
 

--- a/openfisca_core/entities/group_entity.py
+++ b/openfisca_core/entities/group_entity.py
@@ -6,7 +6,7 @@ class GroupEntity(Entity):
     Represents an entity composed of several persons with different roles, on which calculations are run.
     """
 
-    def __init__(self, key, plural, label, doc, roles, containing_entities = []):
+    def __init__(self, key, plural, label, doc, roles, containing_entities = ()):
         super().__init__(key, plural, label, doc)
         self.roles_description = roles
         self.roles = []

--- a/openfisca_core/entities/group_entity.py
+++ b/openfisca_core/entities/group_entity.py
@@ -2,7 +2,7 @@ from openfisca_core.entities import Entity, Role
 
 
 class GroupEntity(Entity):
-    """Represents an entity containing several other entities with different roles.
+    """Represents an entity containing several others with different roles.
 
     A :class:`.GroupEntity` represents an :class:`.Entity` containing
     several other :class:`.Entity` with different :class:`.Role`, and on
@@ -14,12 +14,12 @@ class GroupEntity(Entity):
         label: A summary description.
         doc: A full description.
         roles: The list of :class:`.Role` of the group entity.
-        containing_entities: The list of keys of group entities whose
-            members are guaranteed to be a superset of this group's entities.
+        containing_entities: The list of keys of group entities whose members
+            are guaranteed to be a superset of this group's entities.
 
     .. versionchanged:: 35.7.0
-        Added ``containing_entities``, that allows the defining of group entities
-        which entirely contain other group entities.
+        Added ``containing_entities``, that allows the defining of group
+        entities which entirely contain other group entities.
 
     """
 

--- a/openfisca_core/entities/helpers.py
+++ b/openfisca_core/entities/helpers.py
@@ -1,8 +1,8 @@
 from openfisca_core import entities
 
 
-def build_entity(key, plural, label, doc = "", roles = None, is_person = False, class_override = None):
+def build_entity(key, plural, label, doc = "", roles = None, is_person = False, containing_entities = [], class_override = None):
     if is_person:
         return entities.Entity(key, plural, label, doc)
     else:
-        return entities.GroupEntity(key, plural, label, doc, roles)
+        return entities.GroupEntity(key, plural, label, doc, roles, containing_entities = containing_entities)

--- a/openfisca_core/entities/helpers.py
+++ b/openfisca_core/entities/helpers.py
@@ -1,7 +1,7 @@
 from openfisca_core import entities
 
 
-def build_entity(key, plural, label, doc = "", roles = None, is_person = False, containing_entities = (), class_override = None):
+def build_entity(key, plural, label, doc = "", roles = None, is_person = False, class_override = None, containing_entities = ()):
     if is_person:
         return entities.Entity(key, plural, label, doc)
     else:

--- a/openfisca_core/entities/helpers.py
+++ b/openfisca_core/entities/helpers.py
@@ -1,7 +1,7 @@
 from openfisca_core import entities
 
 
-def build_entity(key, plural, label, doc = "", roles = None, is_person = False, containing_entities = [], class_override = None):
+def build_entity(key, plural, label, doc = "", roles = None, is_person = False, containing_entities = (), class_override = None):
     if is_person:
         return entities.Entity(key, plural, label, doc)
     else:

--- a/openfisca_core/projectors/helpers.py
+++ b/openfisca_core/projectors/helpers.py
@@ -21,3 +21,5 @@ def get_projector_from_shortcut(population, shortcut, parent = None):
         role = next((role for role in population.entity.flattened_roles if (role.max == 1) and (role.key == shortcut)), None)
         if role:
             return projectors.UniqueRoleToEntityProjector(population, role, parent)
+        if shortcut in population.entity.containing_entities:
+            return getattr(projectors.FirstPersonToEntityProjector(population, parent), shortcut)

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,12 +6,13 @@
 ; E501:             We do not enforce a maximum line length.
 ; F403/405:         We ignore * imports.
 ; R0401:            We avoid cyclic imports —required for unit/doc tests.
+; RST301:           We use Google Python Style (see https://pypi.org/project/flake8-rst-docstrings/)
 ; W503/504:         We break lines before binary operators (Knuth's style).
 
 [flake8]
 extend-ignore       = D
 hang-closing        = true
-ignore              = E128,E251,F403,F405,E501,W503,W504
+ignore              = E128,E251,F403,F405,E501,RST301,W503,W504
 in-place            = true
 include-in-doctest  = openfisca_core/commons openfisca_core/types
 rst-directives      = attribute, deprecated, seealso, versionadded, versionchanged

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '35.6.0',
+    version = '35.7.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_formulas.py
+++ b/tests/core/test_formulas.py
@@ -94,3 +94,81 @@ def test_compare_multiplication_and_switch(simulation, month):
     uses_multiplication = simulation.calculate('uses_multiplication', period = month)
     uses_switch = simulation.calculate('uses_switch', period = month)
     assert numpy.all(uses_switch == uses_multiplication)
+
+
+def test_group_encapsulation():
+    from openfisca_core.taxbenefitsystems import TaxBenefitSystem
+    from openfisca_core.entities import build_entity
+    from openfisca_core.periods import ETERNITY
+    person_entity = build_entity(
+        key="person",
+        plural="people",
+        label="A person",
+        is_person=True,
+        )
+    family_entity = build_entity(
+        key="family",
+        plural="families",
+        label="A family (all members in the same household)",
+        containing_entities=["household"],
+        roles=[{
+            "key": "member",
+            "plural": "members",
+            "label": "Member",
+            }]
+        )
+    household_entity = build_entity(
+        key="household",
+        plural="households",
+        label="A household, containing one or more families",
+        roles=[{
+            "key": "member",
+            "plural": "members",
+            "label": "Member",
+            }]
+        )
+
+    entities = [person_entity, family_entity, household_entity]
+
+    system = TaxBenefitSystem(entities)
+
+    class household_level_variable(Variable):
+        value_type = int
+        entity = household_entity
+        definition_period = ETERNITY
+
+    class projected_family_level_variable(Variable):
+        value_type = int
+        entity = family_entity
+        definition_period = ETERNITY
+
+        def formula(family, period):
+            return family.household("household_level_variable", period)
+
+    system.add_variables(household_level_variable, projected_family_level_variable)
+
+    simulation = SimulationBuilder().build_from_dict(system, {
+        "people": {
+            "person1": {},
+            "person2": {},
+            "person3": {}
+            },
+        "families": {
+            "family1": {
+                "members": ["person1", "person2"]
+                },
+            "family2": {
+                "members": ["person3"]
+                },
+            },
+        "households": {
+            "household1": {
+                "members": ["person1", "person2", "person3"],
+                "household_level_variable": {
+                    "eternity": 5
+                    }
+                }
+            }
+        })
+
+    assert (simulation.calculate("projected_family_level_variable", "2021-01-01") == 5).all()

--- a/tests/core/test_formulas.py
+++ b/tests/core/test_formulas.py
@@ -97,9 +97,17 @@ def test_compare_multiplication_and_switch(simulation, month):
 
 
 def test_group_encapsulation():
+    """Projects a calculation to all members of an entity.
+
+    When a household contains more than one family
+    Variables can be defined for the the household
+    And calculations are projected to all the member families.
+
+    """
     from openfisca_core.taxbenefitsystems import TaxBenefitSystem
     from openfisca_core.entities import build_entity
     from openfisca_core.periods import ETERNITY
+
     person_entity = build_entity(
         key="person",
         plural="people",

--- a/tests/core/test_projectors.py
+++ b/tests/core/test_projectors.py
@@ -1,0 +1,86 @@
+from openfisca_core.simulations.simulation_builder import SimulationBuilder
+from openfisca_core.taxbenefitsystems import TaxBenefitSystem
+from openfisca_core.entities import build_entity
+
+def test_shortcut_to_containing_entity_provided():
+    """
+    Tests that, when an entity provides a containing entity,
+    the shortcut to that containing entity is provided.
+    """
+    person_entity = build_entity(
+        key="person",
+        plural="people",
+        label="A person",
+        is_person=True,
+        )
+    family_entity = build_entity(
+        key="family",
+        plural="families",
+        label="A family (all members in the same household)",
+        containing_entities=["household"],
+        roles=[{
+            "key": "member",
+            "plural": "members",
+            "label": "Member",
+            }]
+        )
+    household_entity = build_entity(
+        key="household",
+        plural="households",
+        label="A household, containing one or more families",
+        roles=[{
+            "key": "member",
+            "plural": "members",
+            "label": "Member",
+            }]
+        )
+
+    entities = [person_entity, family_entity, household_entity]
+
+    system = TaxBenefitSystem(entities)
+    simulation = SimulationBuilder().build_from_dict(system, {})
+    assert simulation.populations["family"].household.entity.key == "household"
+
+def test_shortcut_to_containing_entity_not_provided():
+    """
+    Tests that, when an entity doesn't provide a containing 
+    entity, the shortcut to that containing entity is not provided.
+    """
+    person_entity = build_entity(
+        key="person",
+        plural="people",
+        label="A person",
+        is_person=True,
+        )
+    family_entity = build_entity(
+        key="family",
+        plural="families",
+        label="A family (all members in the same household)",
+        containing_entities=[],
+        roles=[{
+            "key": "member",
+            "plural": "members",
+            "label": "Member",
+            }]
+        )
+    household_entity = build_entity(
+        key="household",
+        plural="households",
+        label="A household, containing one or more families",
+        roles=[{
+            "key": "member",
+            "plural": "members",
+            "label": "Member",
+            }]
+        )
+
+    entities = [person_entity, family_entity, household_entity]
+
+    system = TaxBenefitSystem(entities)
+    simulation = SimulationBuilder().build_from_dict(system, {})
+    try:
+        simulation.populations["family"].household
+        assert False
+    except AttributeError:
+        pass
+    

--- a/tests/core/test_projectors.py
+++ b/tests/core/test_projectors.py
@@ -1,6 +1,8 @@
 from openfisca_core.simulations.simulation_builder import SimulationBuilder
 from openfisca_core.taxbenefitsystems import TaxBenefitSystem
 from openfisca_core.entities import build_entity
+from openfisca_core.model_api import Enum, Variable, ETERNITY
+import numpy as np
 
 
 def test_shortcut_to_containing_entity_provided():
@@ -85,3 +87,230 @@ def test_shortcut_to_containing_entity_not_provided():
         raise AssertionError()
     except AttributeError:
         pass
+
+
+def test_enum_projects_downwards():
+    """
+    Test that an Enum-type household-level variable projects
+    values onto its members correctly.
+    """
+
+    person = build_entity(
+        key="person",
+        plural="people",
+        label="A person",
+        is_person=True,
+        )
+    household = build_entity(
+        key="household",
+        plural="households",
+        label="A household",
+        roles=[{
+            "key": "member",
+            "plural": "members",
+            "label": "Member",
+            }]
+        )
+
+    entities = [person, household]
+
+    system = TaxBenefitSystem(entities)
+
+    class enum(Enum):
+        FIRST_OPTION = "First option"
+        SECOND_OPTION = "Second option"
+
+    class household_enum_variable(Variable):
+        value_type = Enum
+        possible_values = enum
+        default_value = enum.FIRST_OPTION
+        entity = household
+        definition_period = ETERNITY
+
+    class projected_enum_variable(Variable):
+        value_type = Enum
+        possible_values = enum
+        default_value = enum.FIRST_OPTION
+        entity = person
+        definition_period = ETERNITY
+
+        def formula(person, period):
+            return person.household("household_enum_variable", period)
+
+    system.add_variables(household_enum_variable, projected_enum_variable)
+
+    simulation = SimulationBuilder().build_from_dict(system, {
+        "people": {
+            "person1": {},
+            "person2": {},
+            "person3": {}
+            },
+        "households": {
+            "household1": {
+                "members": ["person1", "person2", "person3"],
+                "household_enum_variable": {
+                    "eternity": "SECOND_OPTION"
+                    }
+                }
+            }
+        })
+
+    assert (simulation.calculate("projected_enum_variable", "2021-01-01").decode_to_str() == np.array(["SECOND_OPTION"] * 3)).all()
+
+
+def test_enum_projects_upwards():
+    """
+    Test that an Enum-type person-level variable projects
+    values onto its household (from the first person) correctly.
+    """
+
+    person = build_entity(
+        key="person",
+        plural="people",
+        label="A person",
+        is_person=True,
+        )
+    household = build_entity(
+        key="household",
+        plural="households",
+        label="A household",
+        roles=[{
+            "key": "member",
+            "plural": "members",
+            "label": "Member",
+            }]
+        )
+
+    entities = [person, household]
+
+    system = TaxBenefitSystem(entities)
+
+    class enum(Enum):
+        FIRST_OPTION = "First option"
+        SECOND_OPTION = "Second option"
+
+    class household_projected_variable(Variable):
+        value_type = Enum
+        possible_values = enum
+        default_value = enum.FIRST_OPTION
+        entity = household
+        definition_period = ETERNITY
+
+        def formula(household, period):
+            return household.value_from_first_person(household.members("person_enum_variable", period))
+
+    class person_enum_variable(Variable):
+        value_type = Enum
+        possible_values = enum
+        default_value = enum.FIRST_OPTION
+        entity = person
+        definition_period = ETERNITY
+
+    system.add_variables(household_projected_variable, person_enum_variable)
+
+    simulation = SimulationBuilder().build_from_dict(system, {
+        "people": {
+            "person1": {
+                "person_enum_variable": {
+                    "ETERNITY": "SECOND_OPTION"
+                    }
+                },
+            "person2": {},
+            "person3": {}
+            },
+        "households": {
+            "household1": {
+                "members": ["person1", "person2", "person3"],
+                }
+            }
+        })
+
+    assert (simulation.calculate("household_projected_variable", "2021-01-01").decode_to_str() == np.array(["SECOND_OPTION"])).all()
+
+
+def test_enum_projects_between_containing_groups():
+    """
+    Test that an Enum-type person-level variable projects
+    values onto its household (from the first person) correctly.
+    """
+
+    person_entity = build_entity(
+        key="person",
+        plural="people",
+        label="A person",
+        is_person=True,
+        )
+    family_entity = build_entity(
+        key="family",
+        plural="families",
+        label="A family (all members in the same household)",
+        containing_entities=["household"],
+        roles=[{
+            "key": "member",
+            "plural": "members",
+            "label": "Member",
+            }]
+        )
+    household_entity = build_entity(
+        key="household",
+        plural="households",
+        label="A household, containing one or more families",
+        roles=[{
+            "key": "member",
+            "plural": "members",
+            "label": "Member",
+            }]
+        )
+
+    entities = [person_entity, family_entity, household_entity]
+
+    system = TaxBenefitSystem(entities)
+
+    class enum(Enum):
+        FIRST_OPTION = "First option"
+        SECOND_OPTION = "Second option"
+
+    class household_level_variable(Variable):
+        value_type = Enum
+        possible_values = enum
+        default_value = enum.FIRST_OPTION
+        entity = household_entity
+        definition_period = ETERNITY
+
+    class projected_family_level_variable(Variable):
+        value_type = Enum
+        possible_values = enum
+        default_value = enum.FIRST_OPTION
+        entity = family_entity
+        definition_period = ETERNITY
+
+        def formula(family, period):
+            return family.household("household_level_variable", period)
+
+    system.add_variables(household_level_variable, projected_family_level_variable)
+
+    simulation = SimulationBuilder().build_from_dict(system, {
+        "people": {
+            "person1": {},
+            "person2": {},
+            "person3": {}
+            },
+        "families": {
+            "family1": {
+                "members": ["person1", "person2"]
+                },
+            "family2": {
+                "members": ["person3"]
+                },
+            },
+        "households": {
+            "household1": {
+                "members": ["person1", "person2", "person3"],
+                "household_level_variable": {
+                    "eternity": "SECOND_OPTION"
+                    }
+                }
+            }
+        })
+
+    assert (simulation.calculate("projected_family_level_variable", "2021-01-01").decode_to_str() == np.array(["SECOND_OPTION"])).all()

--- a/tests/core/test_projectors.py
+++ b/tests/core/test_projectors.py
@@ -2,6 +2,7 @@ from openfisca_core.simulations.simulation_builder import SimulationBuilder
 from openfisca_core.taxbenefitsystems import TaxBenefitSystem
 from openfisca_core.entities import build_entity
 
+
 def test_shortcut_to_containing_entity_provided():
     """
     Tests that, when an entity provides a containing entity,
@@ -41,9 +42,10 @@ def test_shortcut_to_containing_entity_provided():
     simulation = SimulationBuilder().build_from_dict(system, {})
     assert simulation.populations["family"].household.entity.key == "household"
 
+
 def test_shortcut_to_containing_entity_not_provided():
     """
-    Tests that, when an entity doesn't provide a containing 
+    Tests that, when an entity doesn't provide a containing
     entity, the shortcut to that containing entity is not provided.
     """
     person_entity = build_entity(
@@ -80,7 +82,6 @@ def test_shortcut_to_containing_entity_not_provided():
     simulation = SimulationBuilder().build_from_dict(system, {})
     try:
         simulation.populations["family"].household
-        assert False
+        raise AssertionError()
     except AttributeError:
         pass
-    


### PR DESCRIPTION
Hope this is useful - this fixes #1041 , by adding a shortcut to a containing group entity provided. I've added a test to `test_formulas`.

Essentially, say we have three entities, person, family and household, and we know that all members of a family will be in the same household (but not necessarily vice-versa). Say we also have a variable `household_level_variable` at the household level, and we want to project the result of that variable to the contained families. Currently, I think we have to use:

```python
family_level_variable = family.value_from_first_person(family.members.household("household_level_variable", period))
```

With this, we can instead use:

```python
family_level_variable = family.household("household_level_variable", period)
```

provided, that when we defined the family entity (using either `build_entity` or the `Entity` class), we set the optional keyword argument `containing_entities = ["household"]`.