### PR TITLE
Add install wheel to build

### DIFF
--- a/openfisca_tasks/publish.mk
+++ b/openfisca_tasks/publish.mk
@@ -1,3 +1,5 @@
+.PHONY: build
+
 ## Install openfisca-core for deployment and publishing.
 build:
 	@## This allows us to be sure tests are run against the packaged version

--- a/openfisca_tasks/publish.mk
+++ b/openfisca_tasks/publish.mk
@@ -4,6 +4,6 @@ build:
 	@## of openfisca-core, the same we put in the hands of users and reusers.
 	@$(call print_help,$@:)
 	@pip install --upgrade pip build twine
-	@python setup.py bdist_wheel
+	@python -m build
 	@find dist -name "*.whl" -exec pip install --force-reinstall {}[dev] \;
 	@$(call print_pass,$@:)

--- a/openfisca_tasks/publish.mk
+++ b/openfisca_tasks/publish.mk
@@ -5,5 +5,6 @@ build:
 	@$(call print_help,$@:)
 	@pip install --upgrade pip build twine
 	@python -m build
-	@find dist -name "*.whl" -exec pip install --force-reinstall {}[dev] \;
+        @pip uninstall --yes openfisca-core
+        @find dist -name "*.whl" -exec pip install {}[dev] \;
 	@$(call print_pass,$@:)

--- a/openfisca_tasks/publish.mk
+++ b/openfisca_tasks/publish.mk
@@ -3,7 +3,7 @@ build:
 	@## This allows us to be sure tests are run against the packaged version
 	@## of openfisca-core, the same we put in the hands of users and reusers.
 	@$(call print_help,$@:)
-	@pip install --upgrade pip twine wheel
+	@pip install --upgrade pip build twine
 	@python setup.py bdist_wheel
 	@find dist -name "*.whl" -exec pip install --force-reinstall {}[dev] \;
 	@$(call print_pass,$@:)

--- a/openfisca_tasks/publish.mk
+++ b/openfisca_tasks/publish.mk
@@ -3,6 +3,7 @@ build:
 	@## This allows us to be sure tests are run against the packaged version
 	@## of openfisca-core, the same we put in the hands of users and reusers.
 	@$(call print_help,$@:)
+	@pip install --upgrade pip twine wheel
 	@python setup.py bdist_wheel
 	@find dist -name "*.whl" -exec pip install --force-reinstall {}[dev] \;
 	@$(call print_pass,$@:)

--- a/openfisca_tasks/publish.mk
+++ b/openfisca_tasks/publish.mk
@@ -5,6 +5,6 @@ build:
 	@$(call print_help,$@:)
 	@pip install --upgrade pip build twine
 	@python -m build
-        @pip uninstall --yes openfisca-core
-        @find dist -name "*.whl" -exec pip install {}[dev] \;
+	@pip uninstall --yes openfisca-core
+	@find dist -name "*.whl" -exec pip install {}[dev] \;
 	@$(call print_pass,$@:)


### PR DESCRIPTION
The GitHub Actions set-up was merged and the build[ failed](https://github.com/openfisca/openfisca-core/runs/4078138534?check_suite_focus=true) with an `error: invalid command 'bdist_wheel`.

This PR installs the `wheel` package in the `build`.
