### PR TITLE
Fix message bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 35.7.3 [#1081](https://github.com/openfisca/openfisca-core/pull/1081)
 
-- Fix misnamed attribute in mis-sized population error message
+- Correct error message in case of mis-sized population 
 
 ### 35.7.2 [#1057](https://github.com/openfisca/openfisca-core/pull/1057)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 35.7.3 [#1081](https://github.com/openfisca/openfisca-core/pull/1081)
+
+- Fix misnamed attribute in mis-sized population error message
+
 ### 35.7.2 [#1057](https://github.com/openfisca/openfisca-core/pull/1057)
 
 #### Technical changes

--- a/openfisca_core/populations/population.py
+++ b/openfisca_core/populations/population.py
@@ -44,7 +44,7 @@ class Population:
     def check_array_compatible_with_entity(self, array):
         if not self.count == array.size:
             raise ValueError("Input {} is not a valid value for the entity {} (size = {} != {} = count)".format(
-                array, self.key, array.size, self.count))
+                array, self.entity.key, array.size, self.count))
 
     def check_period_validity(self, variable_name, period):
         if period is None:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '35.7.2',
+    version = '35.7.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
This should fix #1072 . I'll add version change information, but the action seemed to fail quite quickly for some reason.

#### Technical changes

- Use `self.entity.key` rather than `self.key` when generating an error message for a mis-sized population array.