### PR TITLE
Remove calls to deprecated imp module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 35.7.5 [#1090](https://github.com/openfisca/openfisca-core/pull/1090)
+
+#### Technical changes
+
+- Remove calls to deprecated imp module
+
 ### 35.7.4 [#1083](https://github.com/openfisca/openfisca-core/pull/1083)
 
 #### Technical changes

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '35.7.4',
+    version = '35.7.5',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
#### Technical changes

- Replace calls to deprecated `imp` module with `importlib` and `sys`. Fixes #1053.

I successfully ran `make test` locally.


Reopening #1087 cause of merge commit