### PR TITLE
Draft: Publish to Anaconda

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,0 +1,38 @@
+package:
+  name: "openfisca-core"
+  version: "0.0.1"
+
+source:
+  url: https://pypi.io/packages/source/O/OpenFisca-Core/OpenFisca-Core-35.7.5.tar.gz
+  #path: ..
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+  # script: python setup.py install
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+  run:
+    - python >=3.6
+    - dpath ==2.0.5
+    - nptyping ==1.4.4
+    - numexpr >=2.7.0,<=3.0
+    - numpy >=1.11,<1.21
+    - psutil >=5.4.7,<6.0.0
+    - pytest >=4.4.1,<6.0.0  # For openfisca test
+    - PyYAML >=3.10
+    - sortedcontainers ==2.2.2
+    - typing-extensions ==3.10.0.2
+
+about:
+  home: https://openfisca.org
+  license: AGPL-3.0
+  license_file: LICENSE
+  summary: "A versatile microsimulation free software"
+
+


### PR DESCRIPTION
I achieve to upload OpenFisca-Core on Anaconda : https://anaconda.org/leximpact/openfisca-core

#### New features

- Introduce a way to add OpenFisca to [Anaconda](https://www.anaconda.com/)

#### Technical changes

- Add conda/meta.yaml
- Add CI to publish to [Conda Forge](https://conda-forge.org/)



#### What I've done so far
- Add `conda/meta.yaml` in the project
- `docker run --rm -t -i -v $PWD:/src continuumio/miniconda3 /bin/bash`
  - `cd /src`
  - `conda install conda-build`
  - `conda build -c conda-forge --output-folder ./conda-out/ ./conda/`
  - `conda install anaconda-client`
  - `anaconda login`
  - `anaconda upload ./conda-out/noarch/openfisca-core-0.0.1-py_0.tar.bz2`

#### Please note that
- Unlike PiPy, the package name must be lowercase.
- dpath >=1.5.0,<2.0.0' don't exist in conda-forge, only 1.4 or >2.0.1, so I use 
- It is an early work, I have to look at different options to add it to the CI

Tutorials used:
- https://medium.com/analytics-vidhya/publish-a-python-package-to-conda-b352eb0bcb2e

BUT this easy way publish the package in a specific "channel" of Anaconda, to be on conda-forge, we need to use another procedure:
For publishing to Conda-Forge, we have to fork a project and made a PR back to it. There is automated build in Linux, OSX and Windows: https://github.com/conda-forge/staged-recipes/pull/17399
 - "Propose the change as a pull request. Your recipe will automatically be built on Windows, Linux, and OSX to test that it works, but the distribution will not yet be available on the conda-forge channel."
- "Once the recipe is ready it will be merged and a new "feedstock" repository will automatically be created for the recipe. The build and upload processes take place in the feedstock, and once complete the package will be available on the conda-forge channel."

A chat is available for conda-forge integration at https://gitter.im/conda-forge/conda-forge.github.io

#### TODO

- [x] Create a PR: https://github.com/openfisca/openfisca-core/pull/1099
- [x] Create an OpenFisca account on Conda Forge, to use it instead of LexImpact. => Not needed for feedstock ?
- [ ] Upgrade dpath : https://github.com/openfisca/openfisca-core/pull/1065
- [ ] Make a new repo https://github.com/conda-forge/staged-recipes/pull/17399
- [ ] For conda-forge there is a way to use the pypi package source: https://blog.gishub.org/how-to-publish-a-python-package-on-conda-forge
- [ ] Add the build to the CI
- [ ] Use Jinja to use env variable as version https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#templating-with-jinja