### PR TITLE
Fix Web API after Flask dependencies updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### [#1109](https://github.com/openfisca/openfisca-core/pull/1109)
+### 35.7.7 [#1109](https://github.com/openfisca/openfisca-core/pull/1109)
 
 #### Technical changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### [#1109](https://github.com/openfisca/openfisca-core/pull/1109)
+
+#### Technical changes
+
+- Fix `openfisca-core` Web API error triggered by `Flask` dependencies updates
+  - Bump `Flask` patch revision to fix `cannot import name 'json' from 'itsdangerous'` on Web API.
+  - Then, fix `MarkupSafe` revision to avoid `cannot import name 'soft_unicode' from 'markupsafe'` error on Web API.
+
 ### 35.7.6 [#1065](https://github.com/openfisca/openfisca-core/pull/1065)
 
 #### Technical changes

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ general_requirements = [
     ]
 
 api_requirements = [
+    'markupsafe == 2.0.1',  # While flask revision < 2
     'flask == 1.1.4',
     'flask-cors == 3.0.10',
     'gunicorn >= 20.0.0, < 21.0.0',

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '35.7.6',
+    version = '35.7.7',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ general_requirements = [
     ]
 
 api_requirements = [
-    'flask == 1.1.2',
+    'flask == 1.1.4',
     'flask-cors == 3.0.10',
     'gunicorn >= 20.0.0, < 21.0.0',
     'werkzeug >= 1.0.0, < 2.0.0',


### PR DESCRIPTION
Connected to openfisca/openfisca-france#1808 where [test-api job fails](https://github.com/openfisca/openfisca-france/runs/5247747400?check_suite_focus=true) on GitHub Actions.


#### Technical changes

- Fix `openfisca-core` Web API error triggered by `Flask` dependencies updates
  - Bump `Flask` patch revision to fix `cannot import name 'json' from 'itsdangerous'` on Web API.
  - Then, fix `MarkupSafe` revision to avoid `cannot import name 'soft_unicode' from 'markupsafe'` error on Web API.



#### Details


This PR fixes two issues:

**🐛`itsdangerous` revision fixed by `flask` upgrade**

This first one is about `itsdangerous` and was detected by the [test-api job](https://github.com/openfisca/openfisca-france/runs/5247747400?check_suite_focus=true): 
```shell
ImportError: OpenFisca is missing some dependencies to run the Web API: 'cannot import name 'json' from 'itsdangerous' (/opt/hostedtoolcache/Python/3.7.9/x64/lib/python3.7/site-packages/itsdangerous/__init__.py)'. To install them, run `pip install openfisca_core[web-api]`.
```

While, thanks to `pipdeptree` library we can see that:
```shell
$ pipdeptree -r --packages itsdangerous
(...)
itsdangerous==2.1.0 ⬅
  - Flask==1.1.2 [requires: itsdangerous>=0.24] ⬅
    - Flask-Cors==3.0.10 [requires: Flask>=0.9]
```
This was checked on `master` branch, openfisca-core v35.7.6.

Updating Flask to [its last v1.x.x revision which is 1.1.4](https://pypi.org/project/Flask/1.1.4/#history) resolves the issue (as described by [this post in another context](https://serverfault.com/a/1094095))

itsdangerous max revision is fixed and 2.1.0 becomes 1.1.0:
```shell
$ pipdeptree -r --packages itsdangerous
(...)
itsdangerous==1.1.0 ⬅
  - Flask==1.1.4 [requires: itsdangerous>=0.24,<2.0] ⬅
    - Flask-Cors==3.0.10 [requires: Flask>=0.9]
```

But Flask 1.1.2 to 1.1.4 raises a new `MarkupSafe` error.

**🐛 `markupsafe` revision**


The following error was detected after Flask update and by [this job of this PR](https://github.com/openfisca/openfisca-core/runs/5275853382?check_suite_focus=true):
```shell
ImportError: Error importing plugin "tests.fixtures.appclient": OpenFisca is missing some dependencies to run the Web API: 'cannot import name 'soft_unicode' from 'markupsafe' (/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/markupsafe/__init__.py)'. To install them, run `pip install openfisca_core[web-api]`.
```

Knowing that `markupsafe` is a subdependency of `flask`:
```shell
$ pipdeptree -r --packages markupsafe
(...)
MarkupSafe==2.1.0 ⬅
  - Jinja2==2.11.3 [requires: MarkupSafe>=0.23]
    - Flask==1.1.4 [requires: Jinja2>=2.10.1,<3.0] ⬅
      - Flask-Cors==3.0.10 [requires: Flask>=0.9]
```

So, the question might be: should we bump `markupsafe` or `jinja`?

As the previous `Flask==1.1.2` also requires `MarkupSafe==2.1.0` through `Jinja2==3.0.3`:
```shell
$ pipdeptree -r --packages markupsafe
Warning!!! Possibly conflicting dependencies found:
(...)
MarkupSafe==2.1.0
  - Jinja2==3.0.3 [requires: MarkupSafe>=2.0]
    - Flask==1.1.2 [requires: Jinja2>=2.10.1]
      - Flask-Cors==3.0.10 [requires: Flask>=0.9]
```
The solution might neither be in returning to `flask` v1.1.2 nor bumping `jinja` revision to v3.
So, this PR suggests to fix `markupsafe` revision for now (as suggested by [this markupsafe issue](https://github.com/pallets/markupsafe/issues/284)) and removing this fix when `flask` is updated to v2+.


Finally you might ask why we didn't update Flask to v2+.
This was suggested by dependabot [here](https://github.com/openfisca/openfisca-core/pull/1108). This major bump might require syntax checks and the CI fails on another error (`pytest: not found` 🙃). This looks like a misleading old cache. So the choice made here was to fix Flask 1.x.x. usage and to tackle the Flask 2.x.x / CI issue in a next PR. 

