### PR TITLE
Feat add rate from bracket indice method to rate tax scale like

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Introduce `rate_from_bracket_indice` method on `RateTaxScaleLike` class
   - Allows for the determination of the tax rate based on the tax bracket indice
 
+- Introduce `rate_from_tax_base` method on `RateTaxScaleLike` class
+  - Allows for the determination of the tax rate based on the tax base
+
+- Introduce `threshold_from_tax_base` method on `RateTaxScaleLike` class
+  - Allows for the determination of the lower threshold based on the tax base
 
 ### 35.7.8 [#1086](https://github.com/openfisca/openfisca-core/pull/1086)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### [#1114](https://github.com/openfisca/openfisca-core/pull/1114)
+
+#### New Features
+
+- Introduce `rate_from_bracket_indice` method on `RateTaxScaleLike` class
+  - Allows for the determination of the tax rate based on the tax bracket indice
+
+
 ### 35.7.8 [#1086](https://github.com/openfisca/openfisca-core/pull/1086)
 
 #### Technical changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### [#1114](https://github.com/openfisca/openfisca-core/pull/1114)
+### 35.8.0 [#1114](https://github.com/openfisca/openfisca-core/pull/1114)
 
 #### New Features
 

--- a/openfisca_core/taxscales/marginal_rate_tax_scale.py
+++ b/openfisca_core/taxscales/marginal_rate_tax_scale.py
@@ -148,6 +148,65 @@ class MarginalRateTaxScale(RateTaxScaleLike):
 
         return numpy.array(self.rates)[bracket_indices]
 
+    def rate_from_bracket_indice(
+            self,
+            bracket_indice: numpy.int_,
+            ) -> numpy.float_:
+        """
+        Compute the relevant tax rates for the given bracket indices.
+
+        :param: ndarray bracket_indice: Array of the bracket indices.
+
+        :returns: Floating array with relevant tax rates
+                  for the given bracket indices.
+
+        For instance:
+
+        >>> tax_scale = MarginalRateTaxScale()
+        >>> tax_scale.add_bracket(0, 0)
+        >>> tax_scale.add_bracket(200, 0.1)
+        >>> tax_scale.add_bracket(500, 0.25)
+        >>> tax_base = array([50, 150, 1_000])
+        >>> bracket_indice = tax_scale.bracket_indices(tax_base)
+        >>> tax_scale.rate_from_bracket_indice(bracket_indice)
+        [0., 0., 0.25]
+        """
+
+        if bracket_indice.max() > len(self.rates) - 1:
+            raise IndexError(
+                f"bracket_indice parameter ({bracket_indice}) "
+                f"contains one or more bracket indice which is unavailable "
+                f"inside current {self.__class__.__name__} :\n"
+                f"{self}"
+                )
+
+        return numpy.array(self.rates)[bracket_indice]
+
+    def rate_from_tax_base(
+            self,
+            tax_base: NumericalArray,
+            ) -> numpy.float_:
+        """
+        Compute the relevant tax rates for the given tax bases.
+
+        :param: ndarray tax_base: Array of the tax bases.
+
+        :returns: Floating array with relevant tax rates
+                  for the given tax bases.
+
+        For instance:
+
+        >>> tax_scale = MarginalRateTaxScale()
+        >>> tax_scale.add_bracket(0, 0)
+        >>> tax_scale.add_bracket(200, 0.1)
+        >>> tax_scale.add_bracket(500, 0.25)
+        >>> tax_base = array([50, 150, 1_000])
+        >>> tax_scale.rate_from_tax_base(tax_base)
+        [0., 0., 0.25]
+        """
+
+        return self.rate_from_bracket_indice(self.bracket_indices(tax_base))
+
     def inverse(self) -> MarginalRateTaxScale:
         """
         Returns a new instance of MarginalRateTaxScale.

--- a/openfisca_core/taxscales/marginal_rate_tax_scale.py
+++ b/openfisca_core/taxscales/marginal_rate_tax_scale.py
@@ -162,14 +162,15 @@ class MarginalRateTaxScale(RateTaxScaleLike):
 
         For instance:
 
+        >>> import numpy
         >>> tax_scale = MarginalRateTaxScale()
         >>> tax_scale.add_bracket(0, 0)
         >>> tax_scale.add_bracket(200, 0.1)
         >>> tax_scale.add_bracket(500, 0.25)
-        >>> tax_base = array([50, 150, 1_000])
+        >>> tax_base = numpy.array([50, 1_000, 250])
         >>> bracket_indice = tax_scale.bracket_indices(tax_base)
         >>> tax_scale.rate_from_bracket_indice(bracket_indice)
-        [0., 0., 0.25]
+        array([0.  , 0.25, 0.1 ])
         """
 
         if bracket_indice.max() > len(self.rates) - 1:
@@ -196,13 +197,14 @@ class MarginalRateTaxScale(RateTaxScaleLike):
 
         For instance:
 
+        >>> import numpy
         >>> tax_scale = MarginalRateTaxScale()
         >>> tax_scale.add_bracket(0, 0)
         >>> tax_scale.add_bracket(200, 0.1)
         >>> tax_scale.add_bracket(500, 0.25)
-        >>> tax_base = array([50, 150, 1_000])
+        >>> tax_base = numpy.array([1_000, 50, 450])
         >>> tax_scale.rate_from_tax_base(tax_base)
-        [0., 0., 0.25]
+        array([0.25, 0.  , 0.1 ])
         """
 
         return self.rate_from_bracket_indice(self.bracket_indices(tax_base))

--- a/openfisca_core/taxscales/rate_tax_scale_like.py
+++ b/openfisca_core/taxscales/rate_tax_scale_like.py
@@ -244,6 +244,31 @@ class RateTaxScaleLike(TaxScaleLike, abc.ABC):
 
         return self.rate_from_bracket_indice(self.bracket_indices(tax_base))
 
+    def threshold_from_tax_base(
+            self,
+            tax_base: NumericalArray,
+            ) -> NumericalArray:
+        """
+        Compute the relevant thresholds for the given tax bases.
+
+        :param: ndarray tax_base: Array of the tax bases.
+
+        :returns: Floating array with relevant thresholds
+                  for the given tax bases.
+
+        For instance:
+
+        >>> tax_scale = MarginalRateTaxScale()
+        >>> tax_scale.add_bracket(0, 0)
+        >>> tax_scale.add_bracket(200, 0.1)
+        >>> tax_scale.add_bracket(500, 0.25)
+        >>> tax_base = array([50, 150, 1_000])
+        >>> tax_scale.threshold_from_tax_base(tax_base)
+        [0., 0., 500.]
+        """
+
+        return numpy.array(self.thresholds)[self.bracket_indices(tax_base)]
+
     def to_dict(self) -> dict:
         return {
             str(threshold): self.rates[index]

--- a/openfisca_core/taxscales/rate_tax_scale_like.py
+++ b/openfisca_core/taxscales/rate_tax_scale_like.py
@@ -185,6 +185,40 @@ class RateTaxScaleLike(TaxScaleLike, abc.ABC):
 
         return (base1 - thresholds1 >= 0).sum(axis = 1) - 1
 
+    def rate_from_bracket_indice(
+            self,
+            bracket_indice: numpy.int_,
+            ) -> numpy.float_:
+        """
+        Compute the relevant tax rates for the given bracket indices.
+
+        :param: ndarray bracket_indice: Array of the bracket indices.
+
+        :returns: Floating array with relevant tax rates
+                  for the given bracket indices.
+
+        For instance:
+
+        >>> tax_scale = MarginalRateTaxScale()
+        >>> tax_scale.add_bracket(0, 0)
+        >>> tax_scale.add_bracket(200, 0.1)
+        >>> tax_scale.add_bracket(500, 0.25)
+        >>> tax_base = array([50, 150, 1_000])
+        >>> bracket_indice = tax_scale.bracket_indices(tax_base)
+        >>> tax_scale.rate_from_bracket_indice(bracket_indice)
+        [0., 0., 0.25]
+        """
+
+        if bracket_indice.max() > len(self.rates) - 1:
+            raise IndexError(
+                f"bracket_indice parameter ({bracket_indice}) "
+                f"contains one or more bracket indice which is unavailable "
+                f"inside current {self.__class__.__name__} :\n"
+                f"{self}"
+                )
+
+        return numpy.array(self.rates)[bracket_indice]
+
     def to_dict(self) -> dict:
         return {
             str(threshold): self.rates[index]

--- a/openfisca_core/taxscales/rate_tax_scale_like.py
+++ b/openfisca_core/taxscales/rate_tax_scale_like.py
@@ -219,6 +219,31 @@ class RateTaxScaleLike(TaxScaleLike, abc.ABC):
 
         return numpy.array(self.rates)[bracket_indice]
 
+    def rate_from_tax_base(
+            self,
+            tax_base: NumericalArray,
+            ) -> numpy.float_:
+        """
+        Compute the relevant tax rates for the given tax bases.
+
+        :param: ndarray tax_base: Array of the tax bases.
+
+        :returns: Floating array with relevant tax rates
+                  for the given tax bases.
+
+        For instance:
+
+        >>> tax_scale = MarginalRateTaxScale()
+        >>> tax_scale.add_bracket(0, 0)
+        >>> tax_scale.add_bracket(200, 0.1)
+        >>> tax_scale.add_bracket(500, 0.25)
+        >>> tax_base = array([50, 150, 1_000])
+        >>> tax_scale.rate_from_tax_base(tax_base)
+        [0., 0., 0.25]
+        """
+
+        return self.rate_from_bracket_indice(self.bracket_indices(tax_base))
+
     def to_dict(self) -> dict:
         return {
             str(threshold): self.rates[index]

--- a/openfisca_core/taxscales/rate_tax_scale_like.py
+++ b/openfisca_core/taxscales/rate_tax_scale_like.py
@@ -185,65 +185,6 @@ class RateTaxScaleLike(TaxScaleLike, abc.ABC):
 
         return (base1 - thresholds1 >= 0).sum(axis = 1) - 1
 
-    def rate_from_bracket_indice(
-            self,
-            bracket_indice: numpy.int_,
-            ) -> numpy.float_:
-        """
-        Compute the relevant tax rates for the given bracket indices.
-
-        :param: ndarray bracket_indice: Array of the bracket indices.
-
-        :returns: Floating array with relevant tax rates
-                  for the given bracket indices.
-
-        For instance:
-
-        >>> tax_scale = MarginalRateTaxScale()
-        >>> tax_scale.add_bracket(0, 0)
-        >>> tax_scale.add_bracket(200, 0.1)
-        >>> tax_scale.add_bracket(500, 0.25)
-        >>> tax_base = array([50, 150, 1_000])
-        >>> bracket_indice = tax_scale.bracket_indices(tax_base)
-        >>> tax_scale.rate_from_bracket_indice(bracket_indice)
-        [0., 0., 0.25]
-        """
-
-        if bracket_indice.max() > len(self.rates) - 1:
-            raise IndexError(
-                f"bracket_indice parameter ({bracket_indice}) "
-                f"contains one or more bracket indice which is unavailable "
-                f"inside current {self.__class__.__name__} :\n"
-                f"{self}"
-                )
-
-        return numpy.array(self.rates)[bracket_indice]
-
-    def rate_from_tax_base(
-            self,
-            tax_base: NumericalArray,
-            ) -> numpy.float_:
-        """
-        Compute the relevant tax rates for the given tax bases.
-
-        :param: ndarray tax_base: Array of the tax bases.
-
-        :returns: Floating array with relevant tax rates
-                  for the given tax bases.
-
-        For instance:
-
-        >>> tax_scale = MarginalRateTaxScale()
-        >>> tax_scale.add_bracket(0, 0)
-        >>> tax_scale.add_bracket(200, 0.1)
-        >>> tax_scale.add_bracket(500, 0.25)
-        >>> tax_base = array([50, 150, 1_000])
-        >>> tax_scale.rate_from_tax_base(tax_base)
-        [0., 0., 0.25]
-        """
-
-        return self.rate_from_bracket_indice(self.bracket_indices(tax_base))
-
     def threshold_from_tax_base(
             self,
             tax_base: NumericalArray,

--- a/openfisca_core/taxscales/rate_tax_scale_like.py
+++ b/openfisca_core/taxscales/rate_tax_scale_like.py
@@ -199,13 +199,15 @@ class RateTaxScaleLike(TaxScaleLike, abc.ABC):
 
         For instance:
 
-        >>> tax_scale = MarginalRateTaxScale()
+        >>> import numpy
+        >>> from openfisca_core import taxscales
+        >>> tax_scale = taxscales.MarginalRateTaxScale()
         >>> tax_scale.add_bracket(0, 0)
         >>> tax_scale.add_bracket(200, 0.1)
         >>> tax_scale.add_bracket(500, 0.25)
-        >>> tax_base = array([50, 150, 1_000])
+        >>> tax_base = numpy.array([450, 1_150, 10])
         >>> tax_scale.threshold_from_tax_base(tax_base)
-        [0., 0., 500.]
+        array([200, 500,   0])
         """
 
         return numpy.array(self.thresholds)[self.bracket_indices(tax_base)]

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '35.7.8',
+    version = '35.8.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/tax_scales/test_marginal_rate_tax_scale.py
+++ b/tests/core/tax_scales/test_marginal_rate_tax_scale.py
@@ -223,3 +223,17 @@ def test_to_average():
         [0, 0.0375, 0.1, 0.125],
         absolute_error_margin = 1e-10,
         )
+
+
+def test_rate_from_bracket_indice():
+    tax_base = numpy.array([0, 1_000, 1_500, 50_000])
+    tax_scale = taxscales.MarginalRateTaxScale()
+    tax_scale.add_bracket(0, 0)
+    tax_scale.add_bracket(400, 0.1)
+    tax_scale.add_bracket(15_000, 0.4)
+
+    bracket_indice = tax_scale.bracket_indices(tax_base)
+    result = tax_scale.rate_from_bracket_indice(bracket_indice)
+
+    assert isinstance(result, numpy.ndarray)
+    assert (result == numpy.array([0., 0.1, 0.1, 0.4])).all()

--- a/tests/core/tax_scales/test_marginal_rate_tax_scale.py
+++ b/tests/core/tax_scales/test_marginal_rate_tax_scale.py
@@ -223,17 +223,3 @@ def test_to_average():
         [0, 0.0375, 0.1, 0.125],
         absolute_error_margin = 1e-10,
         )
-
-
-def test_rate_from_bracket_indice():
-    tax_base = numpy.array([0, 1_000, 1_500, 50_000])
-    tax_scale = taxscales.MarginalRateTaxScale()
-    tax_scale.add_bracket(0, 0)
-    tax_scale.add_bracket(400, 0.1)
-    tax_scale.add_bracket(15_000, 0.4)
-
-    bracket_indice = tax_scale.bracket_indices(tax_base)
-    result = tax_scale.rate_from_bracket_indice(bracket_indice)
-
-    assert isinstance(result, numpy.ndarray)
-    assert (result == numpy.array([0., 0.1, 0.1, 0.4])).all()

--- a/tests/core/tax_scales/test_marginal_rate_tax_scale.py
+++ b/tests/core/tax_scales/test_marginal_rate_tax_scale.py
@@ -223,3 +223,31 @@ def test_to_average():
         [0, 0.0375, 0.1, 0.125],
         absolute_error_margin = 1e-10,
         )
+
+
+def test_rate_from_bracket_indice():
+    tax_base = numpy.array([0, 1_000, 1_500, 50_000])
+    tax_scale = taxscales.MarginalRateTaxScale()
+    tax_scale.add_bracket(0, 0)
+    tax_scale.add_bracket(400, 0.1)
+    tax_scale.add_bracket(15_000, 0.4)
+
+    bracket_indice = tax_scale.bracket_indices(tax_base)
+    result = tax_scale.rate_from_bracket_indice(bracket_indice)
+
+    assert isinstance(result, numpy.ndarray)
+    assert (result == numpy.array([0., 0.1, 0.1, 0.4])).all()
+
+
+def test_rate_from_tax_base():
+    tax_base = numpy.array([0, 3_000, 15_500, 500_000])
+    tax_scale = taxscales.MarginalRateTaxScale()
+    tax_scale.add_bracket(0, 0)
+    tax_scale.add_bracket(400, 0.1)
+    tax_scale.add_bracket(15_000, 0.4)
+    tax_scale.add_bracket(200_000, 0.6)
+
+    result = tax_scale.rate_from_tax_base(tax_base)
+
+    assert isinstance(result, numpy.ndarray)
+    assert (result == numpy.array([0., 0.1, 0.4, 0.6])).all()

--- a/tests/core/tax_scales/test_rate_tax_scale_like.py
+++ b/tests/core/tax_scales/test_rate_tax_scale_like.py
@@ -3,34 +3,6 @@ import numpy
 from openfisca_core import taxscales
 
 
-def test_rate_from_bracket_indice():
-    tax_base = numpy.array([0, 1_000, 1_500, 50_000])
-    tax_scale = taxscales.MarginalRateTaxScale()
-    tax_scale.add_bracket(0, 0)
-    tax_scale.add_bracket(400, 0.1)
-    tax_scale.add_bracket(15_000, 0.4)
-
-    bracket_indice = tax_scale.bracket_indices(tax_base)
-    result = tax_scale.rate_from_bracket_indice(bracket_indice)
-
-    assert isinstance(result, numpy.ndarray)
-    assert (result == numpy.array([0., 0.1, 0.1, 0.4])).all()
-
-
-def test_rate_from_tax_base():
-    tax_base = numpy.array([0, 3_000, 15_500, 500_000])
-    tax_scale = taxscales.MarginalRateTaxScale()
-    tax_scale.add_bracket(0, 0)
-    tax_scale.add_bracket(400, 0.1)
-    tax_scale.add_bracket(15_000, 0.4)
-    tax_scale.add_bracket(200_000, 0.6)
-
-    result = tax_scale.rate_from_tax_base(tax_base)
-
-    assert isinstance(result, numpy.ndarray)
-    assert (result == numpy.array([0., 0.1, 0.4, 0.6])).all()
-
-
 def test_threshold_from_tax_base():
     tax_base = numpy.array([0, 33_000, 500, 400_000])
     tax_scale = taxscales.LinearAverageRateTaxScale()

--- a/tests/core/tax_scales/test_rate_tax_scale_like.py
+++ b/tests/core/tax_scales/test_rate_tax_scale_like.py
@@ -1,0 +1,18 @@
+import numpy
+
+from openfisca_core import taxscales
+
+
+def test_rate_from_bracket_indice():
+    tax_base = numpy.array([0, 1_000, 1_500, 50_000])
+    tax_scale = taxscales.MarginalRateTaxScale()
+    tax_scale.add_bracket(0, 0)
+    tax_scale.add_bracket(400, 0.1)
+    tax_scale.add_bracket(15_000, 0.4)
+
+    bracket_indice = tax_scale.bracket_indices(tax_base)
+    result = tax_scale.rate_from_bracket_indice(bracket_indice)
+
+    assert isinstance(result, numpy.ndarray)
+    assert (result == numpy.array([0., 0.1, 0.1, 0.4])).all()
+

--- a/tests/core/tax_scales/test_rate_tax_scale_like.py
+++ b/tests/core/tax_scales/test_rate_tax_scale_like.py
@@ -16,3 +16,30 @@ def test_rate_from_bracket_indice():
     assert isinstance(result, numpy.ndarray)
     assert (result == numpy.array([0., 0.1, 0.1, 0.4])).all()
 
+
+def test_rate_from_tax_base():
+    tax_base = numpy.array([0, 3_000, 15_500, 500_000])
+    tax_scale = taxscales.MarginalRateTaxScale()
+    tax_scale.add_bracket(0, 0)
+    tax_scale.add_bracket(400, 0.1)
+    tax_scale.add_bracket(15_000, 0.4)
+    tax_scale.add_bracket(200_000, 0.6)
+
+    result = tax_scale.rate_from_tax_base(tax_base)
+
+    assert isinstance(result, numpy.ndarray)
+    assert (result == numpy.array([0., 0.1, 0.4, 0.6])).all()
+
+
+def test_threshold_from_tax_base():
+    tax_base = numpy.array([0, 33_000, 500, 400_000])
+    tax_scale = taxscales.LinearAverageRateTaxScale()
+    tax_scale.add_bracket(0, 0)
+    tax_scale.add_bracket(400, 0.1)
+    tax_scale.add_bracket(15_000, 0.4)
+    tax_scale.add_bracket(200_000, 0.6)
+
+    result = tax_scale.threshold_from_tax_base(tax_base)
+
+    assert isinstance(result, numpy.ndarray)
+    assert (result == numpy.array([0, 15_000, 400, 200_000])).all()


### PR DESCRIPTION
As suggested by @benjello, this PR is intended to allow, for a given tax scale, the determination of the tax rate according to the tax bracket indice.

This feature would be useful for a fix in `openfisca-france` : https://github.com/openfisca/openfisca-france/pull/1831#discussion_r835448750
#### New features

- Introduce `rate_from_bracket_indice` method on `RateTaxScaleLike` class
  - Allows for the determination of the tax rate based on the tax bracket indice
