### PR TITLE
[conda] Fix comment replacement that crash conda build

### DIFF
--- a/.conda/README.md
+++ b/.conda/README.md
@@ -19,17 +19,19 @@ The CI automatically uploads the PyPi package; see the `.github/workflow.yml`, s
 - Put the token in a CI environment variable named `ANACONDA_TOKEN`.
 
 
-## Manual actions before CI configuration
+## Manual actions to test before CI
 
-To create the package you can do the following in the project root folder:
+Everything is done by the CI but if you want to test it locally, here is how to do it.
 
-- Edit `.conda/meta.yaml` and update it if needed:
-    - Version number
-    - Hash SHA256
-    - Package URL on PyPi
+Do the following in the project root folder:
 
-- Build & Upload package:
+- Auto-update `.conda/meta.yaml` with last infos from pypi by running:
+    - `python .github/get_pypi_info.py -p OPenfisca-core`
+
+- Build package:
     - `conda install -c anaconda conda-build anaconda-client`
-    - `conda build .conda`
+    - `conda build -c conda-forge .conda`
+
+ - Upload the package to Anaconda.org, but DON'T do it if you don't understand what you are doing:
     - `anaconda login`
     - `anaconda upload openfisca-core-<VERSION>-py_0.tar.bz2`

--- a/.conda/README.md
+++ b/.conda/README.md
@@ -32,6 +32,6 @@ Do the following in the project root folder:
     - `conda install -c anaconda conda-build anaconda-client` (`conda-build` to build the package and [anaconda-client](https://github.com/Anaconda-Platform/anaconda-client) to push the package to anaconda.org)
     - `conda build -c conda-forge .conda`
 
- - Upload the package to Anaconda.org, but DON'T do it if you don't understand what you are doing:
+ - Upload the package to Anaconda.org, but DON'T do it if you don't want to publish your locally built package as official openfisca-core library:
     - `anaconda login`
     - `anaconda upload openfisca-core-<VERSION>-py_0.tar.bz2`

--- a/.conda/README.md
+++ b/.conda/README.md
@@ -29,7 +29,7 @@ Do the following in the project root folder:
     - `python .github/get_pypi_info.py -p OpenFisca-Core`
 
 - Build package:
-    - `conda install -c anaconda conda-build anaconda-client`
+    - `conda install -c anaconda conda-build anaconda-client` (`conda-build` to build the package and [anaconda-client](https://github.com/Anaconda-Platform/anaconda-client) to push the package to anaconda.org)
     - `conda build -c conda-forge .conda`
 
  - Upload the package to Anaconda.org, but DON'T do it if you don't understand what you are doing:

--- a/.conda/README.md
+++ b/.conda/README.md
@@ -26,7 +26,7 @@ Everything is done by the CI but if you want to test it locally, here is how to 
 Do the following in the project root folder:
 
 - Auto-update `.conda/meta.yaml` with last infos from pypi by running:
-    - `python .github/get_pypi_info.py -p OPenfisca-core`
+    - `python .github/get_pypi_info.py -p OpenFisca-Core`
 
 - Build package:
     - `conda install -c anaconda conda-build anaconda-client`

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -1,6 +1,6 @@
 ###############################################################################
 ## File for Anaconda.org
-## WARNING : strings PYPI VERSION, PYPI URL, PYPI SHA256 and PYPI DEPS will be replaced
+## WARNING : strings PYPI VERSION, PYPI URL and PYPI SHA256 will be replaced
 ## by CI script get_pypi_info.py, leave them as is.
 ###############################################################################
 
@@ -29,11 +29,12 @@ requirements:
     - pip
   run:
     - python >=3.6,<4.0
+    - dpath >=1.5.0,<3.0.0
     - nptyping ==1.4.4
-    - numexpr <=3.0,>=2.7.0
-    - numpy <1.21,>=1.11
-    - psutil <6.0.0,>=5.4.7
-    - pytest <6.0.0,>=4.4.1
+    - numexpr >=2.7.0,<=3.0
+    - numpy >=1.11,<1.21
+    - psutil >=5.4.7,<6.0.0
+    - pytest >=4.4.1,<6.0.0
     - PyYAML >=3.10
     - sortedcontainers ==2.2.2
     - typing-extensions ==3.10.0.2

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -1,6 +1,6 @@
 ###############################################################################
 ## File for Anaconda.org
-## WARNING : strings PYPI_VERSION, PYPI_URL, PYPI_SHA256 and PYPI_DEPS will be replaced
+## WARNING : strings PYPI VERSION, PYPI URL, PYPI SHA256 and PYPI DEPS will be replaced
 ## by CI script get_pypi_info.py, leave them as is.
 ###############################################################################
 
@@ -29,7 +29,14 @@ requirements:
     - pip
   run:
     - python >=3.6,<4.0
-PYPI_DEPS
+    - nptyping ==1.4.4
+    - numexpr <=3.0,>=2.7.0
+    - numpy <1.21,>=1.11
+    - psutil <6.0.0,>=5.4.7
+    - pytest <6.0.0,>=4.4.1
+    - PyYAML >=3.10
+    - sortedcontainers ==2.2.2
+    - typing-extensions ==3.10.0.2
 
 test:
   imports:

--- a/.github/get_pypi_info.py
+++ b/.github/get_pypi_info.py
@@ -63,11 +63,6 @@ def replace_in_file(filepath: str, info: dict):
     meta = meta.replace("PYPI_VERSION", info["last_version"])
     meta = meta.replace("PYPI_URL", info["url"])
     meta = meta.replace("PYPI_SHA256", info["sha256"])
-    deps_and_version = ""
-    for name, version in info["deps_and_version"].items():
-        deps_and_version += f"    - {name} {version}\n"
-    print(f"Adding dependencies to conda:\n{deps_and_version}")  # noqa: T001
-    meta = meta.replace("PYPI_DEPS", deps_and_version)
     with open(filepath, "wt", encoding="utf-8") as fout:
         fout.write(meta)
     print(f"File {filepath} has been updated with info from PyPi.")  # noqa: T001

--- a/.github/get_pypi_info.py
+++ b/.github/get_pypi_info.py
@@ -7,7 +7,6 @@ python3 .github/get_pypi_info.py -p OpenFisca-Core
 """
 
 import argparse
-import re
 
 import requests
 
@@ -27,26 +26,14 @@ def get_info(package_name: str = "") -> dict:
         raise Exception(f"ERROR calling PyPI ({url}) : {resp}")
     resp = resp.json()
     version = resp["info"]["version"]
-    deps_and_version = {}
-    for package in resp["info"]["requires_dist"]:
-        if "; extra ==" in package:
-            continue
-        package_name = package.split("(")[0].replace(" ", "")
-        package_name = package_name.replace("[pipeline]", "")
-        if package_name == "tables":
-            package_name = "pytables"
-        package_version = (
-            re.search("\(([^)]+)", package).group(1).replace(" ", "")  # noqa: W605
-            )  # "openfisca-france (>=113.0.2)"
-        deps_and_version[package_name] = package_version
 
     for v in resp["releases"][version]:
-        if v["packagetype"] == "sdist":  # for .tag.gz
+        # Find packagetype=="sdist" to get source code in .tar.gz
+        if v["packagetype"] == "sdist":
             return {
                 "last_version": version,
                 "url": v["url"],
                 "sha256": v["digests"]["sha256"],
-                "deps_and_version": deps_and_version,
                 }
     return {}
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -260,6 +260,8 @@ jobs:
       - name: Update meta.yaml
         run: |
           python3 -m pip install requests argparse
+          # Sleep to allow PyPi to update his API
+          sleep 60
           python3 .github/get_pypi_info.py -p OpenFisca-Core
       - name: Conda Config
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -260,7 +260,7 @@ jobs:
       - name: Update meta.yaml
         run: |
           python3 -m pip install requests argparse
-          # Sleep to allow PyPi to update his API
+          # Sleep to allow PyPi to update its API
           sleep 60
           python3 .github/get_pypi_info.py -p OpenFisca-Core
       - name: Conda Config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 35.8.3 [#1127](https://github.com/openfisca/openfisca-core/pull/1127)
+
+#### Technical changes
+
+- Fix the build for Anaconda in CI. The conda build failed on master because of a replacement in a comment string. 
+  - The _ were removed in the comment to avoid a replace.
+
 ### 35.8.2 [#1128](https://github.com/openfisca/openfisca-core/pull/1128)
 
 #### Technical changes

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To install it locally you can use one of these two options:
 * [conda](https://docs.conda.io/en/latest/) package manager that we recommend for Windows operating system users,
 * or standard Python [pip](https://packaging.python.org/en/latest/key_projects/#pip) package manager.
 
-### Installing `openfisca-core with `pip`
+### Installing `openfisca-core` with `pip`
 
 This installation requires [Python](https://www.python.org/downloads/) 3.7+ and [GIT](https://git-scm.com) installations.
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '35.8.2',
+    version = '35.8.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
Connected to #1105 (and [this comment](https://github.com/openfisca/openfisca-core/pull/1105#issuecomment-1135902404))

#### Technical changes

- The conda build failed on master because of a replacement in a comment string. I removed the `_` in the comment to avoid replace in comment. These replace is made by the script `.github/get_pypi_info.py` that get info from PyPi.
- With @sandcha we choose to remove the fonctionality that get dependencies from PyPi because it only works for main deps and not for extra requirements.
