### PR TITLE
Remove ambiguous docstring references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 35.8.2 [#1128](https://github.com/openfisca/openfisca-core/pull/1128)
+
+#### Technical changes
+
+- Remove ambiguous links in docstrings.
+
 ### 35.8.1 [#1105](https://github.com/openfisca/openfisca-core/pull/1105)
 
 #### Technical changes

--- a/openfisca_core/populations/population.py
+++ b/openfisca_core/populations/population.py
@@ -114,7 +114,7 @@ See more information at <https://openfisca.org/doc/coding-the-legislation/35_per
     @projectors.projectable
     def has_role(self, role):
         """
-            Check if a person has a given role within its :any:`GroupEntity`
+            Check if a person has a given role within its `GroupEntity`
 
             Example:
 

--- a/openfisca_core/reforms/reform.py
+++ b/openfisca_core/reforms/reform.py
@@ -11,7 +11,7 @@ class Reform(TaxBenefitSystem):
 
         All reforms must subclass `Reform` and implement a method `apply()`.
 
-        In this method, the reform can add or replace variables and call :any:`modify_parameters` to modify the parameters of the legislation.
+        In this method, the reform can add or replace variables and call `modify_parameters` to modify the parameters of the legislation.
 
         Example:
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '35.8.1',
+    version = '35.8.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
Some docstring refs are ambiguous. Until now, these warnings were not raised. Following [updates](https://github.com/openfisca/openfisca-doc/pull/264) in the documentation generation system, these references now raise errors when compiled and block documentation updates. This changeset removes links that are ambiguous so that the documentation can be generated again.
