### PR TITLE
Do not treat doc warnings as errors

### DIFF
--- a/openfisca_tasks/test_doc.mk
+++ b/openfisca_tasks/test_doc.mk
@@ -74,5 +74,5 @@ test-doc-install:
 ## Dry-build the doc.
 test-doc-build:
 	@$(call print_help,$@:)
-	@sphinx-build -M dummy doc/source doc/build -n -q -W
+	@sphinx-build -M dummy doc/source doc/build -n -q
 	@$(call print_pass,$@:)


### PR DESCRIPTION
This changeset stops documentation compilation warnings from being treated as errors.

An untreatable warning appeared in the codebase since an update to Sphinx (the engine building the doc): `<unknown>:1: WARNING: py:obj reference target not found: openfisca_core.types.data_types.arrays.T`. Warnings are currently treated as errors when building the doc, meaning that the doc test always fails. For example, this failing CI is now blocking a PR as trivial as #1132.

Applying this changeset implies that additional, legitimate warnings will not be made easily visible in CI. This is however the only way I found after a lot of investigation to solve this situation. See https://github.com/openfisca/openfisca-doc/pull/264#issuecomment-1157868878.