### PR TITLE
Fix pristine editable install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 35.8.5 [#1137](https://github.com/openfisca/openfisca-core/pull/1137)
+
+#### Technical changes
+
+- Fix pylint dependency in fresh editable installations
+  - Ignore pytest requirement, used to collect test cases, if it is not yet installed.
+
 ### 35.8.4 [#1131](https://github.com/openfisca/openfisca-core/pull/1131)
 
 #### Technical changes

--- a/openfisca_tasks/install.mk
+++ b/openfisca_tasks/install.mk
@@ -2,7 +2,7 @@
 install:
 	@$(call print_help,$@:)
 	@pip install --upgrade pip twine wheel
-	@pip install --editable .[dev] --upgrade --use-deprecated=legacy-resolver
+	@pip install --editable ".[dev]" --upgrade --use-deprecated=legacy-resolver
 
 ## Uninstall project dependencies.
 uninstall:

--- a/openfisca_tasks/test_code.mk
+++ b/openfisca_tasks/test_code.mk
@@ -20,7 +20,7 @@ test-code: test-core test-country test-extension
 	@$(call print_pass,$@:)
 
 ## Run openfisca-core tests.
-test-core: $(shell pytest --quiet --quiet --collect-only | cut -f 1 -d ":")
+test-core: $(shell pytest --quiet --quiet --collect-only 2> /dev/null | cut -f 1 -d ":")
 	@$(call print_help,$@:)
 	@PYTEST_ADDOPTS="$${PYTEST_ADDOPTS} ${pytest_args}" \
 		coverage run -m \

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '35.8.4',
+    version = '35.8.5',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ dev_requirements = [
     'autopep8 >= 1.4.0, < 1.6.0',
     'coverage == 6.0.2',
     'darglint == 1.8.0',
-    'flake8 >= 3.9.0, < 4.0.0',
+    'flake8 >= 4.0.0, < 4.1.0',
     'flake8-bugbear >= 19.3.0, < 20.0.0',
     'flake8-docstrings == 1.6.0',
     'flake8-print >= 3.1.0, < 4.0.0',


### PR DESCRIPTION
Fixes #1136 

Thanks for contributing to OpenFisca! Remove this line, as well as any other in the following that don't fit your contribution  :)

#### Technical changes

- Fix pylint dependency in fresh editable installations
  - Ignore pytest requirement, used to collect test cases, if it is not yet installed.
