### PR TITLE
Fix doc test & build dependency errors

### DIFF
--- a/.github/get-numpy-version.py
+++ b/.github/get-numpy-version.py
@@ -26,7 +26,7 @@ def prev() -> NoReturn:
         sys.exit(os.EX_DATAERR)
 
     minor -= 1
-    print(f"{major}.{minor}.0")  # noqa: T001
+    print(f"{major}.{minor}.0")  # noqa: T201
     sys.exit(os.EX_OK)
 
 

--- a/.github/get_pypi_info.py
+++ b/.github/get_pypi_info.py
@@ -20,7 +20,7 @@ def get_info(package_name: str = "") -> dict:
     if package_name == "":
         raise ValueError("Package name not provided.")
     url = f"https://pypi.org/pypi/{package_name}/json"
-    print(f"Calling {url}")  # noqa: T001
+    print(f"Calling {url}")  # noqa: T201
     resp = requests.get(url)
     if resp.status_code != 200:
         raise Exception(f"ERROR calling PyPI ({url}) : {resp}")
@@ -52,7 +52,7 @@ def replace_in_file(filepath: str, info: dict):
     meta = meta.replace("PYPI_SHA256", info["sha256"])
     with open(filepath, "wt", encoding="utf-8") as fout:
         fout.write(meta)
-    print(f"File {filepath} has been updated with info from PyPi.")  # noqa: T001
+    print(f"File {filepath} has been updated with info from PyPi.")  # noqa: T201
 
 
 if __name__ == "__main__":
@@ -74,5 +74,5 @@ if __name__ == "__main__":
         )
     args = parser.parse_args()
     info = get_info(args.package)
-    print("Information of the last published PyPi package :", info["last_version"])  # noqa: T001
+    print("Information of the last published PyPi package :", info["last_version"])  # noqa: T201
     replace_in_file(args.filename, info)

--- a/openfisca_core/periods/period_.py
+++ b/openfisca_core/periods/period_.py
@@ -345,9 +345,9 @@ class Period(tuple):
         >>> period('year', '2012', 1).size_in_months
         12
         """
-        if (self[0] == config.MONTH):
+        if self[0] == config.MONTH:
             return self[2]
-        if(self[0] == config.YEAR):
+        if self[0] == config.YEAR:
             return self[2] * 12
         raise ValueError("Cannot calculate number of months in {0}".format(self[0]))
 

--- a/openfisca_core/scripts/remove_fuzzy.py
+++ b/openfisca_core/scripts/remove_fuzzy.py
@@ -6,7 +6,7 @@ import datetime
 import sys
 import numpy as np
 
-assert(len(sys.argv) == 2)
+assert len(sys.argv) == 2
 filename = sys.argv[1]
 
 with open(filename, 'r') as f:

--- a/openfisca_tasks/test_code.mk
+++ b/openfisca_tasks/test_code.mk
@@ -20,11 +20,10 @@ test-code: test-core test-country test-extension
 	@$(call print_pass,$@:)
 
 ## Run openfisca-core tests.
-test-core: $(shell pytest --quiet --quiet --collect-only 2> /dev/null | cut -f 1 -d ":")
+test-core:
 	@$(call print_help,$@:)
-	@PYTEST_ADDOPTS="$${PYTEST_ADDOPTS} ${pytest_args}" \
-		coverage run -m \
-		${openfisca} test $? \
+	@PYTEST_ADDOPTS="$${PYTEST_ADDOPTS} ${pytest_args}" coverage run -m ${openfisca} test \
+		$(shell pytest --quiet --quiet --collect-only 2> /dev/null | cut -f 1 -d ":") \
 		${openfisca_args}
 	@$(call print_pass,$@:)
 

--- a/openfisca_tasks/test_doc.mk
+++ b/openfisca_tasks/test_doc.mk
@@ -39,8 +39,8 @@ test-doc-checkout:
 			&& { \
 				{ \
 					>&2 echo "$(print_info) Trying to checkout the branch 'openfisca-doc/${branch}'..." ; \
-					git branch -D ${branch} 2> /dev/null ; \
-					git checkout ${branch} 2> /dev/null ; \
+					git branch -D ${branch} ; \
+					git checkout ${branch} ; \
 				} \
 					&& git pull --ff-only origin ${branch} \
 					|| { \
@@ -61,14 +61,14 @@ test-doc-checkout:
 					} \
 			} \
 			|| git pull --ff-only origin master ; \
-	} 1> /dev/null
+	}
 	@$(call print_pass,$@:)
 
 ## Install doc dependencies.
 test-doc-install:
 	@$(call print_help,$@:)
-	@pip install --requirement doc/requirements.txt 1> /dev/null
-	@pip install --editable .[dev] --upgrade 1> /dev/null
+	@pip install --requirement doc/requirements.txt
+	@pip install --editable .[dev] --upgrade
 	@$(call print_pass,$@:)
 
 ## Dry-build the doc.

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ api_requirements = [
     'flask >= 1.1.4, < 2.0.0',
     'flask-cors == 3.0.10',
     'gunicorn >= 20.0.0, < 21.0.0',
+    'jinja2 >= 2.11.0, < 3.0.0',
     'werkzeug >= 1.0.1, < 2.0.0',
     ]
 
@@ -34,7 +35,7 @@ dev_requirements = [
     'autopep8 >= 1.4.0, < 1.6.0',
     'coverage == 6.0.2',
     'darglint == 1.8.0',
-    'flake8 >= 3.9.0, < 4.0.0',
+    'flake8 >= 5.0.0, < 5.1.0',
     'flake8-bugbear >= 19.3.0, < 20.0.0',
     'flake8-docstrings == 1.6.0',
     'flake8-print >= 3.1.0, < 4.0.0',
@@ -42,8 +43,8 @@ dev_requirements = [
     'mypy == 0.910',
     'openfisca-country-template >= 3.10.0, < 4.0.0',
     'openfisca-extension-template >= 1.2.0rc0, < 2.0.0',
-    'pycodestyle >= 2.7.0, < 2.8.0',
-    'pylint == 2.10.2',
+    'pycodestyle >= 2.9.0, < 2.10.0',
+    'pylint >= 2.13.0, < 2.14.0',
     ] + api_requirements
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -23,18 +23,18 @@ general_requirements = [
     ]
 
 api_requirements = [
-    'markupsafe >= 2.0.1, < 2.1.0',
-    'flask >= 1.1.4, < 2.0.0',
+    'markupsafe == 2.0.1',  # While flask revision < 2
+    'flask == 1.1.4',
     'flask-cors == 3.0.10',
     'gunicorn >= 20.0.0, < 21.0.0',
-    'werkzeug >= 1.0.1, < 2.0.0',
+    'werkzeug >= 1.0.0, < 2.0.0',
     ]
 
 dev_requirements = [
     'autopep8 >= 1.4.0, < 1.6.0',
     'coverage == 6.0.2',
     'darglint == 1.8.0',
-    'flake8 >= 3.9.0, < 4.0.0',
+    'flake8 >= 4.0.0, < 4.1.0',
     'flake8-bugbear >= 19.3.0, < 20.0.0',
     'flake8-docstrings == 1.6.0',
     'flake8-print >= 3.1.0, < 4.0.0',
@@ -42,7 +42,6 @@ dev_requirements = [
     'mypy == 0.910',
     'openfisca-country-template >= 3.10.0, < 4.0.0',
     'openfisca-extension-template >= 1.2.0rc0, < 2.0.0',
-    'pycodestyle >= 2.7.0, < 2.8.0',
     'pylint == 2.10.2',
     ] + api_requirements
 

--- a/setup.py
+++ b/setup.py
@@ -32,19 +32,20 @@ api_requirements = [
     ]
 
 dev_requirements = [
-    'autopep8 >= 1.4.0, < 1.6.0',
-    'coverage == 6.0.2',
-    'darglint == 1.8.0',
-    'flake8 >= 5.0.0, < 5.1.0',
-    'flake8-bugbear >= 22.0.0, < 23.0.0',
+    'autopep8 == 1.5.0',
+    'coverage == 6.4.2',
+    'darglint == 1.8.1',
+    'flake8 == 3.9.2',
+    'flake8-bugbear == 22.7.1',
     'flake8-docstrings == 1.6.0',
-    'flake8-print >= 3.1.0, < 4.0.0',
-    'flake8-rst-docstrings == 0.2.3',
+    'flake8-print == 5.0.0',
+    'flake8-rst-docstrings == 0.2.7',
+    'importlib-metadata == 4.12.0',
     'mypy == 0.910',
     'openfisca-country-template >= 3.10.0, < 4.0.0',
     'openfisca-extension-template >= 1.2.0rc0, < 2.0.0',
-    'pycodestyle >= 2.9.0, < 2.10.0',
-    'pylint >= 2.13.0, < 2.14.0',
+    'pycodestyle == 2.7.0',
+    'pylint == 2.14.5',
     ] + api_requirements
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -23,18 +23,18 @@ general_requirements = [
     ]
 
 api_requirements = [
-    'markupsafe == 2.0.1',  # While flask revision < 2
-    'flask == 1.1.4',
+    'markupsafe >= 2.0.1, < 2.1.0',
+    'flask >= 1.1.4, < 2.0.0',
     'flask-cors == 3.0.10',
     'gunicorn >= 20.0.0, < 21.0.0',
-    'werkzeug >= 1.0.0, < 2.0.0',
+    'werkzeug >= 1.0.1, < 2.0.0',
     ]
 
 dev_requirements = [
     'autopep8 >= 1.4.0, < 1.6.0',
     'coverage == 6.0.2',
     'darglint == 1.8.0',
-    'flake8 >= 4.0.0, < 4.1.0',
+    'flake8 >= 3.9.0, < 4.0.0',
     'flake8-bugbear >= 19.3.0, < 20.0.0',
     'flake8-docstrings == 1.6.0',
     'flake8-print >= 3.1.0, < 4.0.0',
@@ -42,6 +42,7 @@ dev_requirements = [
     'mypy == 0.910',
     'openfisca-country-template >= 3.10.0, < 4.0.0',
     'openfisca-extension-template >= 1.2.0rc0, < 2.0.0',
+    'pycodestyle >= 2.7.0, < 2.8.0',
     'pylint == 2.10.2',
     ] + api_requirements
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dev_requirements = [
     'coverage == 6.0.2',
     'darglint == 1.8.0',
     'flake8 >= 5.0.0, < 5.1.0',
-    'flake8-bugbear >= 19.3.0, < 20.0.0',
+    'flake8-bugbear >= 22.0.0, < 23.0.0',
     'flake8-docstrings == 1.6.0',
     'flake8-print >= 3.1.0, < 4.0.0',
     'flake8-rst-docstrings == 0.2.3',

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -37,10 +37,10 @@ def new_simulation(tax_benefit_system, test_case, period = MONTH):
 def test_role_index_and_positions(tax_benefit_system):
     simulation = new_simulation(tax_benefit_system, TEST_CASE)
     tools.assert_near(simulation.household.members_entity_id, [0, 0, 0, 0, 1, 1])
-    assert((simulation.household.members_role == [FIRST_PARENT, SECOND_PARENT, CHILD, CHILD, FIRST_PARENT, CHILD]).all())
+    assert (simulation.household.members_role == [FIRST_PARENT, SECOND_PARENT, CHILD, CHILD, FIRST_PARENT, CHILD]).all()
     tools.assert_near(simulation.household.members_position, [0, 1, 2, 3, 0, 1])
-    assert(simulation.person.ids == ["ind0", "ind1", "ind2", "ind3", "ind4", "ind5"])
-    assert(simulation.household.ids == ['h1', 'h2'])
+    assert simulation.person.ids == ["ind0", "ind1", "ind2", "ind3", "ind4", "ind5"]
+    assert simulation.household.ids == ['h1', 'h2']
 
 
 def test_entity_structure_with_constructor(tax_benefit_system):
@@ -69,7 +69,7 @@ def test_entity_structure_with_constructor(tax_benefit_system):
     household = simulation.household
 
     tools.assert_near(household.members_entity_id, [0, 0, 1, 0, 0])
-    assert((household.members_role == [FIRST_PARENT, SECOND_PARENT, FIRST_PARENT, CHILD, CHILD]).all())
+    assert (household.members_role == [FIRST_PARENT, SECOND_PARENT, FIRST_PARENT, CHILD, CHILD]).all()
     tools.assert_near(household.members_position, [0, 1, 0, 2, 3])
 
 
@@ -366,15 +366,15 @@ def test_projectors_methods(tax_benefit_system):
     person = simulation.person
 
     projected_vector = household.first_parent.has_role(entities.Household.FIRST_PARENT)
-    assert(len(projected_vector) == 1)  # Must be of a household dimension
+    assert (len(projected_vector) == 1)  # Must be of a household dimension
 
     salary_i = person.household.members('salary', '2017-01')
-    assert(len(person.household.sum(salary_i)) == 2)  # Must be of a person dimension
-    assert(len(person.household.max(salary_i)) == 2)  # Must be of a person dimension
-    assert(len(person.household.min(salary_i)) == 2)  # Must be of a person dimension
-    assert(len(person.household.all(salary_i)) == 2)  # Must be of a person dimension
-    assert(len(person.household.any(salary_i)) == 2)  # Must be of a person dimension
-    assert(len(household.first_parent.get_rank(household, salary_i)) == 1)  # Must be of a person dimension
+    assert len(person.household.sum(salary_i)) == 2  # Must be of a person dimension
+    assert len(person.household.max(salary_i)) == 2  # Must be of a person dimension
+    assert len(person.household.min(salary_i)) == 2  # Must be of a person dimension
+    assert len(person.household.all(salary_i)) == 2  # Must be of a person dimension
+    assert len(person.household.any(salary_i)) == 2  # Must be of a person dimension
+    assert len(household.first_parent.get_rank(household, salary_i)) == 1  # Must be of a person dimension
 
 
 def test_sum_following_bug_ipp_1(tax_benefit_system):
@@ -427,8 +427,8 @@ def test_get_memory_usage(tax_benefit_system):
     simulation = SimulationBuilder().build_from_dict(tax_benefit_system, test_case)
     simulation.calculate('disposable_income', '2017-01')
     memory_usage = simulation.person.get_memory_usage(variables = ['salary'])
-    assert(memory_usage['total_nb_bytes'] > 0)
-    assert(len(memory_usage['by_variable']) == 1)
+    assert memory_usage['total_nb_bytes'] > 0
+    assert len(memory_usage['by_variable']) == 1
 
 
 def test_unordered_persons(tax_benefit_system):

--- a/tests/core/test_opt_out_cache.py
+++ b/tests/core/test_opt_out_cache.py
@@ -51,7 +51,7 @@ def add_variables_to_cache_blakclist(tax_benefit_system):
 def test_without_cache_opt_out(simulation):
     simulation.calculate('output', period = PERIOD)
     intermediate_cache = simulation.persons.get_holder('intermediate')
-    assert(intermediate_cache.get_array(PERIOD) is not None)
+    assert intermediate_cache.get_array(PERIOD) is not None
 
 
 @pytest.mark.parametrize("simulation", [({'input': 1}, PERIOD)], indirect = True)
@@ -60,11 +60,11 @@ def test_with_cache_opt_out(simulation):
     simulation.opt_out_cache = True
     simulation.calculate('output', period = PERIOD)
     intermediate_cache = simulation.persons.get_holder('intermediate')
-    assert(intermediate_cache.get_array(PERIOD) is None)
+    assert intermediate_cache.get_array(PERIOD) is None
 
 
 @pytest.mark.parametrize("simulation", [({'input': 1}, PERIOD)], indirect = True)
 def test_with_no_blacklist(simulation):
     simulation.calculate('output', period = PERIOD)
     intermediate_cache = simulation.persons.get_holder('intermediate')
-    assert(intermediate_cache.get_array(PERIOD) is not None)
+    assert intermediate_cache.get_array(PERIOD) is not None

--- a/tests/core/test_reforms.py
+++ b/tests/core/test_reforms.py
@@ -288,7 +288,7 @@ def test_update_variable(make_simulation, tax_benefit_system):
 
     disposable_income2 = reform_simulation.calculate('disposable_income', period = '2017-01')
     # Before 2018, the former formula is used
-    assert(disposable_income2 > 100)
+    assert disposable_income2 > 100
 
 
 def test_replace_variable(tax_benefit_system):

--- a/tests/core/test_simulations.py
+++ b/tests/core/test_simulations.py
@@ -62,5 +62,5 @@ def test_get_memory_usage(tax_benefit_system):
     simulation = SimulationBuilder().build_from_entities(tax_benefit_system, single)
     simulation.calculate('disposable_income', '2017-01')
     memory_usage = simulation.get_memory_usage(variables = ['salary'])
-    assert(memory_usage['total_nb_bytes'] > 0)
-    assert(len(memory_usage['by_variable']) == 1)
+    assert memory_usage['total_nb_bytes'] > 0
+    assert len(memory_usage['by_variable']) == 1

--- a/tests/core/variables/test_variables.py
+++ b/tests/core/variables/test_variables.py
@@ -270,7 +270,7 @@ tax_benefit_system.add_variable(no_end_attribute__formulas__start_formats)
 
 def test_formulas_attributes_dated_formulas():
     formulas = tax_benefit_system.variables['no_end_attribute__formulas__start_formats'].formulas
-    assert(len(formulas) == 2)
+    assert len(formulas) == 2
     assert formulas['2000-01-01'] is not None
     assert formulas['2010-01-01'] is not None
 

--- a/tests/web_api/test_calculate.py
+++ b/tests/web_api/test_calculate.py
@@ -382,27 +382,19 @@ def test_handle_period_mismatch_error(test_client):
 
 
 def test_gracefully_handle_unexpected_errors(test_client):
-    """
-    Context
-    =======
+    """Calculate the housing tax due by Bill a thousand years ago.
 
     Whenever an exception is raised by the calculation engine, the API will try
     to handle it and to provide a useful message to the user (4XX). When the
     unexpected happens, if the exception is available it will be forwarded
     and given to the user even in this worst case scenario (500).
 
-    Scenario
-    ========
-
-    Calculate the housing tax due by Bill a thousand years ago.
-
-    Expected behaviour
-    ==================
-
     In the `country-template`, Housing Tax is only defined from 2010 onwards.
     The calculation engine should therefore raise an exception `ParameterNotFound`.
     The API is not expecting this, but she should handle the situation nonetheless.
+
     """
+
     variable = "housing_tax"
     period = "1234-05-06"
 


### PR DESCRIPTION
Fixes #1136
Fixes #1140

#### Technical changes

- Fix `pycodestyle` dependency in fresh editable installations.
- Fix `flake8` dependency in fresh editable installations.

Note: this PR is the continuation of #1137, but seems the solution was not complete. This PR should unblock doc tests failing because of dependency mismatch.
