### PR TITLE
Deprecate Instant.period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+# 37.0.0 [#1142](https://github.com/openfisca/openfisca-core/pull/1142)
+
+#### Deprecations
+
+- In _periods.Instant_:
+  - Remove `period`, method used to build a `Period` from an `Instant`.
+  - This method created an upward circular dependency between `Instant` and `Period` causing lots of trouble.
+  - The functionality is still provided by `periods.period` and the `Period` constructor.
+
+#### Migration details
+
+- Replace `some_period.start.period` and similar methods with `Period((unit, some_period.start, 1))`.
+
 # 36.0.0 [#1149](https://github.com/openfisca/openfisca-core/pull/1162)
 
 #### Breaking changes
@@ -869,7 +882,7 @@ _Note: this version has been unpublished due to an issue introduced by 34.2.9 in
   - Much more detail (and class diagrams) in the PR description
 - Remove support from the syntax `some_entity.SOME_ROLE` to access roles (where `some_entity` is the entity passed to a formula).
 
-### Migration details
+#### Migration details
 
 - Use the standard SomeEntity.SOME_ROLE instead. (Where SomeEntity is the capitalized entity or instance, Household.PARENT.)
 - Code that relied excessively on internal implementation details of Entity may break, and should be updated to access methods of Entity/Population instead.

--- a/openfisca_core/holders/helpers.py
+++ b/openfisca_core/holders/helpers.py
@@ -3,6 +3,7 @@ import logging
 import numpy
 
 from openfisca_core import periods
+from openfisca_core.periods import Period
 
 log = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ def set_input_dispatch_by_period(holder, period, array):
     after_instant = period.start.offset(period_size, period_unit)
 
     # Cache the input data, skipping the existing cached months
-    sub_period = period.start.period(cached_period_unit)
+    sub_period = Period((cached_period_unit, period.start, 1))
     while sub_period.start < after_instant:
         existing_array = holder.get_array(sub_period)
         if existing_array is None:
@@ -60,7 +61,7 @@ def set_input_divide_by_period(holder, period, array):
 
     # Count the number of elementary periods to change, and the difference with what is already known.
     remaining_array = array.copy()
-    sub_period = period.start.period(cached_period_unit)
+    sub_period = Period((cached_period_unit, period.start, 1))
     sub_periods_count = 0
     while sub_period.start < after_instant:
         existing_array = holder.get_array(sub_period)
@@ -73,7 +74,7 @@ def set_input_divide_by_period(holder, period, array):
     # Cache the input data
     if sub_periods_count > 0:
         divided_array = remaining_array / sub_periods_count
-        sub_period = period.start.period(cached_period_unit)
+        sub_period = Period((cached_period_unit, period.start, 1))
         while sub_period.start < after_instant:
             if holder.get_array(sub_period) is None:
                 holder._set(sub_period, divided_array)

--- a/openfisca_core/periods/__init__.py
+++ b/openfisca_core/periods/__init__.py
@@ -33,7 +33,6 @@ from .config import (  # noqa: F401
     )
 
 from .helpers import (  # noqa: F401
-    N_,
     instant,
     instant_date,
     period,

--- a/openfisca_core/periods/instant_.py
+++ b/openfisca_core/periods/instant_.py
@@ -1,8 +1,7 @@
 import calendar
 import datetime
 
-from openfisca_core import periods
-from openfisca_core.periods import config
+from . import config
 
 
 class Instant(tuple):
@@ -81,21 +80,6 @@ class Instant(tuple):
         2
         """
         return self[1]
-
-    def period(self, unit, size = 1):
-        """
-        Create a new period starting at instant.
-
-        >>> instant(2014).period('month')
-        Period(('month', Instant((2014, 1, 1)), 1))
-        >>> instant('2014-2').period('year', 2)
-        Period(('year', Instant((2014, 2, 1)), 2))
-        >>> instant('2014-2-3').period('day', size = 2)
-        Period(('day', Instant((2014, 2, 3)), 2))
-        """
-        assert unit in (config.DAY, config.MONTH, config.YEAR), 'Invalid unit: {} of type {}'.format(unit, type(unit))
-        assert isinstance(size, int) and size >= 1, 'Invalid size: {} of type {}'.format(size, type(size))
-        return periods.Period((unit, self, size))
 
     def offset(self, offset, unit):
         """

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '36.0.0',
+    version = '37.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
Depends on #1160 

#### Deprecations

- In _periods.Instant_:
  - Remove `period`, method used to build a `Period` from an `Instant`.
  - This method created an upward circular dependency between `Instant` and `Period` causing lots of trouble.
  - The functionality is still provided by `periods.period` and the `Period` constructor.

#### Migration details

- Replace `some_period.start.period` and similar methods with `Period((unit, some_period.start, 1))`.