### PR TITLE
Remove base attribute from ParameterScaleBracket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+# 36.0.0 [#1149](https://github.com/openfisca/openfisca-core/pull/1162)
+
+#### Breaking changes
+
+- In `ParameterScaleBracket`:
+  - Remove the `base` attribute
+  - The attribute's usage was unclear and it was only being used by some French social security variables
+
 ## 35.12.0 [#1160](https://github.com/openfisca/openfisca-core/pull/1160)
 
 #### New Features

--- a/openfisca_core/parameters/parameter_scale.py
+++ b/openfisca_core/parameters/parameter_scale.py
@@ -96,25 +96,17 @@ class ParameterScale(AtInstantLike):
             scale = LinearAverageRateTaxScale()
 
             for bracket in brackets:
-                if 'base' in bracket._children:
-                    base = bracket.base
-                else:
-                    base = 1.
                 if 'average_rate' in bracket._children and 'threshold' in bracket._children:
                     average_rate = bracket.average_rate
                     threshold = bracket.threshold
-                    scale.add_bracket(threshold, average_rate * base)
+                    scale.add_bracket(threshold, average_rate)
             return scale
         else:
             scale = MarginalRateTaxScale()
 
             for bracket in brackets:
-                if 'base' in bracket._children:
-                    base = bracket.base
-                else:
-                    base = 1.
                 if 'rate' in bracket._children and 'threshold' in bracket._children:
                     rate = bracket.rate
                     threshold = bracket.threshold
-                    scale.add_bracket(threshold, rate * base)
+                    scale.add_bracket(threshold, rate)
             return scale

--- a/openfisca_core/parameters/parameter_scale_bracket.py
+++ b/openfisca_core/parameters/parameter_scale_bracket.py
@@ -6,4 +6,4 @@ class ParameterScaleBracket(ParameterNode):
     A parameter scale bracket.
     """
 
-    _allowed_keys = set(['amount', 'threshold', 'rate', 'average_rate', 'base'])
+    _allowed_keys = set(['amount', 'threshold', 'rate', 'average_rate'])

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '35.12.0',
+    version = '36.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [


### PR DESCRIPTION
Depends on #1160 

#### Breaking changes

- ParameterScaleBracte:
  - Remove base attribute

This attribute is unclear and was used only for some French social security contributions 