### PR TITLE
Introduce a way to run tests in parallel

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -60,7 +60,7 @@ jobs:
           key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}
 
       - name: Run openfisca-core tests
-        run:  make test-core
+        run:  make test-core openfisca_args="--workers auto"
 
       - name: Submit coverage to Coveralls
         run: |
@@ -89,7 +89,7 @@ jobs:
           key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}
 
       - name: Run Country Template tests
-        run: make test-country
+        run: make test-country openfisca_args="--workers auto"
 
   test-extension-template:
     runs-on: ubuntu-20.04
@@ -113,7 +113,7 @@ jobs:
           key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}
 
       - name: Run Extension Template tests
-        run: make test-extension
+        run: make test-extension openfisca_args="--workers auto"
 
   check-numpy:
     runs-on: ubuntu-20.04

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -60,7 +60,7 @@ jobs:
           key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}
 
       - name: Run openfisca-core tests
-        run:  make test-core openfisca_args="--workers auto"
+        run:  make test-core
 
       - name: Submit coverage to Coveralls
         run: |
@@ -89,7 +89,7 @@ jobs:
           key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}
 
       - name: Run Country Template tests
-        run: make test-country openfisca_args="--workers auto"
+        run: make test-country
 
   test-extension-template:
     runs-on: ubuntu-20.04
@@ -113,7 +113,7 @@ jobs:
           key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}
 
       - name: Run Extension Template tests
-        run: make test-extension openfisca_args="--workers auto"
+        run: make test-extension
 
   check-numpy:
     runs-on: ubuntu-20.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 37.0.1 [#1171](https://github.com/openfisca/openfisca-core/pull/1171)
+
+#### Technical changes
+
+- Introduce a way to run test in parallel.
+- Check `openfisca test --help` for usage instructions.
+
 # 37.0.0 [#1142](https://github.com/openfisca/openfisca-core/pull/1142)
 
 #### Deprecations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 #### Technical changes
 
-- Introduce a way to run test in parallel.
-- Check `openfisca test --help` for usage instructions.
+- Introduce option `--workers` to `openfisca test to run tests in parallel`.
+  - Check `openfisca test --help` for usage instructions.
+- Add short option `-g` to `openfisca` as a synonym to `--performance-graph`.
 
 # 37.0.0 [#1142](https://github.com/openfisca/openfisca-core/pull/1142)
 

--- a/openfisca_core/scripts/openfisca_command.py
+++ b/openfisca_core/scripts/openfisca_command.py
@@ -32,18 +32,89 @@ def get_parser():
     parser_serve = build_serve_parser(parser_serve)
 
     def build_test_parser(parser):
-        parser.add_argument('path', help = "paths (files or directories) of tests to execute", nargs = '+')
+        parser.add_argument("path", help = "paths (files or directories) of tests to execute", nargs = "+")
+
         parser = add_tax_benefit_system_arguments(parser)
-        parser.add_argument('-a', '--aggregate', action = 'store_true', default = False, help = "increase output verbosity to aggregate. If specified, output the avg, max, and min values of the calculation trace. This flag has no effect without --verbose.")
-        parser.add_argument('-d', '--max-depth', type = int, default = None, help = "set maximal verbosity depth. If specified, output the calculation trace up to the provided depth. This flag has no effect without --verbose.")
-        parser.add_argument('-g', '--performance-graph', '--performance', action = 'store_true', default = False, help = "output a performance graph in a 'performance_graph.html' file")
-        parser.add_argument('-i', '--ignore-variables', nargs = '*', default = None, help = "variables to ignore. If specified, do not test the given variables.")
-        parser.add_argument('-n', '--name_filter', default = None, help = "partial name of tests to execute. Only tests with the given name_filter in their name, file name, or keywords will be run.")
-        parser.add_argument('-o', '--only-variables', nargs = '*', default = None, help = "variables to test. If specified, only test the given variables.")
-        parser.add_argument('-p', '--pdb', action = 'store_true', default = False, help = "drop into debugger on failures or errors")
-        parser.add_argument('-t', '--performance-tables', action = 'store_true', default = False, help = "output performance CSV tables")
-        parser.add_argument('-v', '--verbose', action = 'store_true', default = False, help = "increase output verbosity. If specified, output the entire calculation trace.")
-        parser.add_argument('-w', '--workers', nargs = 1, default = None, help = "run tests distributed. Use `auto` to detect the number of cores.")
+
+        parser.add_argument(
+            "-a",
+            "--aggregate",
+            action = "store_true",
+            default = False,
+            help = "increase output verbosity to aggregate. If specified, output the avg, max, and min values of the calculation trace. This flag has no effect without --verbose.",
+            )
+
+        parser.add_argument(
+            "-d",
+            "--max-depth",
+            type = int,
+            default = None,
+            help = "set maximal verbosity depth. If specified, output the calculation trace up to the provided depth. This flag has no effect without --verbose.",
+            )
+
+        parser.add_argument(
+            "-g",
+            "--performance-graph",
+            "--performance",
+            action = "store_true",
+            default = False,
+            help = "output a performance graph in a 'performance_graph.html' file",
+            )
+
+        parser.add_argument(
+            "-i",
+            "--ignore-variables",
+            nargs = "*",
+            default = None,
+            help = "variables to ignore. If specified, do not test the given variables.",
+            )
+
+        parser.add_argument(
+            "-n",
+            "--name_filter",
+            default = None,
+            help = "partial name of tests to execute. Only tests with the given name_filter in their name, file name, or keywords will be run.",
+            )
+
+        parser.add_argument(
+            "-o",
+            "--only-variables",
+            nargs = "*",
+            default = None,
+            help = "variables to test. If specified, only test the given variables.",
+            )
+
+        parser.add_argument(
+            "-p",
+            "--pdb",
+            action = "store_true",
+            default = False,
+            help = "drop into debugger on failures or errors",
+            )
+
+        parser.add_argument(
+            "-t",
+            "--performance-tables",
+            action = "store_true",
+            default = False,
+            help = "output performance CSV tables",
+            )
+
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            action = "store_true",
+            default = False,
+            help = "increase output verbosity. If specified, output the entire calculation trace.",
+            )
+
+        parser.add_argument(
+            "-w",
+            "--workers",
+            nargs = 1,
+            default = "auto",
+            help = "run tests distributed per core. Use `auto` to detect the number of cores.",
+            )
 
         return parser
 

--- a/openfisca_core/scripts/openfisca_command.py
+++ b/openfisca_core/scripts/openfisca_command.py
@@ -34,15 +34,16 @@ def get_parser():
     def build_test_parser(parser):
         parser.add_argument('path', help = "paths (files or directories) of tests to execute", nargs = '+')
         parser = add_tax_benefit_system_arguments(parser)
-        parser.add_argument('-n', '--name_filter', default = None, help = "partial name of tests to execute. Only tests with the given name_filter in their name, file name, or keywords will be run.")
-        parser.add_argument('-p', '--pdb', action = 'store_true', default = False, help = "drop into debugger on failures or errors")
-        parser.add_argument('--performance-graph', '--performance', action = 'store_true', default = False, help = "output a performance graph in a 'performance_graph.html' file")
-        parser.add_argument('--performance-tables', action = 'store_true', default = False, help = "output performance CSV tables")
-        parser.add_argument('-v', '--verbose', action = 'store_true', default = False, help = "increase output verbosity. If specified, output the entire calculation trace.")
         parser.add_argument('-a', '--aggregate', action = 'store_true', default = False, help = "increase output verbosity to aggregate. If specified, output the avg, max, and min values of the calculation trace. This flag has no effect without --verbose.")
         parser.add_argument('-d', '--max-depth', type = int, default = None, help = "set maximal verbosity depth. If specified, output the calculation trace up to the provided depth. This flag has no effect without --verbose.")
-        parser.add_argument('-o', '--only-variables', nargs = '*', default = None, help = "variables to test. If specified, only test the given variables.")
+        parser.add_argument('-g', '--performance-graph', '--performance', action = 'store_true', default = False, help = "output a performance graph in a 'performance_graph.html' file")
         parser.add_argument('-i', '--ignore-variables', nargs = '*', default = None, help = "variables to ignore. If specified, do not test the given variables.")
+        parser.add_argument('-n', '--name_filter', default = None, help = "partial name of tests to execute. Only tests with the given name_filter in their name, file name, or keywords will be run.")
+        parser.add_argument('-o', '--only-variables', nargs = '*', default = None, help = "variables to test. If specified, only test the given variables.")
+        parser.add_argument('-p', '--pdb', action = 'store_true', default = False, help = "drop into debugger on failures or errors")
+        parser.add_argument('-t', '--performance-tables', action = 'store_true', default = False, help = "output performance CSV tables")
+        parser.add_argument('-v', '--verbose', action = 'store_true', default = False, help = "increase output verbosity. If specified, output the entire calculation trace.")
+        parser.add_argument('-w', '--workers', nargs = 1, default = None, help = "run tests distributed. Use `auto` to detect the number of cores.")
 
         return parser
 

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -15,16 +15,16 @@ def main(parser):
     tax_benefit_system = build_tax_benefit_system(args.country_package, args.extensions, args.reforms)
 
     options = {
-        'aggregate': args.aggregate,
-        'ignore_variables': args.ignore_variables,
-        'max_depth': args.max_depth,
-        'name_filter': args.name_filter,
-        'only_variables': args.only_variables,
-        'pdb': args.pdb,
-        'performance_graph': args.performance_graph,
-        'performance_tables': args.performance_tables,
-        'verbose': args.verbose,
-        'workers': args.workers,
+        "aggregate": args.aggregate,
+        "ignore_variables": args.ignore_variables,
+        "max_depth": args.max_depth,
+        "name_filter": args.name_filter,
+        "only_variables": args.only_variables,
+        "pdb": args.pdb,
+        "performance_graph": args.performance_graph,
+        "performance_tables": args.performance_tables,
+        "verbose": args.verbose,
+        "workers": args.workers,
         }
 
     paths = [os.path.abspath(path) for path in args.path]

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -15,15 +15,16 @@ def main(parser):
     tax_benefit_system = build_tax_benefit_system(args.country_package, args.extensions, args.reforms)
 
     options = {
+        'aggregate': args.aggregate,
+        'ignore_variables': args.ignore_variables,
+        'max_depth': args.max_depth,
+        'name_filter': args.name_filter,
+        'only_variables': args.only_variables,
         'pdb': args.pdb,
         'performance_graph': args.performance_graph,
         'performance_tables': args.performance_tables,
         'verbose': args.verbose,
-        'aggregate': args.aggregate,
-        'max_depth': args.max_depth,
-        'name_filter': args.name_filter,
-        'only_variables': args.only_variables,
-        'ignore_variables': args.ignore_variables,
+        'workers': args.workers,
         }
 
     paths = [os.path.abspath(path) for path in args.path]

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -131,8 +131,9 @@ def run_tests(
     """
 
     argv = []
-    workers = options.get("workers")
     plugins = [OpenFiscaPlugin(tax_benefit_system, options)]
+    workers = options.get("workers")
+    tests_per_worker = options.get("tests_per_worker")
 
     if options.get('pdb'):
         argv.append('--pdb')
@@ -141,7 +142,7 @@ def run_tests(
         argv.append('--verbose')
 
     if workers is not None:
-        argv.append(f"--workers={workers[0]}")
+        argv.append(f"--workers={workers}")
 
     if isinstance(paths, str):
         paths = [paths]

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -29,6 +29,7 @@ class Options(TypedDict, total = False):
     performance_graph: bool
     performance_tables: bool
     verbose: bool
+    workers: Optional[Sequence[str]]
 
 
 @dataclasses.dataclass(frozen = True)
@@ -130,6 +131,7 @@ def run_tests(
     """
 
     argv = []
+    workers = options.get("workers")
     plugins = [OpenFiscaPlugin(tax_benefit_system, options)]
 
     if options.get('pdb'):
@@ -137,6 +139,9 @@ def run_tests(
 
     if options.get('verbose'):
         argv.append('--verbose')
+
+    if workers is not None:
+        argv.append(f"--workers={workers[0]}")
 
     if isinstance(paths, str):
         paths = [paths]

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -131,9 +131,8 @@ def run_tests(
     """
 
     argv = []
-    plugins = [OpenFiscaPlugin(tax_benefit_system, options)]
     workers = options.get("workers")
-    tests_per_worker = options.get("tests_per_worker")
+    plugins = [OpenFiscaPlugin(tax_benefit_system, options)]
 
     if options.get('pdb'):
         argv.append('--pdb')

--- a/openfisca_tasks/test_code.mk
+++ b/openfisca_tasks/test_code.mk
@@ -45,7 +45,8 @@ test-core: $(shell pytest --quiet --quiet --collect-only 2> /dev/null | cut -f 1
 test-country:
 	@$(call print_help,$@:)
 	@PYTEST_ADDOPTS="$${PYTEST_ADDOPTS} ${pytest_args}" \
-		openfisca test ${python_packages}/openfisca_country_template/tests \
+		python -m \
+		${openfisca} test ${python_packages}/openfisca_country_template/tests \
 		--country-package openfisca_country_template \
 		${openfisca_args}
 	@$(call print_pass,$@:)
@@ -54,7 +55,8 @@ test-country:
 test-extension:
 	@$(call print_help,$@:)
 	@PYTEST_ADDOPTS="$${PYTEST_ADDOPTS} ${pytest_args}" \
-		openfisca test ${python_packages}/openfisca_extension_template/tests \
+		python -m \
+		${openfisca} test ${python_packages}/openfisca_extension_template/tests \
 		--country-package openfisca_country_template \
 		--extensions openfisca_extension_template \
 		${openfisca_args}

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ skip_covered        = true
 skip_empty          = true
 
 [tool:pytest]
-addopts             = --doctest-modules --disable-pytest-warnings --showlocals
+addopts             = --disable-pytest-warnings --doctest-modules --showlocals
 doctest_optionflags = ELLIPSIS IGNORE_EXCEPTION_DETAIL NUMBER NORMALIZE_WHITESPACE
 python_files        = **/*.py
 testpaths           = tests

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ dev_requirements = [
     'mypy == 0.910',
     'pycodestyle >= 2.8.0, < 2.9.0',
     'pylint == 2.10.2',
-    'pytest-parallel < 1.0.0',
+    'pytest-parallel < 0.2.0',
     'xdoctest >= 1.0.0, < 2.0.0',
     ] + api_requirements
 

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '37.0.0',
+    version = '37.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ dev_requirements = [
     'mypy == 0.910',
     'pycodestyle >= 2.8.0, < 2.9.0',
     'pylint == 2.10.2',
+    'pytest-parallel < 1.0.0',
     'xdoctest >= 1.0.0, < 2.0.0',
     ] + api_requirements
 


### PR DESCRIPTION
Fixes #1025 

#### Technical changes

- Introduce a way to run test in parallel.
- Check `openfisca test --help` for usage instructions.
