### PR TITLE
Add importlib_metadata requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ long_description = (this_directory / "README.md").read_text()
 
 general_requirements = [
     'dpath >= 1.5.0, < 3.0.0',
+    'importlib_metadata >= 5.2.0',
     'nptyping == 1.4.4',
     'numexpr >= 2.7.0, <= 3.0',
     'numpy >= 1.11, < 1.21',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ long_description = (this_directory / "README.md").read_text()
 
 general_requirements = [
     'dpath >= 1.5.0, < 3.0.0',
-    'importlib_metadata >= 5.2.0',
+    'importlib-metadata < 4.3',  # For flake8 4 compatibility
     'nptyping == 1.4.4',
     'numexpr >= 2.7.0, <= 3.0',
     'numpy >= 1.11, < 1.21',


### PR DESCRIPTION
#### Technical changes

- Add missing requirement `importlib_metadata` imported by `openfisca_core/taxbenefitsystems/tax_benefit_system.py` (Fix #1176 ; see also [comment of issue 1165](https://github.com/openfisca/openfisca-core/pull/1165#issuecomment-1332299948))
