### PR TITLE
Fix YamlItem in test_runner.py to clone TBS in case of reforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 38.0.4 [#1182](https://github.com/openfisca/openfisca-core/pull/1182)
+
+#### Technical changes
+
+- Method `_get_tax_benefit_system()` of class `YamlItem` in file  `openfisca_core/tools/test_runner.py` will now clone the TBS when applying reforms to avoid running tests with previously reformed TBS.
+
+
 ### 38.0.3 [#1179](https://github.com/openfisca/openfisca-core/pull/1179)
 
 #### Bug fix

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -349,13 +349,12 @@ def _get_tax_benefit_system(baseline, reforms, extensions):
     if _tax_benefit_system_cache.get(key):
         return _tax_benefit_system_cache.get(key)
 
-    current_tax_benefit_system = baseline
+    current_tax_benefit_system = baseline.clone()
 
     for reform_path in reforms:
         current_tax_benefit_system = current_tax_benefit_system.apply_reform(reform_path)
 
     for extension in extensions:
-        current_tax_benefit_system = current_tax_benefit_system.clone()
         current_tax_benefit_system.load_extension(extension)
 
     _tax_benefit_system_cache[key] = current_tax_benefit_system

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ dev_requirements = [
 
 setup(
     name = 'OpenFisca-Core',
-    version = '38.0.3',
+    version = '38.0.4',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/tools/test_runner/test_yaml_runner.py
+++ b/tests/core/tools/test_runner/test_yaml_runner.py
@@ -92,6 +92,12 @@ def test_variable_not_found():
     assert excinfo.value.variable_name == "unknown_variable"
 
 
+def test_tax_benefit_systems_with_cache():
+    baseline = TaxBenefitSystem()
+    ab_tax_benefit_system = _get_tax_benefit_system(baseline, [], [])
+    assert baseline != ab_tax_benefit_system
+
+
 def test_tax_benefit_systems_with_reform_cache():
     baseline = TaxBenefitSystem()
 


### PR DESCRIPTION
#### Technical changes

- Method `_get_tax_benefit_system()` of class `YamlItem` in file  `openfisca_core/tools/test_runner.py` will now clone the TBS when applying reforms to avoid running tests with previously reformed TBS.

#### Notes
In the case we want to run **2 tests or more** with differents `reforms` and no `extensions` we were sharing the same baseline so we were executing following tests with the TBS set in previous tests.
