### PR TITLE
Remove comments extraction not used and very slow on newer python versions

### DIFF
--- a/openfisca_core/variables/variable.py
+++ b/openfisca_core/variables/variable.py
@@ -364,12 +364,10 @@ class Variable:
         """
         Get instrospection data about the code of the variable.
 
-        :returns: (comments, source file path, source code, start line number)
+        :returns: (source file path, source code, start line number)
         :rtype: tuple
 
         """
-        comments = inspect.getcomments(cls)
-
         # Handle dynamically generated variable classes or Jupyter Notebooks, which have no source.
         try:
             absolute_file_path = inspect.getsourcefile(cls)
@@ -385,7 +383,7 @@ class Variable:
         except (IOError, TypeError):
             source_code, start_line_number = None, None
 
-        return comments, source_file_path, source_code, start_line_number
+        return source_file_path, source_code, start_line_number
 
     def get_formula(
         self,

--- a/openfisca_web_api/loader/variables.py
+++ b/openfisca_web_api/loader/variables.py
@@ -71,7 +71,6 @@ def build_formulas(
 
 def build_variable(variable, country_package_metadata, tax_benefit_system):
     (
-        comments,
         source_file_path,
         source_code,
         start_line_number,


### PR DESCRIPTION
Comments extraction is not tested, doesn't seem to be used and is making the API very very very slow.

I am currently refactoring this section, it remains the source code extraction and generation but for comments it looks simpler as the logic can be removed.

#### Breaking changes

- In _Variable.get_introspection_data_:
  - `comments` removed from the tuple returned


232 seconds spent for an unused feature here:

![Screenshot 2023-07-10 at 18-30-38 full_7minutes_profile3](https://github.com/openfisca/openfisca-core/assets/1410356/f09ce6f8-6012-4741-8d23-8a8792fbde57)


A single long `findsource` trace (and I'm working on it, I extracted that PR from my work)

![Screenshot 2023-07-10 at 18-36-42 without_comments](https://github.com/openfisca/openfisca-core/assets/1410356/3e8eed05-c89e-4b42-a67c-544ee8678814)
