### PR TITLE
Refactor introspection data generation to get a much quicker startup time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+# 41.0.0 [#1189](https://github.com/openfisca/openfisca-core/pull/1189)
+
+#### Breaking changes
+
+- `Variable.get_introspection_data` no longer has parameters nor calling functions
+
+The Web API was very prone to crashing, timeouting at startup because of the time consuming python file parsing to generate documentation displayed for instance in the Legislation Explorer.
+
 ##  40.1.0 [#1174](https://github.com/openfisca/openfisca-core/pull/1174)
 
 #### New Features

--- a/openfisca_core/taxbenefitsystems/tax_benefit_system.py
+++ b/openfisca_core/taxbenefitsystems/tax_benefit_system.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional, Sequence, Union
 
+import ast
 import copy
 import functools
 import glob
@@ -13,6 +14,7 @@ import os
 import sys
 import traceback
 import typing
+import linecache
 
 from openfisca_core import commons, periods, variables
 from openfisca_core.entities import Entity
@@ -224,11 +226,28 @@ class TaxBenefitSystem:
             #  - The same file, loaded by different tax and benefit systems, has distinct module names. Hence the `id(self)` in the module name.
             module_name = f"{id(self)}_{hash(os.path.abspath(file_path))}_{file_name}"
 
+            def findsource(tree, qualname):
+                class_finder = inspect._ClassFinder(qualname)
+                try:
+                    class_finder.visit(tree)
+                except inspect.ClassFoundException as e:
+                    line_number = e.args[0]
+                    return lines, line_number
+                else:
+                    raise OSError('could not find class definition')
+
             try:
                 spec = importlib.util.spec_from_file_location(module_name, file_path)
                 module = importlib.util.module_from_spec(spec)
                 sys.modules[module_name] = module
+                # print(file_path)
+                # import pdb; pdb.set_trace()
+                lines = linecache.getlines(file_path, module.__dict__)
+                source = ''.join(lines)
+                tree = ast.parse(source)
                 spec.loader.exec_module(module)
+
+
             except NameError as e:
                 logging.error(
                     str(e)
@@ -247,6 +266,7 @@ class TaxBenefitSystem:
                     and issubclass(pot_variable, Variable)
                     and pot_variable.__module__ == module_name
                 ):
+                    pot_variable.introspection_data = findsource(tree, pot_variable.__qualname__)
                     self.add_variable(pot_variable)
         except Exception:
             log.error(

--- a/openfisca_core/variables/variable.py
+++ b/openfisca_core/variables/variable.py
@@ -364,12 +364,10 @@ class Variable:
         """
         Get instrospection data about the code of the variable.
 
-        :returns: (comments, source file path, source code, start line number)
+        :returns: (source file path, source code, start line number)
         :rtype: tuple
 
         """
-        comments = inspect.getcomments(cls)
-
         # Handle dynamically generated variable classes or Jupyter Notebooks, which have no source.
         try:
             absolute_file_path = inspect.getsourcefile(cls)
@@ -385,7 +383,7 @@ class Variable:
         except (IOError, TypeError):
             source_code, start_line_number = None, None
 
-        return comments, source_file_path, source_code, start_line_number
+        return source_file_path, source_code, start_line_number
 
     def get_formula(
         self,

--- a/openfisca_core/variables/variable.py
+++ b/openfisca_core/variables/variable.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Optional, Union
 
 import datetime
-import inspect
 import re
 import textwrap
 
@@ -160,7 +159,6 @@ class Variable:
         self.introspection_data = self.set(
             attr,
             "introspection_data",
-            default={},
         )
 
         formulas_attr, unexpected_attrs = helpers._partition(
@@ -366,30 +364,8 @@ class Variable:
         return len(self.formulas) == 0
 
     @classmethod
-    def get_introspection_data(cls, tax_benefit_system):
-        """
-        Get instrospection data about the code of the variable.
-
-        :returns: (source file path, source code, start line number)
-        :rtype: tuple
-
-        """
-        # Handle dynamically generated variable classes or Jupyter Notebooks, which have no source.
-        try:
-            absolute_file_path = inspect.getsourcefile(cls)
-        except TypeError:
-            source_file_path = None
-        else:
-            source_file_path = absolute_file_path.replace(
-                tax_benefit_system.get_package_metadata()["location"], ""
-            )
-        try:
-            source_lines, start_line_number = [], 0
-            source_code = textwrap.dedent("".join(source_lines))
-        except (IOError, TypeError):
-            source_code, start_line_number = None, None
-
-        return source_file_path, source_code, start_line_number
+    def get_introspection_data(cls):
+        return cls.introspection_data
 
     def get_formula(
         self,

--- a/openfisca_core/variables/variable.py
+++ b/openfisca_core/variables/variable.py
@@ -157,6 +157,12 @@ class Variable:
             default=config.VALUE_TYPES[self.value_type]["is_period_size_independent"],
         )
 
+        self.introspection_data = self.set(
+            attr,
+            "introspection_data",
+            default={},
+        )
+
         formulas_attr, unexpected_attrs = helpers._partition(
             attr, lambda name, value: name.startswith(config.FORMULA_NAME_PREFIX)
         )
@@ -378,7 +384,7 @@ class Variable:
                 tax_benefit_system.get_package_metadata()["location"], ""
             )
         try:
-            source_lines, start_line_number = inspect.getsourcelines(cls)
+            source_lines, start_line_number = [], 0
             source_code = textwrap.dedent("".join(source_lines))
         except (IOError, TypeError):
             source_code, start_line_number = None, None

--- a/openfisca_core/variables/variable.py
+++ b/openfisca_core/variables/variable.py
@@ -365,7 +365,10 @@ class Variable:
 
     @classmethod
     def get_introspection_data(cls):
-        return cls.introspection_data
+        try:
+            return cls.introspection_data
+        except AttributeError:
+            return '', None, 0
 
     def get_formula(
         self,

--- a/openfisca_web_api/loader/spec.py
+++ b/openfisca_web_api/loader/spec.py
@@ -85,12 +85,12 @@ def build_openAPI_specification(api_data):
         dpath.util.new(
             spec,
             "components/schemas/SituationOutput/example",
-            {}, #handlers.calculate(tax_benefit_system, deepcopy(simulation_example)),
+            handlers.calculate(tax_benefit_system, deepcopy(simulation_example)),
         )  # calculate has side-effects
         dpath.util.new(
             spec,
             "components/schemas/Trace/example",
-            {}, #handlers.trace(tax_benefit_system, simulation_example),
+            handlers.trace(tax_benefit_system, simulation_example),
         )
     else:
         message = "No simulation example has been defined for this tax and benefit system. If you are the maintainer of {}, you can define an example by following this documentation: https://openfisca.org/doc/openfisca-web-api/config-openapi.html".format(

--- a/openfisca_web_api/loader/spec.py
+++ b/openfisca_web_api/loader/spec.py
@@ -85,12 +85,12 @@ def build_openAPI_specification(api_data):
         dpath.util.new(
             spec,
             "components/schemas/SituationOutput/example",
-            handlers.calculate(tax_benefit_system, deepcopy(simulation_example)),
+            {}, #handlers.calculate(tax_benefit_system, deepcopy(simulation_example)),
         )  # calculate has side-effects
         dpath.util.new(
             spec,
             "components/schemas/Trace/example",
-            handlers.trace(tax_benefit_system, simulation_example),
+            {}, #handlers.trace(tax_benefit_system, simulation_example),
         )
     else:
         message = "No simulation example has been defined for this tax and benefit system. If you are the maintainer of {}, you can define an example by following this documentation: https://openfisca.org/doc/openfisca-web-api/config-openapi.html".format(

--- a/openfisca_web_api/loader/variables.py
+++ b/openfisca_web_api/loader/variables.py
@@ -39,7 +39,7 @@ def build_source_url(
 
 
 def build_formula(
-    formula, country_package_metadata, source_file_path, tax_benefit_system
+    formula, country_package_metadata, source_file_path
 ):
     source_code, start_line_number = inspect.getsourcelines(formula)
 
@@ -59,22 +59,22 @@ def build_formula(
 
 
 def build_formulas(
-    formulas, country_package_metadata, source_file_path, tax_benefit_system
+    formulas, country_package_metadata, source_file_path
 ):
     return {
         start_date: build_formula(
-            formula, country_package_metadata, source_file_path, tax_benefit_system
+            formula, country_package_metadata, source_file_path
         )
         for start_date, formula in formulas.items()
     }
 
 
-def build_variable(variable, country_package_metadata, tax_benefit_system):
+def build_variable(variable, country_package_metadata, ):
     (
         source_file_path,
         source_code,
         start_line_number,
-    ) = variable.get_introspection_data(tax_benefit_system)
+    ) = variable.get_introspection_data()
     result = {
         "id": variable.name,
         "description": variable.label,
@@ -99,8 +99,7 @@ def build_variable(variable, country_package_metadata, tax_benefit_system):
         result["formulas"] = build_formulas(
             variable.formulas,
             country_package_metadata,
-            source_file_path,
-            tax_benefit_system,
+            source_file_path
         )
 
         if variable.end:
@@ -116,6 +115,6 @@ def build_variable(variable, country_package_metadata, tax_benefit_system):
 
 def build_variables(tax_benefit_system, country_package_metadata):
     return {
-        name: build_variable(variable, country_package_metadata, tax_benefit_system)
+        name: build_variable(variable, country_package_metadata)
         for name, variable in tax_benefit_system.variables.items()
     }

--- a/openfisca_web_api/loader/variables.py
+++ b/openfisca_web_api/loader/variables.py
@@ -71,7 +71,6 @@ def build_formulas(
 
 def build_variable(variable, country_package_metadata, tax_benefit_system):
     (
-        comments,
         source_file_path,
         source_code,
         start_line_number,

--- a/openfisca_web_api/loader/variables.py
+++ b/openfisca_web_api/loader/variables.py
@@ -69,7 +69,7 @@ def build_formulas(
     }
 
 
-def build_variable(variable, country_package_metadata, ):
+def build_variable(variable, country_package_metadata):
     (
         source_file_path,
         source_code,

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ dev_requirements = [
 
 setup(
     name="OpenFisca-Core",
-    version="40.1.0",
+    version="41.0.0",
     author="OpenFisca Team",
     author_email="contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
Python version bump made OpenFisca Web API much much slower.
It takes 5 minutes or so (cf discussion on Slack).

This slow startup is mainly due to the introspection data generation and more precisely to the python files parsing.

## before

![Screenshot 2023-07-17 at 17-26-04 full_7minutes_profile3](https://github.com/openfisca/openfisca-core/assets/1410356/40e1a871-4b3b-42ae-9c57-d86235a72021)


## after

![Screenshot 2023-07-17 at 17-27-49 fix_1946](https://github.com/openfisca/openfisca-core/assets/1410356/b06e6e8f-3892-4bc1-a098-30dd9f7d7ce2)


**similar to #1188**

#### Breaking changes

- In _Variables_:
  - `get_introspection_data` no longer have parameters as well as calling functions

#### Technical notes

I think it is worth sharing my development strategy:

I worked with a country package (France) and started `gunicorn run --config config.py` with
> `run.py`
```python
from openfisca_core.scripts import build_tax_benefit_system
from openfisca_web_api.app import create_app


country_package = 'openfisca_france'

tax_benefit_system = build_tax_benefit_system(
    country_package_name = country_package,
    extensions = [],
    reforms = []
)

application = create_app(tax_benefit_system)
```
and
> `config.py`
```python
import cProfile
import pstats
from io import StringIO
import logging
import os
import tempfile
import time

timeout=1200

profiles = {}
def post_fork(server, worker):
    worker.start_time = time.time()
    profile = cProfile.Profile()
    profile.enable()
    profiles[worker.pid] = profile
    worker.log.info("PROFILING %d" % (worker.pid))

def worker_abort(worker):
    tf = tempfile.NamedTemporaryFile(delete = False)
    worker.log.info("PROFILING RESULT %d: http://127.0.0.1:8081/snakeviz/%s" % (worker.pid, tf.name))
    profiles[worker.pid].dump_stats(tf.name)

def post_worker_init(worker):
    tf = tempfile.NamedTemporaryFile(delete = False)
    worker.log.info("PROFILING RESULT %d: http://127.0.0.1:8081/snakeviz/%s" % (worker.pid, tf.name))
    profiles[worker.pid].dump_stats(tf.name)
```

It allowed me to get visual clues with snakeviz on areas of potential improvements (as well as slow interesting portions I could comment out).

I also cloned https://github.com/python/cpython to have a better understanding of underlying functions. However, I didn't dig much in code in C I mainly stayed in Python and I recycled code snippets in our contexts.