### PR TITLE
Add dunder contains and dunder iter to TracingParameterNodeAtInstant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 41.3.0 [#1200](https://github.com/openfisca/openfisca-core/pull/1200)
+
+> As `TracingParameterNodeAtInstant` is a wrapper for `ParameterNodeAtInstant`
+> which allows iteration and the use of `contains`, it was not possible
+> to use those on a `TracingParameterNodeAtInstant`
+
+#### New features
+
+- Allows iterations on `TracingParameterNodeAtInstant`
+- Allows keyword `contains` on `TracingParameterNodeAtInstant`
+
 ## 41.2.0 [#1199](https://github.com/openfisca/openfisca-core/pull/1199)
 
 #### Technical changes

--- a/openfisca_core/tracers/tracing_parameter_node_at_instant.py
+++ b/openfisca_core/tracers/tracing_parameter_node_at_instant.py
@@ -36,6 +36,12 @@ class TracingParameterNodeAtInstant:
         child = getattr(self.parameter_node_at_instant, key)
         return self.get_traced_child(child, key)
 
+    def __contains__(self, key) -> bool:
+        return key in self.parameter_node_at_instant
+
+    def __iter__(self):
+        return iter(self.parameter_node_at_instant)
+
     def __getitem__(
         self,
         key: Union[str, ArrayLike],

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ dev_requirements = [
 
 setup(
     name="OpenFisca-Core",
-    version="41.2.0",
+    version="41.3.0",
     author="OpenFisca Team",
     author_email="contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
## 41.3.0 [#1200](https://github.com/openfisca/openfisca-core/pull/1200)

> As `TracingParameterNodeAtInstant` is a wrapper for `ParameterNodeAtInstant`
> which allows iteration and the use of `contains`, it was not possible
> to use those on a `TracingParameterNodeAtInstant`

#### New features

- Allows iterations on `TracingParameterNodeAtInstant`
- Allows keyword `contains` on `TracingParameterNodeAtInstant`
