### PR TITLE
Fix Pypi's deployment by editing CI workflow to authenticate to Pypi via API token

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -184,8 +184,8 @@ jobs:
     needs: [ check-for-functional-changes ]
     if: needs.check-for-functional-changes.outputs.status == 'success'
     env:
-      PYPI_USERNAME: openfisca-bot
-      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      PYPI_USERNAME: __token__
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN_OPENFISCA_BOT }}
       CIRCLE_TOKEN: ${{ secrets.CIRCLECI_V1_OPENFISCADOC_TOKEN }} # Personal API token created in CircleCI to grant full read and write permissions
 
     steps:
@@ -213,7 +213,7 @@ jobs:
           key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}
 
       - name: Upload a Python package to PyPi
-        run: twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD
+        run: twine upload dist/* --username $PYPI_USERNAME --password $PYPI_TOKEN
 
       - name: Publish a git tag
         run: "${GITHUB_WORKSPACE}/.github/publish-git-tag.sh"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 41.4.2 [#1203](https://github.com/openfisca/openfisca-core/pull/1203)
+
+#### Technical changes
+
+- Changes the Pypi's deployment authentication way to use token API following Pypi's 2FA enforcement starting 2024/01/01.
+
 ### 41.4.1 [#1202](https://github.com/openfisca/openfisca-core/pull/1202)
 
 #### Technical changes

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ dev_requirements = [
 
 setup(
     name="OpenFisca-Core",
-    version="41.4.1",
+    version="41.4.2",
     author="OpenFisca Team",
     author_email="contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
#### Technical changes

- Changes the Pypi's deployment authentication way to use token API following Pypi's 2FA enforcement starting 2024/01/01
