### PR TITLE
Increase compatibility and resilience of package metadata loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-### 41.4.4 [#1208](https://github.com/openfisca/openfisca-core/pull/1208)
+### 41.4.5 [#1209](https://github.com/openfisca/openfisca-core/pull/1209)
+
+#### Technical changes
+
+- Support loading metadata from both `setup.py` and `pyproject.toml` package description files.
+
+### ~41.4.4~ [#1208](https://github.com/openfisca/openfisca-core/pull/1208)
+
+_Unpublished due to introduced backwards incompatibilities._
 
 #### Technical changes
 

--- a/openfisca_core/taxbenefitsystems/tax_benefit_system.py
+++ b/openfisca_core/taxbenefitsystems/tax_benefit_system.py
@@ -517,8 +517,8 @@ class TaxBenefitSystem:
             log.warn("Unable to load package metadata, exposing default metadata", e)
             source_metadata = {
                 "Name": self.__class__.__name__,
-                "Version": "",
-                "Home-page": "",
+                "Version": "0.0.0",
+                "Home-page": "https://openfisca.org",
             }
 
         try:
@@ -526,7 +526,7 @@ class TaxBenefitSystem:
             location = source_file.split(package_name)[0].rstrip("/")
         except Exception as e:
             log.warn("Unable to load package source folder", e)
-            location = ""
+            location = "_unknown_"
 
         repository_url = ""
         if source_metadata.get("Project-URL"):  # pyproject.toml metadata format

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ dev_requirements = [
 
 setup(
     name="OpenFisca-Core",
-    version="41.4.4",
+    version="41.4.5",
     author="OpenFisca Team",
     author_email="contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
This follows #1208 that broke backwards compatibility and led to a yanked release.

Tested on Country Template and France.

#### Technical changes

- Bring back ability to load package metadata as required by Web API from `setup.py`, while maintaining compatibility with more modern `pyproject.toml`.
- Increase resilience to missing metadata.
- Simplify code by grouping exception catching.
- Log warnings when metadata cannot be obtained.
