### PR TITLE
Deploy documentation

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -179,19 +179,6 @@ jobs:
       - id: stop-early
         run: if "${GITHUB_WORKSPACE}/.github/has-functional-changes.sh" ; then echo "::set-output name=status::success" ; fi # The `check-for-functional-changes` job should always succeed regardless of the `has-functional-changes` script's exit code. Consequently, we do not use that exit code to trigger deploy, but rather a dedicated output variable `status`, to avoid a job failure if the exit code is different from 0. Conversely, if the job fails the entire workflow would be marked as `failed` which is disturbing for contributors.
 
-  deploy-doc: # TESTING
-    runs-on: ubuntu-latest
-    steps:
-      - name: Update doc
-        run: |
-          curl -L \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.OPENFISCADOC_BOT_ACCESS_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/openfisca/openfisca-doc/actions/workflows/deploy.yaml/dispatches \
-            -d '{"ref":"cd"}'
-
   deploy:
     runs-on: ubuntu-22.04
     needs: [ check-for-functional-changes ]

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -179,6 +179,19 @@ jobs:
       - id: stop-early
         run: if "${GITHUB_WORKSPACE}/.github/has-functional-changes.sh" ; then echo "::set-output name=status::success" ; fi # The `check-for-functional-changes` job should always succeed regardless of the `has-functional-changes` script's exit code. Consequently, we do not use that exit code to trigger deploy, but rather a dedicated output variable `status`, to avoid a job failure if the exit code is different from 0. Conversely, if the job fails the entire workflow would be marked as `failed` which is disturbing for contributors.
 
+  deploy-doc: # TESTING
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update doc
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.OPENFISCADOC_BOT_ACCESS_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/openfisca/openfisca-doc/actions/workflows/deploy.yaml/dispatches \
+            -d '{"ref":"cd"}'
+
   deploy:
     runs-on: ubuntu-22.04
     needs: [ check-for-functional-changes ]

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -186,7 +186,6 @@ jobs:
     env:
       PYPI_USERNAME: __token__
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN_OPENFISCA_BOT }}
-      CIRCLE_TOKEN: ${{ secrets.CIRCLECI_V1_OPENFISCADOC_TOKEN }} # Personal API token created in CircleCI to grant full read and write permissions
 
     steps:
       - uses: actions/checkout@v2
@@ -220,7 +219,13 @@ jobs:
 
       - name: Update doc
         run: |
-          curl -X POST --header "Content-Type: application/json" -d '{"branch":"master"}' https://circleci.com/api/v1.1/project/github/openfisca/openfisca-doc/build?circle-token=${{ secrets.CIRCLECI_V1_OPENFISCADOC_TOKEN }}
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.OPENFISCADOC_BOT_ACCESS_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/openfisca/openfisca-doc/actions/workflows/deploy.yaml/dispatches \
+            -d '{"ref":"master"}'
 
   build-conda:
     runs-on: ubuntu-22.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 41.4.7 [#1212](https://github.com/openfisca/openfisca-core/pull/1212)
+
+#### Technical changes
+
+- Update documentation continuous deployment method to reflect OpenFisca-Doc [process updates](https://github.com/openfisca/openfisca-doc/pull/308)
+
 ### 41.4.6 [#1210](https://github.com/openfisca/openfisca-core/pull/1210)
 
 #### Technical changes

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ dev_requirements = [
 
 setup(
     name="OpenFisca-Core",
-    version="41.4.6",
+    version="41.4.7",
     author="OpenFisca Team",
     author_email="contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
#### Technical changes

- Update documentation deployment trigger to adapt to https://github.com/openfisca/openfisca-doc/pull/308

- - - -

Proof that the deployment is triggered can be found on the [Doc Actions log](https://github.com/openfisca/openfisca-doc/actions/runs/9175096799).

Details of implementation and difficulties can be found on https://github.com/openfisca/openfisca-doc/pull/308#issuecomment-2121712431.

I suggest to wait until https://github.com/openfisca/openfisca-doc/pull/309 is merged to proceed with merging this PR, as it would be the ideal moment to change the `ref` to `main` rather than having an additional patch published later. The review is still relevant to have now thought, considering that the logic itself will not change.

- - - -

If this PR is merged:

- [ ] `CIRCLECI_OPENFISCADOC_TOKEN` secret should be erased
- [ ] `CIRCLECI_V1_OPENFISCADOC_TOKEN` secret should be erased

