### PR TITLE
Add an option to keep variable in cache

### DIFF
--- a/openfisca_core/simulations/simulation.py
+++ b/openfisca_core/simulations/simulation.py
@@ -93,8 +93,14 @@ class Simulation:
 
     # ----- Calculation methods ----- #
 
-    def calculate(self, variable_name: str, period):
-        """Calculate ``variable_name`` for ``period``."""
+    def calculate(
+        self, variable_name: str, period, force_keep_cache: Optional[Set[Dict]] = None
+    ):
+        """
+        Calculate ``variable_name`` for ``period``.
+
+        force_keep_cache : Set[Dict] = None : A set of dictionaries containing the variable name and period for which the cache should be kept.
+        """
 
         if period is not None and not isinstance(period, periods.Period):
             period = periods.period(period)
@@ -102,13 +108,13 @@ class Simulation:
         self.tracer.record_calculation_start(variable_name, period)
 
         try:
-            result = self._calculate(variable_name, period)
+            result = self._calculate(variable_name, period, force_keep_cache)
             self.tracer.record_calculation_result(result)
             return result
 
         finally:
             self.tracer.record_calculation_end()
-            self.purge_cache_of_invalid_values()
+            self.purge_cache_of_invalid_values(force_keep_cache)
 
     def _calculate(self, variable_name: str, period: periods.Period):
         """
@@ -153,11 +159,22 @@ class Simulation:
 
         return array
 
-    def purge_cache_of_invalid_values(self):
+    def purge_cache_of_invalid_values(
+        self, force_keep_cache: Optional[Set[Dict]] = None
+    ):
+        """
+        Purge the cache of values that are no longer valid.
+        force_keep_cache : Set[Dict] = None : A set of dictionaries containing the variable name and period for which the cache should be kept.
+        """
         # We wait for the end of calculate(), signalled by an empty stack, before purging the cache
         if self.tracer.stack:
             return
         for _name, _period in self.invalidated_caches:
+            if (
+                force_keep_cache
+                and {"variable": _name, "period": _period} in force_keep_cache
+            ):
+                continue
             holder = self.get_holder(_name)
             holder.delete_arrays(_period)
         self.invalidated_caches = set()


### PR DESCRIPTION
#### New features

- Add an option `force_keep_cache` in `simulation.calculate` to override the deletion of some cached variable by `purge_cache_of_invalid_values`. For example in OpenFisca-France if you calculate the `rfr` variable and then what to compute quantile : the `rfr`  will be computed again because it has been deleted from the cache.


Sample code to use this with OpenFiscaFrance:

```py
import os
import shutil
import time
import numpy as np
from openfisca_core.simulation_builder import SimulationBuilder
from openfisca_core.tools.simulation_dumper import dump_simulation
from openfisca_france import FranceTaxBenefitSystem
from openfisca_core.periods import Period, DateUnit, Instant

dump_path = "/tmp/dump_openfisca_lqzkgsdj"

tbs = FranceTaxBenefitSystem()

sb = SimulationBuilder()
simulation = sb.build_default_simulation(tbs, count=3)
instant = Instant((2023, 1, 1))
        
period = Period((DateUnit.YEAR, instant, 1))
simulation.set_input("salaire_de_base", period, np.array([10_000, 2500, 3500]))
white_list = [  {"variable": "rfr", "period": period}]
rfr = simulation.calculate("rfr", period, white_list=white_list)
if os.path.exists(dump_path):
    # Remove folder
    shutil.rmtree(dump_path)

dump_simulation(simulation, dump_path)

if os.path.exists(dump_path + "/rfr_plus_values_hors_rni/2023.npy"):
    print("Le rfr_plus_values_hors_rni est bien dans le dump.")
    if os.path.exists(dump_path + "/rfr/2023.npy"):
        print("OK, le rfr est aussi dans le dump.")
    else:
        print("ERROR : Le RFR n'est pas dans le dump alors qu'il vient dêtre calculé.")
        exit(1)
```

More information here in French : https://openfisca.slack.com/archives/C47KV33QF/p1726588042968229
