### PR TITLE
Update python version to 3.12.3

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -14,13 +14,15 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-22.04, windows-2019]
-        numpy: [1.26.4, 1.24.2]
+        numpy: [1.26.4]
         # Patch version must be specified to avoid any cache confusion, since
         # the cache key depends on the full Python version. If left unspecified,
         # different patch versions could be allocated between jobs,  and any
         # such difference would lead to a cache not found error.
-        python: [3.11.9, 3.9.13]
+        python: [3.12.3, 3.9.13]
         include:
+        - python: 3.9.13
+          numpy: 1.24.2
         - os: ubuntu-22.04
           activate_command: source venv/bin/activate
         - os: windows-2019
@@ -45,9 +47,11 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-22.04, windows-2019]
-        numpy: [1.26.4, 1.24.2]
-        python: [3.11.9, 3.9.13]
+        numpy: [1.26.4]
+        python: [3.12.3, 3.9.13]
         include:
+        - python: 3.9.13
+          numpy: 1.24.2
         - os: ubuntu-22.04
           activate_command: source venv/bin/activate
         - os: windows-2019
@@ -72,8 +76,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        numpy: [1.24.2]
-        python: [3.11.9, 3.9.13]
+        numpy: [1.26.4]
+        python: [3.12.3, 3.9.13]
     uses: ./.github/workflows/_lint-pip.yaml
     with:
       os: ubuntu-22.04

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -21,8 +21,14 @@ jobs:
         # such difference would lead to a cache not found error.
         python: [3.12.3, 3.9.13]
         include:
-        - python: 3.9.13
+        - os: ubuntu-22.04
+          python: 3.9.13
           numpy: 1.24.2
+          activate_command: source venv/bin/activate
+        - os: windows-2019
+          python: 3.9.13
+          numpy: 1.24.2
+          activate_command: .\venv\Scripts\activate
         - os: ubuntu-22.04
           activate_command: source venv/bin/activate
         - os: windows-2019
@@ -50,8 +56,14 @@ jobs:
         numpy: [1.26.4]
         python: [3.12.3, 3.9.13]
         include:
-        - python: 3.9.13
+        - os: ubuntu-22.04
+          python: 3.9.13
           numpy: 1.24.2
+          activate_command: source venv/bin/activate
+        - os: windows-2019
+          python: 3.9.13
+          numpy: 1.24.2
+          activate_command: .\venv\Scripts\activate
         - os: ubuntu-22.04
           activate_command: source venv/bin/activate
         - os: windows-2019

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -14,13 +14,15 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-22.04, windows-2019]
-        numpy: [1.26.4, 1.24.2]
+        numpy: [1.26.4]
         # Patch version must be specified to avoid any cache confusion, since
         # the cache key depends on the full Python version. If left unspecified,
         # different patch versions could be allocated between jobs, and any
         # such difference would lead to a cache not found error.
         python: [3.12.3, 3.9.13]
         include:
+        - python: 3.9.13
+          numpy: 1.24.2
         - os: ubuntu-22.04
           activate_command: source venv/bin/activate
         - os: windows-2019
@@ -45,9 +47,11 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-22.04, windows-2019]
-        numpy: [1.26.4, 1.24.2]
+        numpy: [1.26.4]
         python: [3.12.3, 3.9.13]
         include:
+        - python: 3.9.13
+          numpy: 1.24.2
         - os: ubuntu-22.04
           activate_command: source venv/bin/activate
         - os: windows-2019
@@ -72,7 +76,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        numpy: [1.24.2]
+        numpy: [1.26.4]
         python: [3.12.3, 3.9.13]
     uses: ./.github/workflows/_lint-pip.yaml
     with:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -39,7 +39,7 @@ jobs:
     with:
       os: ubuntu-22.04
       numpy: 1.26.4
-      python: 3.12.3
+      python: 3.10.6
 
   test-pip:
     needs: [setup-pip]
@@ -69,7 +69,7 @@ jobs:
     with:
       os: ubuntu-22.04
       numpy: 1.26.4
-      python: 3.12.3
+      python: 3.10.6
 
   lint-pip:
     needs: [setup-pip]

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -21,8 +21,18 @@ jobs:
         # such difference would lead to a cache not found error.
         python: [3.12.3, 3.9.13]
         include:
-        - python: 3.9.13
+        - os: ubuntu-22.04
+          python: 3.9.13
           numpy: 1.24.2
+          activate_command: source venv/bin/activate
+        - os: ubuntu-22.04
+          python: 3.13.3
+          numpy: 1.26.4
+          activate_command: source venv/bin/activate
+        - os: windows-2019
+          python: 3.9.13
+          numpy: 1.24.2
+          activate_command: .\venv\Scripts\activate
         - os: ubuntu-22.04
           activate_command: source venv/bin/activate
         - os: windows-2019
@@ -44,14 +54,24 @@ jobs:
   test-pip:
     needs: [setup-pip]
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-22.04, windows-2019]
         numpy: [1.26.4]
         python: [3.12.3, 3.9.13]
         include:
-        - python: 3.9.13
+        - os: ubuntu-22.04
+          python: 3.9.13
           numpy: 1.24.2
+          activate_command: source venv/bin/activate
+        - os: ubuntu-22.04
+          python: 3.13.3
+          numpy: 1.26.4
+          activate_command: source venv/bin/activate
+        - os: windows-2019
+          python: 3.9.13
+          numpy: 1.24.2
+          activate_command: .\venv\Scripts\activate
         - os: ubuntu-22.04
           activate_command: source venv/bin/activate
         - os: windows-2019

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -25,10 +25,6 @@ jobs:
           python: 3.9.13
           numpy: 1.24.2
           activate_command: source venv/bin/activate
-        - os: ubuntu-22.04
-          python: 3.13.3
-          numpy: 1.26.4
-          activate_command: source venv/bin/activate
         - os: windows-2019
           python: 3.9.13
           numpy: 1.24.2
@@ -63,10 +59,6 @@ jobs:
         - os: ubuntu-22.04
           python: 3.9.13
           numpy: 1.24.2
-          activate_command: source venv/bin/activate
-        - os: ubuntu-22.04
-          python: 3.13.3
-          numpy: 1.26.4
           activate_command: source venv/bin/activate
         - os: windows-2019
           python: 3.9.13

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -19,7 +19,7 @@ jobs:
         # the cache key depends on the full Python version. If left unspecified,
         # different patch versions could be allocated between jobs, and any
         # such difference would lead to a cache not found error.
-        python: [3.11.9, 3.9.13]
+        python: [3.12.3, 3.9.13]
         include:
         - os: ubuntu-22.04
           activate_command: source venv/bin/activate
@@ -37,7 +37,7 @@ jobs:
     with:
       os: ubuntu-22.04
       numpy: 1.26.4
-      python: 3.10.6
+      python: 3.12.3
 
   test-pip:
     needs: [setup-pip]
@@ -46,7 +46,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, windows-2019]
         numpy: [1.26.4, 1.24.2]
-        python: [3.11.9, 3.9.13]
+        python: [3.12.3, 3.9.13]
         include:
         - os: ubuntu-22.04
           activate_command: source venv/bin/activate
@@ -65,7 +65,7 @@ jobs:
     with:
       os: ubuntu-22.04
       numpy: 1.26.4
-      python: 3.10.6
+      python: 3.12.3
 
   lint-pip:
     needs: [setup-pip]
@@ -73,7 +73,7 @@ jobs:
       fail-fast: true
       matrix:
         numpy: [1.24.2]
-        python: [3.11.9, 3.9.13]
+        python: [3.12.3, 3.9.13]
     uses: ./.github/workflows/_lint-pip.yaml
     with:
       os: ubuntu-22.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Documentation
 
-- Change Github Action matrix test to support Python 3.12.
+- Change Github Action matrix test to support Python 3.12 and 3.13.
 
 ### 43.3.5 [#1325](https://github.com/openfisca/openfisca-core/pull/1325)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 43.3.6 [#1289](https://github.com/openfisca/openfisca-core/pull/1289)
+
+#### Documentation
+
+- Change Github Action matrix test to support Python 3.12.
+
 ### 43.3.5 [#1325](https://github.com/openfisca/openfisca-core/pull/1325)
 
 #### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Documentation
 
-- Change Github Action matrix test to support Python 3.12 and 3.13.
+- Change Github Action matrix test to support Python 3.12.
 
 ### 43.3.5 [#1325](https://github.com/openfisca/openfisca-core/pull/1325)
 

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,6 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
         "Topic :: Scientific/Engineering :: Information Analysis",
     ],
     description="A versatile microsimulation free software",

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ dev_requirements = [
 
 setup(
     name="OpenFisca-Core",
-    version="43.3.5",
+    version="43.3.6",
     author="OpenFisca Team",
     author_email="contact@openfisca.org",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,8 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Scientific/Engineering :: Information Analysis",
     ],
     description="A versatile microsimulation free software",

--- a/tasks/publish.mk
+++ b/tasks/publish.mk
@@ -3,7 +3,7 @@
 ## Install project's build dependencies.
 install-dist:
 	@$(call print_help,$@:)
-	@python -m pip install .[ci,dev] build
+	@python -m pip install .[ci,dev]
 	@$(call print_pass,$@:)
 
 ## Build & install openfisca-core for deployment and publishing.
@@ -11,9 +11,6 @@ build:
 	@## This allows us to be sure tests are run against the packaged version
 	@## of openfisca-core, the same we put in the hands of users and reusers.
 	@$(call print_help,$@:)
-	@python -m pip install --upgrade pip
-	@python -m pip install build
-	@python -m pip list | grep build
 	@python -m build
 	@python -m pip uninstall --yes openfisca-core
 	@find dist -name "*.whl" -exec python -m pip install --no-deps {} \;

--- a/tasks/publish.mk
+++ b/tasks/publish.mk
@@ -3,7 +3,7 @@
 ## Install project's build dependencies.
 install-dist:
 	@$(call print_help,$@:)
-	@python -m pip install .[ci,dev]
+	@python -m pip install .[ci,dev] build
 	@$(call print_pass,$@:)
 
 ## Build & install openfisca-core for deployment and publishing.
@@ -11,6 +11,9 @@ build:
 	@## This allows us to be sure tests are run against the packaged version
 	@## of openfisca-core, the same we put in the hands of users and reusers.
 	@$(call print_help,$@:)
+	@python -m pip install --upgrade pip
+	@python -m pip install build
+	@python -m pip list | grep build
 	@python -m build
 	@python -m pip uninstall --yes openfisca-core
 	@find dist -name "*.whl" -exec python -m pip install --no-deps {} \;


### PR DESCRIPTION
This PR will close #1287 

OpenFisca-core is working with Python 3.12 since the version 43, but allowed minimal Numpy version, 1.24, do not work with Python 3.12.

So this PR change matrix test to only test Numpy version 1.26.4 with Python 3.12, and 1.24.2 + 1.26.4 for Python 3.9.13.
