### PR TITLE
fix: default maxsize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 43.2.6 [#1297](https://github.com/openfisca/openfisca-core/pull/1297)
+
+#### Bugfix
+
+- Add `int` default to `max_depth` in `openfisca test`
+
 ### 43.2.5 [#1296](https://github.com/openfisca/openfisca-core/pull/1296)
 
 #### Bugfix

--- a/openfisca_core/scripts/openfisca_command.py
+++ b/openfisca_core/scripts/openfisca_command.py
@@ -117,7 +117,7 @@ def get_parser():
             "-d",
             "--max-depth",
             type=int,
-            default=None,
+            default=sys.maxsize,
             help="set maximal verbosity depth. If specified, output the calculation trace up to the provided depth. This flag has no effect without --verbose.",
         )
         parser.add_argument(

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -25,7 +25,7 @@ from openfisca_core.warnings import LibYAMLWarning
 class Options(TypedDict, total=False):
     aggregate: bool
     ignore_variables: Sequence[str] | None
-    max_depth: int | None
+    max_depth: int
     name_filter: str | None
     only_variables: Sequence[str] | None
     pdb: bool

--- a/openfisca_core/tracers/computation_log.py
+++ b/openfisca_core/tracers/computation_log.py
@@ -40,7 +40,8 @@ class ComputationLog:
 
         This mode is more suited for simulations on a large population.
 
-        If ``max_depth`` is ``None`` (default), print the entire computation.
+        If ``max_depth`` is ``sys.maxsize`` (default), print the entire
+        computation.
 
         If ``max_depth`` is set, for example to ``3``, only print computed
         vectors up to a depth of ``max_depth``.

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ dev_requirements = [
 
 setup(
     name="OpenFisca-Core",
-    version="43.2.5",
+    version="43.2.6",
     author="OpenFisca Team",
     author_email="contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
Fixes #1293
See also #1299

#### Technical changes

- Add `int` default to `max_depth` in `openfisca test`
