### PR TITLE
fix: deepcopy variables in clone of tax_benefit_system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 43.3.0 [#1319](https://github.com/openfisca/openfisca-core/pull/1319)
+
+#### Technical change
+
+- Use a deepcopy of variables in tax and benefit system cloning instead of a copy.
+
 ### 43.2.9 [#1304](https://github.com/openfisca/openfisca-core/pull/1304)
 
 #### Bugfix

--- a/openfisca_core/taxbenefitsystems/tax_benefit_system.py
+++ b/openfisca_core/taxbenefitsystems/tax_benefit_system.py
@@ -576,7 +576,7 @@ class TaxBenefitSystem:
 
         new_dict["parameters"] = self.parameters.clone()
         new_dict["_parameters_at_instant_cache"] = {}
-        new_dict["variables"] = self.variables.copy()
+        new_dict["variables"] = copy.deepcopy(self.variables)
         new_dict["open_api_config"] = self.open_api_config.copy()
         return new
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ dev_requirements = [
 
 setup(
     name="OpenFisca-Core",
-    version="43.2.9",
+    version="43.3.0",
     author="OpenFisca Team",
     author_email="contact@openfisca.org",
     classifiers=[

--- a/tests/core/test_tracers.py
+++ b/tests/core/test_tracers.py
@@ -439,7 +439,7 @@ def test_log_aggregate(tracer) -> None:
     tracer._exit_calculation()
     lines = tracer.computation_log.lines(aggregate=True)
 
-    assert lines[0] == "  A<2017> >> {'avg': 1.0, 'max': 1, 'min': 1}"
+    assert lines[0] == "  A<2017> >> {'avg': 1.0, 'max': 1, 'min': 1}" or lines[0] == "  A<2017> >> {'avg': np.float64(1.0), 'max': np.int64(1), 'min': np.int64(1)}"
 
 
 def test_log_aggregate_with_enum(tracer) -> None:

--- a/tests/core/test_tracers.py
+++ b/tests/core/test_tracers.py
@@ -438,8 +438,13 @@ def test_log_aggregate(tracer) -> None:
     tracer.record_calculation_result(numpy.asarray([1]))
     tracer._exit_calculation()
     lines = tracer.computation_log.lines(aggregate=True)
-
-    assert lines[0] == "  A<2017> >> {'avg': 1.0, 'max': 1, 'min': 1}" or lines[0] == "  A<2017> >> {'avg': np.float64(1.0), 'max': np.int64(1), 'min': np.int64(1)}"
+    # TODO(Mauko Quiroga-Alvarado): Remove when support for NumPy 1.x is dropped
+    # https://numpy.org/doc/stable/release.html
+    expected_numpy_1 = "  A<2017> >> {'avg': 1.0, 'max': 1, 'min': 1}"
+    expected_numpy_2 = (
+        "  A<2017> >> {'avg': np.float64(1.0), 'max': np.int64(1), 'min': np.int64(1)}"
+    )
+    assert lines[0] == expected_numpy_1 or lines[0] == expected_numpy_2
 
 
 def test_log_aggregate_with_enum(tracer) -> None:


### PR DESCRIPTION
Depends on #1321

#### Technical changes

- Change the copy of the variables in tax_benefit_system.clone() to a deepcopy 
