### PR TITLE
docs: fix ambiguous doc refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 43.3.5 [#1325](https://github.com/openfisca/openfisca-core/pull/1325)
+
+#### Documentation
+
+- Remove ambiguous documentation references.
+
 ### 43.3.4 [#1302](https://github.com/openfisca/openfisca-core/pull/1302)
 
 #### Technical changes

--- a/openfisca_core/populations/_core_population.py
+++ b/openfisca_core/populations/_core_population.py
@@ -25,22 +25,22 @@ class CorePopulation:
     """Base class to build populations from.
 
     Args:
-        entity: The :class:`.CoreEntity` of the population.
+        entity: The :class:`~entities.CoreEntity` of the population.
         *__args: Variable length argument list.
         **__kwds: Arbitrary keyword arguments.
 
     """
 
-    #: The number :class:`.CoreEntity` members in the population.
+    #: The number :class:`~entities.CoreEntity` members in the population.
     count: int = 0
 
-    #: The :class:`.CoreEntity` of the population.
+    #: The :class:`~entities.CoreEntity` of the population.
     entity: t.CoreEntity
 
     #: A pseudo index for the members of the population.
     ids: Sequence[str] = []
 
-    #: The :class:`.Simulation` for which the population is calculated.
+    #: The :class:`~simulations.Simulation` for which the population is calculated.
     simulation: None | t.Simulation = None
 
     def __init__(self, entity: t.CoreEntity, *__args: object, **__kwds: object) -> None:
@@ -61,7 +61,7 @@ class CorePopulation:
             options: The options to use for the calculation.
 
         Returns:
-            None: If there is no :class:`.Simulation`.
+            None: If there is no :class:`~simulations.Simulation`.
             ndarray[generic]: The result of the calculation.
 
         Raises:

--- a/openfisca_core/reforms/reform.py
+++ b/openfisca_core/reforms/reform.py
@@ -71,7 +71,8 @@ class Reform(TaxBenefitSystem):
         Call this function in `apply()` if the reform asks for legislation parameter modifications.
 
         Args:
-            modifier_function: A function that takes a :obj:`.ParameterNode` and should return an object of the same type.
+            modifier_function: A function that takes a :obj:`~parameters.ParameterNode`
+            and should return an object of the same type.
 
         """
         baseline_parameters = self.baseline.parameters

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ dev_requirements = [
 
 setup(
     name="OpenFisca-Core",
-    version="43.3.4",
+    version="43.3.5",
     author="OpenFisca Team",
     author_email="contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
Depended upon by https://github.com/openfisca/openfisca-doc/pull/315

#### Documentation

- Remove ambiguous documentation references