### PR TITLE
Bump twine version to >= 6

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -171,6 +171,11 @@ jobs:
         path: dist
         key: pip-release-ubuntu-22.04-np1.24.2-py3.9.13-${{ hashFiles('setup.py') }}-${{ github.sha }}
 
+    - name: Check package format
+      run: |
+        source venv/bin/activate
+        twine check dist/*
+
     - name: Upload package to PyPi
       run: |
         source venv/bin/activate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
+### 43.3.7 [#1328](https://github.com/openfisca/openfisca-core/pull/1328)
+
+#### Technical changes
+
+- Bump the Twine version to fix the PyPi upload issue.
+
 ### 43.3.6 [#1289](https://github.com/openfisca/openfisca-core/pull/1289)
 
-#### Documentation
+#### Technical changes
 
 - Change Github Action matrix test to support Python 3.12.
 

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
         "dev": dev_requirements,
         "ci": [
             "build >=0.10.0, <0.11.0",
-            "twine >=5.1.1, <6.0",
+            "twine >=6.0, <7.0",
             "wheel >=0.40.0, <0.41.0",
         ],
         "tracker": ["OpenFisca-Tracker >=0.4.0, <0.5.0"],

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ dev_requirements = [
 
 setup(
     name="OpenFisca-Core",
-    version="43.3.6",
+    version="43.3.7",
     author="OpenFisca Team",
     author_email="contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
#### Technical changes

The previous build of Core [refuses to upload](https://github.com/openfisca/openfisca-core/actions/runs/14795653690/job/41542588268), the error was:
```
 Uploading distributions to https://upload.pypi.org/legacy/
ERROR    InvalidDistribution: Metadata is missing required fields: Name,        
         Version.                                                               
         Make sure the distribution includes the files where those fields are   
         specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2,   
         2.0, 2.1, 2.2, 2.3.  
```

In the METADATA file inside the dist archive we read:
`Metadata-Version: 2.4`

The solution proposed here is to bump the twine version to support Metadata-Version 2.4.

I also add a check of the dist files before trying to upload them.