### PR TITLE
Add min computation period

### DIFF
--- a/openfisca_core/simulations/simulation.py
+++ b/openfisca_core/simulations/simulation.py
@@ -59,6 +59,7 @@ class Simulation:
         self.max_spiral_loops: int = 1
         self.memory_config = None
         self._data_storage_dir = None
+        self.start_computation_date = None
 
     @property
     def trace(self):
@@ -144,6 +145,11 @@ class Simulation:
         array = None
 
         # First, try to run a formula
+        if self.start_computation_date is not None:
+            if not isinstance(self.start_computation_date, periods.Period):
+                self.start_computation_date = periods.period(self.start_computation_date)
+            if period < self.start_computation_date:
+                return holder.default_array()
         try:
             self._check_for_cycle(variable.name, period)
             array = self._run_formula(variable, population, period)

--- a/openfisca_core/simulations/simulation.py
+++ b/openfisca_core/simulations/simulation.py
@@ -145,6 +145,7 @@ class Simulation:
         array = None
 
         # First, try to run a formula
+
         if self.start_computation_date is not None:
             if not isinstance(self.start_computation_date, periods.Period):
                 self.start_computation_date = periods.period(self.start_computation_date)


### PR DESCRIPTION
#### New features

- Add a parameter `start_computation_period` in simulation : if this parameter is not None, the simulation return the default value for all variable calculate before this period. The aim is to avoid computation of variables for period before the input  variables period.
