### PR TITLE
Fix `return` instead of `raise`.

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04, windows-2019]
+        os: [ubuntu-22.04, windows-2025]
         numpy: [1.26.4]
         # Patch version must be specified to avoid any cache confusion, since
         # the cache key depends on the full Python version. If left unspecified,
@@ -25,13 +25,13 @@ jobs:
           python: 3.9.13
           numpy: 1.24.2
           activate_command: source venv/bin/activate
-        - os: windows-2019
+        - os: windows-2025
           python: 3.9.13
           numpy: 1.24.2
           activate_command: .\venv\Scripts\activate
         - os: ubuntu-22.04
           activate_command: source venv/bin/activate
-        - os: windows-2019
+        - os: windows-2025
           activate_command: .\venv\Scripts\activate
     uses: ./.github/workflows/_before-pip.yaml
     with:
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04, windows-2019]
+        os: [ubuntu-22.04, windows-2025]
         numpy: [1.26.4]
         python: [3.12.3, 3.9.13]
         include:
@@ -60,13 +60,13 @@ jobs:
           python: 3.9.13
           numpy: 1.24.2
           activate_command: source venv/bin/activate
-        - os: windows-2019
+        - os: windows-2025
           python: 3.9.13
           numpy: 1.24.2
           activate_command: .\venv\Scripts\activate
         - os: ubuntu-22.04
           activate_command: source venv/bin/activate
-        - os: windows-2019
+        - os: windows-2025
           activate_command: .\venv\Scripts\activate
     uses: ./.github/workflows/_test-pip.yaml
     with:
@@ -245,7 +245,7 @@ jobs:
           --api-key ${{ secrets.ANACONDA_TOKEN }}
 
   test-on-windows:
-    runs-on: windows-2019
+    runs-on: windows-2025
     needs: [publish-to-conda]
     defaults:
       run:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04, windows-2019]
+        os: [ubuntu-22.04, windows-2025]
         numpy: [1.26.4]
         # Patch version must be specified to avoid any cache confusion, since
         # the cache key depends on the full Python version. If left unspecified,
@@ -25,13 +25,13 @@ jobs:
           python: 3.9.13
           numpy: 1.24.2
           activate_command: source venv/bin/activate
-        - os: windows-2019
+        - os: windows-2025
           python: 3.9.13
           numpy: 1.24.2
           activate_command: .\venv\Scripts\activate
         - os: ubuntu-22.04
           activate_command: source venv/bin/activate
-        - os: windows-2019
+        - os: windows-2025
           activate_command: .\venv\Scripts\activate
     uses: ./.github/workflows/_before-pip.yaml
     with:
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-2019]
+        os: [ubuntu-22.04, windows-2025]
         numpy: [1.26.4]
         python: [3.12.3, 3.9.13]
         include:
@@ -60,13 +60,13 @@ jobs:
           python: 3.9.13
           numpy: 1.24.2
           activate_command: source venv/bin/activate
-        - os: windows-2019
+        - os: windows-2025
           python: 3.9.13
           numpy: 1.24.2
           activate_command: .\venv\Scripts\activate
         - os: ubuntu-22.04
           activate_command: source venv/bin/activate
-        - os: windows-2019
+        - os: windows-2025
           activate_command: .\venv\Scripts\activate
     uses: ./.github/workflows/_test-pip.yaml
     with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 43.3.9 [#1332](https://github.com/openfisca/openfisca-core/pull/1332)
+
+#### New features
+
+- Fix a `return` instead of a `raise`.
+
 ### 43.3.8 [#1329](https://github.com/openfisca/openfisca-core/pull/1329)
 
 #### New features

--- a/openfisca_core/reforms/reform.py
+++ b/openfisca_core/reforms/reform.py
@@ -79,7 +79,7 @@ class Reform(TaxBenefitSystem):
         baseline_parameters_copy = copy.deepcopy(baseline_parameters)
         reform_parameters = modifier_function(baseline_parameters_copy)
         if not isinstance(reform_parameters, ParameterNode):
-            return ValueError(
+            raise ValueError(
                 f"modifier_function {modifier_function.__name__} in module {modifier_function.__module__} must return a ParameterNode",
             )
         self.parameters = reform_parameters

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ dev_requirements = [
 
 setup(
     name="OpenFisca-Core",
-    version="43.3.8",
+    version="43.3.9",
     author="OpenFisca Team",
     author_email="contact@openfisca.org",
     classifiers=[

--- a/tests/core/parameter_validation/test_reform_parameter_validation.py
+++ b/tests/core/parameter_validation/test_reform_parameter_validation.py
@@ -1,0 +1,132 @@
+import pytest
+
+from openfisca_core.parameters import ParameterNode
+from openfisca_core.reforms import Reform
+
+
+def test_modify_parameters_must_return_parameter_node(tax_benefit_system):
+    """Test that modify_parameters raises ValueError when modifier function doesn't return ParameterNode."""
+    
+    def modifier_function_without_return(parameters):
+        """A modifier function that doesn't return anything (returns None)."""
+        parameters.benefits.basic_income.update(start="2015-01-01", value=100)
+        # Missing return statement - this should raise ValueError
+    
+    def modifier_function_returns_wrong_type(parameters):
+        """A modifier function that returns the wrong type."""
+        parameters.benefits.basic_income.update(start="2015-01-01", value=100)
+        return "not a ParameterNode"  # Wrong return type
+    
+    def modifier_function_returns_none_explicitly(parameters):
+        """A modifier function that explicitly returns None."""
+        parameters.benefits.basic_income.update(start="2015-01-01", value=100)
+        return None
+    
+    def modifier_function_correct(parameters):
+        """A modifier function that correctly returns ParameterNode."""
+        parameters.benefits.basic_income.update(start="2015-01-01", value=100)
+        return parameters
+    
+    # Test case 1: Function without return statement (implicitly returns None)
+    class ReformWithoutReturn(Reform):
+        def apply(self):
+            self.modify_parameters(modifier_function=modifier_function_without_return)
+    
+    with pytest.raises(ValueError) as exc_info:
+        ReformWithoutReturn(tax_benefit_system)
+    
+    assert "modifier_function_without_return" in str(exc_info.value)
+    assert "must return a ParameterNode" in str(exc_info.value)
+    
+    # Test case 2: Function returns wrong type
+    class ReformWithWrongReturnType(Reform):
+        def apply(self):
+            self.modify_parameters(modifier_function=modifier_function_returns_wrong_type)
+    
+    with pytest.raises(ValueError) as exc_info:
+        ReformWithWrongReturnType(tax_benefit_system)
+    
+    assert "modifier_function_returns_wrong_type" in str(exc_info.value)
+    assert "must return a ParameterNode" in str(exc_info.value)
+    
+    # Test case 3: Function explicitly returns None
+    class ReformWithExplicitNone(Reform):
+        def apply(self):
+            self.modify_parameters(modifier_function=modifier_function_returns_none_explicitly)
+    
+    with pytest.raises(ValueError) as exc_info:
+        ReformWithExplicitNone(tax_benefit_system)
+    
+    assert "modifier_function_returns_none_explicitly" in str(exc_info.value)
+    assert "must return a ParameterNode" in str(exc_info.value)
+    
+    # Test case 4: Correct function that returns ParameterNode (should work)
+    class ReformCorrect(Reform):
+        def apply(self):
+            self.modify_parameters(modifier_function=modifier_function_correct)
+    
+    # This should not raise any exception
+    reformed_tbs = ReformCorrect(tax_benefit_system)
+    
+    # Verify the reform was applied correctly
+    assert reformed_tbs.parameters.benefits.basic_income("2015-01-01") == 100
+
+
+def test_modify_parameters_error_message_includes_function_details(tax_benefit_system):
+    """Test that the error message includes the function name and module."""
+    
+    def my_faulty_modifier(parameters):
+        return "wrong type"
+    
+    class TestReform(Reform):
+        def apply(self):
+            self.modify_parameters(modifier_function=my_faulty_modifier)
+    
+    with pytest.raises(ValueError) as exc_info:
+        TestReform(tax_benefit_system)
+    
+    error_message = str(exc_info.value)
+    assert "my_faulty_modifier" in error_message
+    assert "__main__" in error_message or "test_reform_parameter_validation" in error_message
+    assert "must return a ParameterNode" in error_message
+
+
+def test_modify_parameters_with_lambda_function(tax_benefit_system):
+    """Test that the error message works correctly even with lambda functions."""
+    
+    class TestReform(Reform):
+        def apply(self):
+            # Using a lambda that doesn't return ParameterNode
+            self.modify_parameters(modifier_function=lambda params: None)
+    
+    with pytest.raises(ValueError) as exc_info:
+        TestReform(tax_benefit_system)
+    
+    error_message = str(exc_info.value)
+    assert "<lambda>" in error_message
+    assert "must return a ParameterNode" in error_message
+
+
+def test_modify_parameters_preserves_parameter_structure(tax_benefit_system):
+    """Test that a correctly implemented modifier function preserves parameter structure."""
+    
+    def correct_modifier(parameters):
+        # Create a copy to avoid modifying the original
+        import copy
+        modified_params = copy.deepcopy(parameters)
+        modified_params.benefits.basic_income.update(start="2015-01-01", value=200)
+        return modified_params
+    
+    class TestReform(Reform):
+        def apply(self):
+            self.modify_parameters(modifier_function=correct_modifier)
+    
+    reformed_tbs = TestReform(tax_benefit_system)
+    
+    # Verify the parameter structure is preserved and modification applied
+    assert isinstance(reformed_tbs.parameters, ParameterNode)
+    assert reformed_tbs.parameters.benefits.basic_income("2015-01-01") == 200
+    
+    # Verify that the original tax benefit system is not modified
+    original_value = tax_benefit_system.parameters.benefits.basic_income("2015-01-01")
+    assert original_value != 200  # Should be the original value

--- a/tests/core/parameter_validation/test_reform_parameter_validation.py
+++ b/tests/core/parameter_validation/test_reform_parameter_validation.py
@@ -6,102 +6,109 @@ from openfisca_core.reforms import Reform
 
 def test_modify_parameters_must_return_parameter_node(tax_benefit_system):
     """Test that modify_parameters raises ValueError when modifier function doesn't return ParameterNode."""
-    
+
     def modifier_function_without_return(parameters):
         """A modifier function that doesn't return anything (returns None)."""
         parameters.benefits.basic_income.update(start="2015-01-01", value=100)
         # Missing return statement - this should raise ValueError
-    
+
     def modifier_function_returns_wrong_type(parameters):
         """A modifier function that returns the wrong type."""
         parameters.benefits.basic_income.update(start="2015-01-01", value=100)
         return "not a ParameterNode"  # Wrong return type
-    
+
     def modifier_function_returns_none_explicitly(parameters):
         """A modifier function that explicitly returns None."""
         parameters.benefits.basic_income.update(start="2015-01-01", value=100)
         return None
-    
+
     def modifier_function_correct(parameters):
         """A modifier function that correctly returns ParameterNode."""
         parameters.benefits.basic_income.update(start="2015-01-01", value=100)
         return parameters
-    
+
     # Test case 1: Function without return statement (implicitly returns None)
     class ReformWithoutReturn(Reform):
         def apply(self):
             self.modify_parameters(modifier_function=modifier_function_without_return)
-    
+
     with pytest.raises(ValueError) as exc_info:
         ReformWithoutReturn(tax_benefit_system)
-    
+
     assert "modifier_function_without_return" in str(exc_info.value)
     assert "must return a ParameterNode" in str(exc_info.value)
-    
+
     # Test case 2: Function returns wrong type
     class ReformWithWrongReturnType(Reform):
         def apply(self):
-            self.modify_parameters(modifier_function=modifier_function_returns_wrong_type)
-    
+            self.modify_parameters(
+                modifier_function=modifier_function_returns_wrong_type
+            )
+
     with pytest.raises(ValueError) as exc_info:
         ReformWithWrongReturnType(tax_benefit_system)
-    
+
     assert "modifier_function_returns_wrong_type" in str(exc_info.value)
     assert "must return a ParameterNode" in str(exc_info.value)
-    
+
     # Test case 3: Function explicitly returns None
     class ReformWithExplicitNone(Reform):
         def apply(self):
-            self.modify_parameters(modifier_function=modifier_function_returns_none_explicitly)
-    
+            self.modify_parameters(
+                modifier_function=modifier_function_returns_none_explicitly
+            )
+
     with pytest.raises(ValueError) as exc_info:
         ReformWithExplicitNone(tax_benefit_system)
-    
+
     assert "modifier_function_returns_none_explicitly" in str(exc_info.value)
     assert "must return a ParameterNode" in str(exc_info.value)
-    
+
     # Test case 4: Correct function that returns ParameterNode (should work)
     class ReformCorrect(Reform):
         def apply(self):
             self.modify_parameters(modifier_function=modifier_function_correct)
-    
+
     # This should not raise any exception
     reformed_tbs = ReformCorrect(tax_benefit_system)
-    
+
     # Verify the reform was applied correctly
     assert reformed_tbs.parameters.benefits.basic_income("2015-01-01") == 100
 
 
 def test_modify_parameters_error_message_includes_function_details(tax_benefit_system):
     """Test that the error message includes the function name and module."""
-    
+
     def my_faulty_modifier(parameters):
         return "wrong type"
-    
+
     class TestReform(Reform):
         def apply(self):
             self.modify_parameters(modifier_function=my_faulty_modifier)
-    
+
     with pytest.raises(ValueError) as exc_info:
         TestReform(tax_benefit_system)
-    
+
     error_message = str(exc_info.value)
     assert "my_faulty_modifier" in error_message
-    assert "__main__" in error_message or "test_reform_parameter_validation" in error_message
+    assert (
+        "__main__" in error_message
+        or "test_reform_parameter_validation" in error_message
+    )
     assert "must return a ParameterNode" in error_message
 
 
 def test_modify_parameters_with_lambda_function(tax_benefit_system):
     """Test that the error message works correctly even with lambda functions."""
-    
+
     class TestReform(Reform):
         def apply(self):
             # Using a lambda that doesn't return ParameterNode
             self.modify_parameters(modifier_function=lambda params: None)
-    
+
     with pytest.raises(ValueError) as exc_info:
         TestReform(tax_benefit_system)
-    
+
     error_message = str(exc_info.value)
     assert "<lambda>" in error_message
     assert "must return a ParameterNode" in error_message
@@ -109,24 +116,25 @@ def test_modify_parameters_with_lambda_function(tax_benefit_system):
 
 def test_modify_parameters_preserves_parameter_structure(tax_benefit_system):
     """Test that a correctly implemented modifier function preserves parameter structure."""
-    
+
     def correct_modifier(parameters):
         # Create a copy to avoid modifying the original
         import copy
+
         modified_params = copy.deepcopy(parameters)
         modified_params.benefits.basic_income.update(start="2015-01-01", value=200)
         return modified_params
-    
+
     class TestReform(Reform):
         def apply(self):
             self.modify_parameters(modifier_function=correct_modifier)
-    
+
     reformed_tbs = TestReform(tax_benefit_system)
-    
+
     # Verify the parameter structure is preserved and modification applied
     assert isinstance(reformed_tbs.parameters, ParameterNode)
     assert reformed_tbs.parameters.benefits.basic_income("2015-01-01") == 200
-    
+
     # Verify that the original tax benefit system is not modified
     original_value = tax_benefit_system.parameters.benefits.basic_income("2015-01-01")
     assert original_value != 200  # Should be the original value


### PR DESCRIPTION
#### Technical changes
- the modify_my_parameters function should return the ParameterNode, but you're not getting the expected error.  In the modify_parameters method on line 81, there's a bug in the code. It should raise a ValueError, but instead it returns a ValueError. This means the error is created but not actually thrown, so your code continues executing without the expected error.

- Will close #1331 
