### PR TITLE
Add --ignore-default option to openfisca test command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 44.2.0
+
+#### New features
+
+- Add `--ignore-default` option to `openfisca test` command
+  - When used with `--verbose`, filters out variables that have their default value from the computation log output
+  - When a variable with its default value is hidden, its children are also hidden, even if they have non-default values
+  - This makes the computation log more readable by focusing on variables with meaningful values
+
 ## 44.1.0 [#1355](https://github.com/openfisca/openfisca-core/pull/1355)
 
 #### New features

--- a/README.md
+++ b/README.md
@@ -143,10 +143,13 @@ touch .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit
 
 tee -a .git/hooks/pre-commit << END
-#!/bin/sh
+#!/bin/bash
 #
 # Automatically format your code before committing.
+# Change .venv/bin/activate if your virtual environment is located elsewhere.
+source .venv/bin/activate
 exec make format-style
+exec make check-style
 END
 ```
 

--- a/openfisca_core/scripts/openfisca_command.py
+++ b/openfisca_core/scripts/openfisca_command.py
@@ -152,6 +152,12 @@ def get_parser():
             default=0,
             help="number of parallel workers (default: CPU count - 1)",
         )
+        parser.add_argument(
+            "--ignore-default",
+            action="store_true",
+            default=False,
+            help="in verbose mode, do not display variables that have their default value",
+        )
 
         return parser
 

--- a/openfisca_core/scripts/run_test.py
+++ b/openfisca_core/scripts/run_test.py
@@ -32,6 +32,7 @@ def main(parser) -> None:
         "name_filter": args.name_filter,
         "only_variables": args.only_variables,
         "ignore_variables": args.ignore_variables,
+        "ignore_default": args.ignore_default,
     }
 
     paths = [os.path.abspath(path) for path in args.path]

--- a/openfisca_core/tools/test_runner.py
+++ b/openfisca_core/tools/test_runner.py
@@ -40,6 +40,7 @@ from openfisca_core.warnings import LibYAMLWarning
 
 class Options(TypedDict, total=False):
     aggregate: bool
+    ignore_default: bool
     ignore_variables: Sequence[str] | None
     max_depth: int
     name_filter: str | None
@@ -636,14 +637,25 @@ class YamlItem(pytest.Item):
         finally:
             tracer = self.simulation.tracer
             if verbose:
-                self.print_computation_log(tracer, aggregate, max_depth)
+                ignore_default = self.options.get("ignore_default", False)
+                self.print_computation_log(
+                    tracer,
+                    aggregate,
+                    max_depth,
+                    ignore_default,
+                    self.tax_benefit_system,
+                )
             if performance_graph:
                 self.generate_performance_graph(tracer)
             if performance_tables:
                 self.generate_performance_tables(tracer)
 
-    def print_computation_log(self, tracer, aggregate, max_depth) -> None:
-        tracer.print_computation_log(aggregate, max_depth)
+    def print_computation_log(
+        self, tracer, aggregate, max_depth, ignore_default, tax_benefit_system
+    ) -> None:
+        tracer.print_computation_log(
+            aggregate, max_depth, ignore_default, tax_benefit_system
+        )
 
     def generate_performance_graph(self, tracer) -> None:
         tracer.generate_performance_graph(".")

--- a/openfisca_core/tracers/computation_log.py
+++ b/openfisca_core/tracers/computation_log.py
@@ -5,7 +5,7 @@ import sys
 import numpy
 
 from openfisca_core import types as t
-from openfisca_core.indexed_enums import EnumArray
+from openfisca_core.indexed_enums import Enum, EnumArray
 
 
 class ComputationLog:
@@ -18,17 +18,39 @@ class ComputationLog:
         self,
         aggregate: bool = False,
         max_depth: int = sys.maxsize,
+        ignore_default: bool = False,
+        tax_benefit_system: t.TaxBenefitSystem | None = None,
     ) -> list[str]:
+        """Generate lines for the computation log.
+
+        Args:
+            aggregate: Show aggregated statistics instead of individual values.
+            max_depth: Maximum depth to display in the computation tree.
+            ignore_default: Hide variables with default values and their children.
+            tax_benefit_system: Used to get default values for variables.
+
+        Returns:
+            List of strings representing the computation log lines.
+
+        """
         depth = 1
 
         lines_by_tree = [
-            self._get_node_log(node, depth, aggregate, max_depth)
+            self._get_node_log(
+                node, depth, aggregate, max_depth, ignore_default, tax_benefit_system
+            )
             for node in self._full_tracer.trees
         ]
 
         return self._flatten(lines_by_tree)
 
-    def print_log(self, aggregate: bool = False, max_depth: int = sys.maxsize) -> None:
+    def print_log(
+        self,
+        aggregate: bool = False,
+        max_depth: int = sys.maxsize,
+        ignore_default: bool = False,
+        tax_benefit_system: t.TaxBenefitSystem | None = None,
+    ) -> None:
         """Print the computation log of a simulation.
 
         If ``aggregate`` is ``False`` (default), print the value of each
@@ -44,8 +66,14 @@ class ComputationLog:
 
         If ``max_depth`` is set, for example to ``3``, only print computed
         vectors up to a depth of ``max_depth``.
+
+        If ``ignore_default`` is ``True``, do not display variables that have
+        their default value. When a variable with its default value is hidden,
+        its children are also hidden, even if they have non-default values.
         """
-        for line in self.lines(aggregate, max_depth):
+        for line in self.lines(
+            aggregate, max_depth, ignore_default, tax_benefit_system
+        ):
             print(line)  # noqa: T201
 
     def _get_node_log(
@@ -54,18 +82,80 @@ class ComputationLog:
         depth: int,
         aggregate: bool,
         max_depth: int = sys.maxsize,
+        ignore_default: bool = False,
+        tax_benefit_system: t.TaxBenefitSystem | None = None,
     ) -> list[str]:
         if depth > max_depth:
+            return []
+
+        # Check if we should ignore this node because it has its default value
+        if ignore_default and self._is_default_value(node, tax_benefit_system):
+            # Don't display this node or its children
             return []
 
         node_log = [self._print_line(depth, node, aggregate)]
 
         children_logs = [
-            self._get_node_log(child, depth + 1, aggregate, max_depth)
+            self._get_node_log(
+                child,
+                depth + 1,
+                aggregate,
+                max_depth,
+                ignore_default,
+                tax_benefit_system,
+            )
             for child in node.children
         ]
 
         return node_log + self._flatten(children_logs)
+
+    def _is_default_value(
+        self, node: t.TraceNode, tax_benefit_system: t.TaxBenefitSystem | None
+    ) -> bool:
+        """Check if a node's value is the default value for its variable.
+
+        Args:
+            node: The trace node to check
+            tax_benefit_system: The tax benefit system to get variable information
+
+        Returns:
+            True if the value is the default value, False otherwise
+        """
+        if tax_benefit_system is None or node.value is None:
+            return False
+
+        try:
+            variable = tax_benefit_system.get_variable(node.name)
+            if variable is None:
+                return False
+
+            default_value = variable.default_value
+            if default_value is None:
+                return False
+
+            # For arrays, check if all values equal the default
+            if isinstance(node.value, numpy.ndarray):
+                # Handle EnumArray specially
+                if isinstance(node.value, EnumArray):
+                    # For Enum, compare the enum values
+                    if variable.value_type == Enum:
+                        # Check if all values in the array are the default enum value
+                        return numpy.all(node.value == default_value)
+                    return False
+
+                # For numeric/boolean arrays, check if all values equal default
+                try:
+                    return numpy.all(node.value == default_value)
+                except (ValueError, TypeError):
+                    # If comparison fails, assume not default
+                    return False
+
+            # For scalar values, direct comparison
+            return node.value == default_value
+
+        except Exception:
+            # If we can't determine, assume not default to be safe
+            return False
 
     def _print_line(self, depth: int, node: t.TraceNode, aggregate: bool) -> str:
         indent = "  " * depth

--- a/openfisca_core/tracers/full_tracer.py
+++ b/openfisca_core/tracers/full_tracer.py
@@ -79,9 +79,15 @@ class FullTracer:
         self._exit_calculation()
 
     def print_computation_log(
-        self, aggregate: bool = False, max_depth: int = sys.maxsize
+        self,
+        aggregate: bool = False,
+        max_depth: int = sys.maxsize,
+        ignore_default: bool = False,
+        tax_benefit_system: t.TaxBenefitSystem | None = None,
     ) -> None:
-        self.computation_log.print_log(aggregate, max_depth)
+        self.computation_log.print_log(
+            aggregate, max_depth, ignore_default, tax_benefit_system
+        )
 
     def generate_performance_graph(self, dir_path: str) -> None:
         self.performance_log.generate_graph(dir_path)

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ dev_requirements = [
 
 setup(
     name="OpenFisca-Core",
-    version="44.1.0",
+    version="44.2.0",
     author="OpenFisca Team",
     author_email="contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
#### New features

- Add `--ignore-default` option to `openfisca test` command
  - When used with `--verbose`, filters out variables that have their default value from the computation log output