### PR TITLE
Fix float and int precision for big number calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## XX.X.X [#1378](https://github.com/openfisca/openfisca-core/pull/1378)
+
+#### Technical changes
+
+- Allows calculation for big numbers
+    - Replace `int32 `with `int64 `and `float32 `with `float64`
+
 ## 44.7.0 [#1357](https://github.com/openfisca/openfisca-core/pull/1357)
 
 #### New features

--- a/openfisca_core/tools/__init__.py
+++ b/openfisca_core/tools/__init__.py
@@ -40,9 +40,9 @@ def assert_near(
     if isinstance(target_value, list) and isinstance(target_value[0], str):
         return assert_array_equal(value, target_value)
 
-    target_value = numpy.array(target_value).astype(numpy.float32)
+    target_value = numpy.array(target_value).astype(numpy.float64)
 
-    value = numpy.array(value).astype(numpy.float32)
+    value = numpy.array(value).astype(numpy.float64)
     diff = abs(target_value - value)
     if absolute_error_margin is not None:
         assert (

--- a/openfisca_core/variables/config.py
+++ b/openfisca_core/variables/config.py
@@ -14,14 +14,14 @@ VALUE_TYPES = {
         "is_period_size_independent": True,
     },
     int: {
-        "dtype": numpy.int32,
+        "dtype": numpy.int64,
         "default": 0,
         "json_type": "integer",
         "formatted_value_type": "Int",
         "is_period_size_independent": False,
     },
     float: {
-        "dtype": numpy.float32,
+        "dtype": numpy.float64,
         "default": 0,
         "json_type": "number",
         "formatted_value_type": "Float",

--- a/tests/core/tools/test_runner/test_yaml_runner.py
+++ b/tests/core/tools/test_runner/test_yaml_runner.py
@@ -79,7 +79,7 @@ class TestVariable(Variable):
         self.entity = Entity("person", "persons", None, "")
         self.is_neutralized = False
         self.set_input = None
-        self.dtype = numpy.float32
+        self.dtype = numpy.float64
 
 
 @pytest.mark.skip(reason="Deprecated node constructor")

--- a/tests/core/variables/test_precision.py
+++ b/tests/core/variables/test_precision.py
@@ -1,0 +1,73 @@
+import numpy as np
+from pytest import fixture
+
+from openfisca_core.entities import build_entity
+from openfisca_core.periods import DateUnit
+from openfisca_core.simulations import SimulationBuilder
+from openfisca_core.taxbenefitsystems import TaxBenefitSystem
+from openfisca_core.variables import Variable
+
+Person = build_entity(
+    key="person",
+    plural="persons",
+    label="Person",
+    is_person=True,
+)
+
+
+@fixture
+def tbs():
+    return TaxBenefitSystem([Person])
+
+
+def test_float32_precision():
+    """
+    Reproduction of float precision issue.
+    Calculated from: 524709269 * 0.13 = 68212204.97 -> np.round(68212204.97)
+
+    In float64, this test will pass with a result 68212205.0
+    In float32, this test will fail with a result 68212200.0
+    """
+    tbs = TaxBenefitSystem([Person])
+
+    class value(Variable):
+        value_type = float
+        entity = Person
+        definition_period = DateUnit.MONTH
+
+    class rate(Variable):
+        value_type = float
+        entity = Person
+        definition_period = DateUnit.MONTH
+        default_value = 0.13
+
+    class total(Variable):
+        value_type = float
+        entity = Person
+        definition_period = DateUnit.MONTH
+
+        def formula(person, period, parameters):
+            value1 = person("value", period)
+            rate1 = person("rate", period)
+            return np.round(value1 * rate1)
+
+    tbs.add_variable(value)
+    tbs.add_variable(rate)
+    tbs.add_variable(total)
+
+    period = "2020-01"
+    sb = SimulationBuilder()
+    sim = sb.build_from_dict(tbs, {
+        "persons": {
+            "p1": {
+                "value": {period: 524709269}
+            }
+        }
+    })
+
+    result = sim.calculate("total", period)
+    expected = 68212205.0
+
+    assert result[0] == expected, f"Expected {expected}, got {result[0]}"
+
+


### PR DESCRIPTION
#### Technical changes

- Allows calculation for big numbers
  - Replace `int32` with `int64` and `float32` with `float64`

----

### Context

The French Polynesian administration uses OpenFisca in production to calculate certain taxes, where calculation precision is critical. We expected exact results even when working with very large numbers. However, we identified discrepancies in some calculations involving large values.

To address this issue, we updated the core engine to improve numerical precision. This pull request introduces that fix to the community 😳

#### Here an exemple of failing tests

[French Polynesian tax tests](https://github.com/govpf/openfisca-pf/blob/d3628bdab3845c3bd3f8df54ae0e5ad6262d5e98/openfisca_pf/tests/dicp/tva/tests_tva.yaml#L210)

We detected a difference of 8 francs in a calculation involving millions: 68,212,200 instead of 68,212,208.

```sh
(venv) PS C:\Users\user\Projects\openfisca\openfisca-pf> openfisca test --country-package openfisca_pf .\openfisca_pf\tests\dicp\tva\tests_tva.yaml       
=============================================================================== test session starts ===============================================================================
platform win32 -- Python 3.10.4, pytest-8.4.2, pluggy-1.5.0
rootdir: C:\Users\user\Projects\openfisca\openfisca-pf
configfile: setup.cfg
collected 22 items                                                                                                                                                                 

openfisca_pf\tests\dicp\tva\tests_tva.yaml .FF.F..F.FFF.F........                                                                                                            [  4%]

==================================================================================== FAILURES =====================================================================================
....
__________________________________________________________________________________ test session ___________________________________________________________________________________
C:\Users\user\Projects\openfisca\openfisca-pf\openfisca_pf\tests\dicp\tva\tests_tva.yaml:
  Test '12':
    tva_due_taux_intermediaire@2020-01: [68212200.] differs from 68212208.0 with an absolute margin [8.] > 0
....
============================================================================= short test summary info =============================================================================
FAILED openfisca_pf/tests/dicp/tva/tests_tva.yaml::
...
========================================================================== 8 failed, 14 passed in 0.46s ===========================================================================
```

My test failed in this environnement:

```sh
(venv) PS C:\Users\user\Projects\openfisca\openfisca-pf> pip list                                                                                  
Package            Version     Editable project location
------------------ ----------- -----------------------------------------------------
.....
numpy              1.26.4
OpenFisca-Core     44.7.0      C:\Users\user\Projects\openfisca\openfisca-core
OpenFisca-PF       0.9.0       c:\users\user\projects\openfisca\openfisca-pf
....
```