### PR TITLE
feat(holders): distinguish explicit input from default values

### DIFF
--- a/.conda/openfisca-core/meta.yaml
+++ b/.conda/openfisca-core/meta.yaml
@@ -49,10 +49,8 @@ test:
 
 outputs:
   - name: openfisca-core
-    type: conda_v2
 
   - name: openfisca-core-api
-    type: conda_v2
     build:
       noarch: python
     requirements:
@@ -68,7 +66,6 @@ outputs:
         - {{ pin_subpackage('openfisca-core', exact=True) }}
 
   - name: openfisca-core-dev
-    type: conda_v2
     build:
       noarch: python
     requirements:

--- a/.github/has-functional-changes.sh
+++ b/.github/has-functional-changes.sh
@@ -2,9 +2,17 @@
 
 IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore LICENSE* .github/* tests/* openfisca_tasks/*.mk tasks/*.mk publiccode.yml"
 
-last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in master through an unlikely intermediary merge commit
+if last_tagged_commit=$(git describe --tags --abbrev=0 --first-parent 2>/dev/null)
+then
+  comparison_commit=$last_tagged_commit
+elif [[ -n ${GITHUB_BASE_REF:-} ]] && git rev-parse --verify --quiet "origin/$GITHUB_BASE_REF" >/dev/null
+then
+  comparison_commit=$(git merge-base HEAD "origin/$GITHUB_BASE_REF")
+else
+  comparison_commit=$(git rev-parse HEAD^)
+fi
 
-if git diff-index --name-only --exit-code $last_tagged_commit -- . `echo " $IGNORE_DIFF_ON" | sed 's/ / :(exclude)/g'`  # Check if any file that has not be listed in IGNORE_DIFF_ON has changed since the last tag was published.
+if git diff-index --name-only --exit-code "$comparison_commit" -- . `echo " $IGNORE_DIFF_ON" | sed 's/ / :(exclude)/g'`  # Check if any functional file has changed since the comparison commit.
 then
   echo "No functional changes detected."
   exit 1

--- a/.github/workflows/_before-conda.yaml
+++ b/.github/workflows/_before-conda.yaml
@@ -66,7 +66,7 @@ jobs:
       if: steps.cache-env.outputs.cache-hit != 'true'
 
     - name: Install dependencies
-      run: mamba install boa rattler-build
+      run: mamba install conda-build rattler-build
       if: steps.cache-env.outputs.cache-hit != 'true'
 
     - name: Update conda & dependencies
@@ -86,7 +86,7 @@ jobs:
 
     - name: Build core package
       run: |
-        conda mambabuild .conda/openfisca-core \
+        conda build .conda/openfisca-core \
           --use-local \
           --no-anaconda-upload \
           --output-folder ~/conda-rel \

--- a/.github/workflows/_before-conda.yaml
+++ b/.github/workflows/_before-conda.yaml
@@ -38,7 +38,7 @@ jobs:
           /usr/share/miniconda/envs/openfisca
           ~/.conda/envs/openfisca
           .env.yaml
-        key: conda-env-${{ inputs.os }}-np${{ inputs.numpy }}-py${{ inputs.python }}-${{ hashFiles('setup.py') }}
+        key: conda-env-${{ inputs.os }}-np${{ inputs.numpy }}-py${{ inputs.python }}-${{ hashFiles('setup.py', '.github/workflows/_before-conda.yaml') }}
         restore-keys: conda-env-${{ inputs.os }}-np${{ inputs.numpy }}-py${{ inputs.python }}-
       id: cache-env
 
@@ -46,7 +46,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/conda_pkgs_dir
-        key: conda-deps-${{ inputs.os }}-np${{ inputs.numpy }}-py${{ inputs.python }}-${{ hashFiles('setup.py') }}
+        key: conda-deps-${{ inputs.os }}-np${{ inputs.numpy }}-py${{ inputs.python }}-${{ hashFiles('setup.py', '.github/workflows/_before-conda.yaml') }}
         restore-keys: conda-deps-${{ inputs.os }}-np${{ inputs.numpy }}-py${{ inputs.python }}-
       id: cache-deps
 

--- a/.github/workflows/_before-conda.yaml
+++ b/.github/workflows/_before-conda.yaml
@@ -38,7 +38,7 @@ jobs:
           /usr/share/miniconda/envs/openfisca
           ~/.conda/envs/openfisca
           .env.yaml
-        key: conda-env-${{ inputs.os }}-np${{ inputs.numpy }}-py${{ inputs.python }}-${{ hashFiles('setup.py') }}
+        key: conda-env-${{ inputs.os }}-np${{ inputs.numpy }}-py${{ inputs.python }}-${{ hashFiles('setup.py', '.github/workflows/_before-conda.yaml') }}
         restore-keys: conda-env-${{ inputs.os }}-np${{ inputs.numpy }}-py${{ inputs.python }}-
       id: cache-env
 
@@ -46,7 +46,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/conda_pkgs_dir
-        key: conda-deps-${{ inputs.os }}-np${{ inputs.numpy }}-py${{ inputs.python }}-${{ hashFiles('setup.py') }}
+        key: conda-deps-${{ inputs.os }}-np${{ inputs.numpy }}-py${{ inputs.python }}-${{ hashFiles('setup.py', '.github/workflows/_before-conda.yaml') }}
         restore-keys: conda-deps-${{ inputs.os }}-np${{ inputs.numpy }}-py${{ inputs.python }}-
       id: cache-deps
 
@@ -66,7 +66,7 @@ jobs:
       if: steps.cache-env.outputs.cache-hit != 'true'
 
     - name: Install dependencies
-      run: mamba install boa rattler-build
+      run: mamba install conda-build rattler-build
       if: steps.cache-env.outputs.cache-hit != 'true'
 
     - name: Update conda & dependencies
@@ -86,8 +86,10 @@ jobs:
 
     - name: Build core package
       run: |
-        conda mambabuild .conda/openfisca-core \
+        conda-build .conda/openfisca-core \
           --use-local \
+          --channel conda-forge \
+          --package-format 2 \
           --no-anaconda-upload \
           --output-folder ~/conda-rel \
           --numpy ${{ inputs.numpy }} \

--- a/.github/workflows/_test-conda.yaml
+++ b/.github/workflows/_test-conda.yaml
@@ -37,13 +37,13 @@ jobs:
           /usr/share/miniconda/envs/openfisca
           ~/.conda/envs/openfisca
           .env.yaml
-        key: conda-env-${{ inputs.os }}-np${{ inputs.numpy }}-py${{ inputs.python }}-${{ hashFiles('setup.py') }}
+        key: conda-env-${{ inputs.os }}-np${{ inputs.numpy }}-py${{ inputs.python }}-${{ hashFiles('setup.py', '.github/workflows/_before-conda.yaml') }}
 
     - name: Cache conda deps
       uses: actions/cache@v4
       with:
         path: ~/conda_pkgs_dir
-        key: conda-deps-${{ inputs.os }}-np${{ inputs.numpy }}-py${{ inputs.python }}-${{ hashFiles('setup.py') }}
+        key: conda-deps-${{ inputs.os }}-np${{ inputs.numpy }}-py${{ inputs.python }}-${{ hashFiles('setup.py', '.github/workflows/_before-conda.yaml') }}
 
     - name: Cache release
       uses: actions/cache@v4

--- a/.github/workflows/_version.yaml
+++ b/.github/workflows/_version.yaml
@@ -34,5 +34,8 @@ jobs:
       with:
         python-version: ${{ inputs.python }}
 
+    - name: Install version-check dependencies
+      run: python -m pip install setuptools
+
     - name: Check version number has been properly updated
-      run: ${GITHUB_WORKSPACE}/.github/is-version-number-acceptable.sh
+      run: '"${GITHUB_WORKSPACE}/.github/is-version-number-acceptable.sh"'

--- a/.github/workflows/fork-ci.yaml
+++ b/.github/workflows/fork-ci.yaml
@@ -3,7 +3,13 @@ name: Fork Python 3.11 validation
 on:
   pull_request:
     branches: [master]
+    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
+    inputs:
+      reason:
+        description: Reason for this manual validation run
+        required: true
+        type: string
 
 permissions:
   contents: read

--- a/.github/workflows/fork-ci.yaml
+++ b/.github/workflows/fork-ci.yaml
@@ -1,0 +1,56 @@
+name: Fork Python 3.11 validation
+
+on:
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fork-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  focused-validation:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install project and test fixture package
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --editable ".[dev]"
+          python -m pip install --no-deps openfisca-country-template
+
+      - name: Run focused tests
+        run: >-
+          python -m pytest
+          tests/core/test_holders.py
+          tests/core/test_simulations.py::test_clone
+          -q
+
+      - name: Run focused style checks
+        run: |
+          files=(
+            openfisca_core/holders/helpers.py
+            openfisca_core/holders/holder.py
+            openfisca_core/simulations/simulation.py
+            tests/core/test_holders.py
+            tests/core/test_simulations.py
+          )
+          python -m ruff check "${files[@]}"
+          python -m isort --check "${files[@]}"
+          python -m black --check "${files[@]}"
+          python -m flake8 "${files[@]}"
+          codespell CHANGELOG.md "${files[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 44.8.0
+## 44.8.0 [#1382](https://github.com/openfisca/openfisca-core/pull/1382)
 
 #### New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## 44.8.0 [#1382](https://github.com/openfisca/openfisca-core/pull/1382)
+## 44.8.0 [#2](https://github.com/edithatogo/openfisca-core/issues/2)
 
 #### New features
 
-- Distinguish explicit user input from default / calculated values on holders (#1380)
+- Distinguish explicit user input from default / calculated values on holders (#2)
   - Add `Holder.is_input(period)` and `Holder.get_value_state(period)` (`"explicit"` | `"default"`)
   - Add matching `Simulation.is_input` / `Simulation.get_value_state` helpers
   - Tracking is limited to values set via `set_input` (including period-casting helpers); formula cache via `put_in_cache` is not treated as input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased [#9](https://github.com/edithatogo/openfisca-core/issues/9)
+
+#### Technical changes
+
+- Repair the fork's inherited Conda package build and test workflow.
+
 ## 44.7.0 [#1357](https://github.com/openfisca/openfisca-core/pull/1357)
 
 #### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 44.8.0
+
+#### New features
+
+- Distinguish explicit user input from default / calculated values on holders (#1380)
+  - Add `Holder.is_input(period)` and `Holder.get_value_state(period)` (`"explicit"` | `"default"`)
+  - Add matching `Simulation.is_input` / `Simulation.get_value_state` helpers
+  - Tracking is limited to values set via `set_input` (including period-casting helpers); formula cache via `put_in_cache` is not treated as input
+  - Calculation semantics are unchanged: omitted inputs still default as before; callers can now inspect whether a value was user-provided (e.g. explicit zero vs never set)
+
 ## 44.7.0 [#1357](https://github.com/openfisca/openfisca-core/pull/1357)
 
 #### New features

--- a/openfisca_core/holders/helpers.py
+++ b/openfisca_core/holders/helpers.py
@@ -35,7 +35,7 @@ def set_input_dispatch_by_period(holder, period, array) -> None:
     while sub_period.start < after_instant:
         existing_array = holder.get_array(sub_period)
         if existing_array is None:
-            holder._set(sub_period, array)
+            holder._set(sub_period, array, as_input=True)
         else:
             # The array of the current sub-period is reused for the next ones.
             # TODO: refactor or document this behavior
@@ -84,7 +84,7 @@ def set_input_divide_by_period(holder, period, array) -> None:
         sub_period = periods.Period((cached_period_unit, period.start, 1))
         while sub_period.start < after_instant:
             if holder.get_array(sub_period) is None:
-                holder._set(sub_period, divided_array)
+                holder._set(sub_period, divided_array, as_input=True)
             sub_period = sub_period.offset(1)
     elif not (remaining_array == 0).all():
         msg = f"Inconsistent input: variable {holder.variable.name} has already been set for all months contained in period {period}, and value {array} provided for {period} doesn't match the total ({array - remaining_array}). This error may also be thrown if you try to call set_input twice for the same variable and period."

--- a/openfisca_core/holders/holder.py
+++ b/openfisca_core/holders/holder.py
@@ -44,6 +44,8 @@ class Holder:
                 self._on_disk_storable = True
             if self.variable.name in self.simulation.memory_config.variables_to_drop:
                 self._do_not_store = True
+        # Periods whose values were set via set_input (not formula cache).
+        self._user_input_periods: set = set()
 
     def clone(self, population: t.CorePopulation) -> t.Holder:
         """Copy the holder just enough to be able to run a new simulation without modifying the original simulation."""
@@ -79,6 +81,15 @@ class Holder:
         self._memory_storage.delete(period)
         if self._disk_storage:
             self._disk_storage.delete(period)
+        if period is None:
+            self._user_input_periods.clear()
+        else:
+            period = periods.period(period)
+            self._user_input_periods = {
+                known
+                for known in self._user_input_periods
+                if not period.contains(known)
+            }
 
     def get_array(self, period):
         """Get the value of the variable for the given period.
@@ -235,9 +246,16 @@ class Holder:
             return warnings.warn(warning_message, Warning, stacklevel=2)
         if self.variable.value_type in (float, int) and isinstance(array, str):
             array = commons.eval_expression(array)
-        if self.variable.set_input:
-            return self.variable.set_input(self, period, array)
-        return self._set(period, array)
+        # Mark every ``_set`` performed while handling this call as user input
+        # (including period-casting helpers and custom ``variable.set_input``).
+        previous_recording = getattr(self, "_recording_user_input", False)
+        self._recording_user_input = True
+        try:
+            if self.variable.set_input:
+                return self.variable.set_input(self, period, array)
+            return self._set(period, array, as_input=True)
+        finally:
+            self._recording_user_input = previous_recording
 
     def _to_array(self, value):
         if not isinstance(value, numpy.ndarray):
@@ -262,7 +280,7 @@ class Holder:
                 )
         return value
 
-    def _set(self, period, value) -> None:
+    def _set(self, period, value, *, as_input: bool = False) -> None:
         value = self._to_array(value)
         if not self._eternal:
             if period is None:
@@ -306,6 +324,48 @@ class Holder:
             self._disk_storage.put(value, period)
         else:
             self._memory_storage.put(value, period)
+        if as_input or getattr(self, "_recording_user_input", False):
+            self._user_input_periods.add(period)
+
+    def is_input(self, period) -> bool:
+        """Return whether a value for ``period`` was set via :meth:`set_input`.
+
+        Distinguishes explicit user input (including explicit zeros) from values
+        that come from variable defaults or formula cache. Values stored only by
+        :meth:`put_in_cache` are not considered inputs.
+
+        Args:
+            period: Period to inspect (string or :class:`~openfisca_core.periods.Period`).
+
+        Returns:
+            True if at least one matching period was set through :meth:`set_input`.
+
+        """
+        period = periods.period(period)
+        if period in self._user_input_periods:
+            return True
+        # Accept a wider query period when the stored inputs are elementary periods.
+        if period.unit != self.variable.definition_period or period.size > 1:
+            try:
+                subperiods = period.get_subperiods(self.variable.definition_period)
+            except ValueError:
+                return False
+            return any(sub_period in self._user_input_periods for sub_period in subperiods)
+        return False
+
+    def get_value_state(self, period) -> str:
+        """Return ``"explicit"`` if the value was set as input, else ``"default"``.
+
+        ``"default"`` means the value was not supplied via :meth:`set_input` for
+        this period: the engine may still return the variable default or a
+        calculated value, but that is not tagged as user-provided input.
+
+        This is a narrow API for partial-input / screener workflows (see
+        https://github.com/openfisca/openfisca-core/issues/1380). It does not
+        change calculation semantics.
+
+        """
+        return "explicit" if self.is_input(period) else "default"
 
     def put_in_cache(self, value, period) -> None:
         if self._do_not_store:

--- a/openfisca_core/holders/holder.py
+++ b/openfisca_core/holders/holder.py
@@ -56,6 +56,7 @@ class Holder:
             if key not in ("population", "formula", "simulation"):
                 new_dict[key] = value
 
+        new_dict["_user_input_periods"] = self._user_input_periods.copy()
         new_dict["population"] = population
         new_dict["simulation"] = population.simulation
 
@@ -350,7 +351,9 @@ class Holder:
                 subperiods = period.get_subperiods(self.variable.definition_period)
             except ValueError:
                 return False
-            return any(sub_period in self._user_input_periods for sub_period in subperiods)
+            return any(
+                sub_period in self._user_input_periods for sub_period in subperiods
+            )
         return False
 
     def get_value_state(self, period) -> str:

--- a/openfisca_core/simulations/simulation.py
+++ b/openfisca_core/simulations/simulation.py
@@ -547,6 +547,20 @@ class Simulation:
             return
         self.get_holder(variable_name).set_input(period, value)
 
+    def is_input(self, variable_name: str, period) -> bool:
+        """Return whether ``variable_name`` was set via :meth:`set_input` for ``period``.
+
+        See :meth:`openfisca_core.holders.Holder.is_input`.
+        """
+        return self.get_holder(variable_name).is_input(period)
+
+    def get_value_state(self, variable_name: str, period) -> str:
+        """Return ``"explicit"`` if set as input, else ``"default"``.
+
+        See :meth:`openfisca_core.holders.Holder.get_value_state`.
+        """
+        return self.get_holder(variable_name).get_value_state(period)
+
     def get_variable_population(self, variable_name: str) -> Population:
         variable: Variable | None
 

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ dev_requirements = [
 
 setup(
     name="OpenFisca-Core",
-    version="44.7.0",
+    version="44.8.0",
     author="OpenFisca Team",
     author_email="contact@openfisca.org",
     classifiers=[

--- a/tests/core/test_holders.py
+++ b/tests/core/test_holders.py
@@ -251,3 +251,69 @@ def test_set_input_float_to_int(single) -> None:
     simulation.person.get_holder("age").set_input(period, age)
     result = simulation.calculate("age", period)
     assert result == numpy.asarray([50])
+
+
+def test_is_input_distinguishes_missing_from_explicit_zero(tax_benefit_system) -> None:
+    """Omitted inputs and explicit zeros calculate the same, but value state differs.
+
+    See https://github.com/openfisca/openfisca-core/issues/1380
+    """
+    omitted = SimulationBuilder().build_from_entities(
+        tax_benefit_system,
+        {
+            "persons": {"person1": {}},
+            "households": {"household1": {"adults": ["person1"]}},
+        },
+    )
+    explicit_zero = SimulationBuilder().build_from_entities(
+        tax_benefit_system,
+        {
+            "persons": {"person1": {"salary": {str(period): 0}}},
+            "households": {"household1": {"adults": ["person1"]}},
+        },
+    )
+
+    # Calculation still collapses missing to the numeric default (zero).
+    tools.assert_near(omitted.calculate("salary", period), [0])
+    tools.assert_near(explicit_zero.calculate("salary", period), [0])
+
+    # Input provenance is now queryable.
+    assert not omitted.is_input("salary", period)
+    assert omitted.get_value_state("salary", period) == "default"
+
+    assert explicit_zero.is_input("salary", period)
+    assert explicit_zero.get_value_state("salary", period) == "explicit"
+    assert explicit_zero.person.get_holder("salary").is_input(period)
+
+
+def test_is_input_false_for_calculated_cache(single) -> None:
+    simulation = single
+    # salary is an input variable; disposable_income is calculated.
+    simulation.person.get_holder("salary").set_input(period, numpy.asarray([2000]))
+    simulation.calculate("disposable_income", period)
+
+    assert simulation.is_input("salary", period)
+    assert not simulation.is_input("disposable_income", period)
+    assert simulation.get_value_state("disposable_income", period) == "default"
+
+
+def test_is_input_with_period_casting_helper(single) -> None:
+    simulation = single
+    salary_holder = simulation.person.get_holder("salary")
+    # salary uses set_input_divide_by_period: yearly input fans out to months.
+    salary_holder.set_input("2017", numpy.asarray([12000]))
+
+    assert salary_holder.is_input(period)  # 2017-12
+    assert salary_holder.is_input("2017")
+    assert simulation.get_value_state("salary", "2017-01") == "explicit"
+
+
+def test_delete_arrays_clears_input_tracking(single) -> None:
+    simulation = single
+    salary_holder = simulation.person.get_holder("salary")
+    salary_holder.set_input(period, numpy.asarray([1000]))
+    assert salary_holder.is_input(period)
+
+    salary_holder.delete_arrays(period)
+    assert not salary_holder.is_input(period)
+    assert salary_holder.get_value_state(period) == "default"

--- a/tests/core/test_simulations.py
+++ b/tests/core/test_simulations.py
@@ -1,3 +1,4 @@
+import numpy
 import pytest
 
 from openfisca_country_template.situation_examples import single
@@ -57,6 +58,10 @@ def test_clone(tax_benefit_system) -> None:
     assert salary_holder != salary_holder_clone
     assert salary_holder_clone.simulation == simulation_clone
     assert salary_holder_clone.population == simulation_clone.persons
+
+    salary_holder_clone.set_input("2017-02", numpy.asarray([4000]))
+    assert salary_holder_clone.is_input("2017-02")
+    assert not salary_holder.is_input("2017-02")
 
 
 def test_get_memory_usage(tax_benefit_system) -> None:


### PR DESCRIPTION
#### New features

Fixes #1380.

- Add `Holder.is_input(period)` and `Holder.get_value_state(period)` (`explicit` or `default`).
- Add matching `Simulation.is_input` and `Simulation.get_value_state` helpers.
- Track values provided through `set_input`, including period-casting helpers.
- Clear matching provenance when `delete_arrays` clears holder arrays.

#### Behavioral compatibility

Calculation semantics are unchanged. Omitted inputs still use existing defaults, formula values stored through `put_in_cache` are not treated as user inputs, and the new API is opt-in. This is not unknown-value propagation or an engine-wide missingness rewrite.

#### Verification

- Missing and explicit-zero inputs calculate identically but report different value states.
- Formula/cache values are not reported as inputs.
- Period-cast yearly salary input marks monthly periods explicit.
- Deleting arrays clears the provenance.
- `pytest tests/core/test_holders.py`: 23 passed locally with the country template on Python 3.12.
- Changelog updated and project items linked.

#### Review and CI

The PR is mergeable and requires maintainer review. GitHub reports no contributor workflow rollup; please confirm whether a workflow approval is required.