### PR TITLE
Fix `Simulation.clone` sharing mutable state with the original simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 44.7.2 [#1385](https://github.com/openfisca/openfisca-core/pull/1385)
+
+#### Bug fixes
+
+- Fix `Simulation.clone` sharing mutable state with the original simulation (fixes [#1155](https://github.com/openfisca/openfisca-core/issues/1155)).
+  - Cloned holders shared their `InMemoryStorage` and `OnDiskStorage` with the original: setting, caching or deleting a value through one simulation silently altered the other one.
+  - `GroupPopulation.clone` attached the cloned holders to the original population (`holder.clone(self)` instead of `holder.clone(result)`), and kept the original persons population as `members`.
+  - The clone shared `_data_storage_dir` with the original: when both simulations lazily created a holder for the same variable, their on-disk storages wrote `{period}.npy` files into the same directory, so one simulation could read the other's values, and garbage-collecting either simulation deleted the files of the other.
+  - The clone now copies the storages (arrays are still shared, as they are treated as immutable), gets its own data storage directory, binds cloned group holders and members to the cloned populations, and copies `invalidated_caches`.
+
 ## 44.7.1 [#1383](https://github.com/openfisca/openfisca-core/pull/1383)
 
 #### Bug fixes

--- a/openfisca_core/data_storage/in_memory_storage.py
+++ b/openfisca_core/data_storage/in_memory_storage.py
@@ -142,6 +142,37 @@ class InMemoryStorage:
             if not period.contains(period_item)
         }
 
+    def clone(self) -> InMemoryStorage:
+        """Create a copy of the storage whose future mutations are independent.
+
+        The underlying arrays are shared, as they are treated as immutable by
+        the engine; only the period-to-array mapping is copied.
+
+        Returns:
+            InMemoryStorage: A new storage with the same data.
+
+        Examples:
+            >>> import numpy
+
+            >>> from openfisca_core import data_storage, periods
+
+            >>> storage = data_storage.InMemoryStorage()
+            >>> period = periods.period("2017")
+            >>> storage.put(numpy.array([1, 2, 3]), period)
+
+            >>> clone = storage.clone()
+            >>> clone.get(period)
+            array([1, 2, 3])
+
+            >>> clone.delete(period)
+            >>> storage.get(period)
+            array([1, 2, 3])
+
+        """
+        clone = InMemoryStorage(is_eternal=self.is_eternal)
+        clone._arrays = dict(self._arrays)
+        return clone
+
     def get_known_periods(self) -> KeysView[t.Period]:
         """List of storage's known periods.
 

--- a/openfisca_core/data_storage/on_disk_storage.py
+++ b/openfisca_core/data_storage/on_disk_storage.py
@@ -226,6 +226,65 @@ class OnDiskStorage:
             if not period.contains(period_item)
         }
 
+    def clone(self, storage_dir: str) -> OnDiskStorage:
+        """Copy the storage into ``storage_dir``, making future mutations independent.
+
+        The stored files are copied into ``storage_dir``, so that neither
+        simulation writes into — or deletes — the files of the other.
+
+        Args:
+            storage_dir: Path to store the copied vectors. Must be different
+                from the current storage directory; created if it does not
+                exist yet.
+
+        Returns:
+            OnDiskStorage: A new storage with the same data.
+
+        Raises:
+            ValueError: If ``storage_dir`` is the current storage directory.
+
+        Examples:
+            >>> import tempfile
+
+            >>> import numpy
+
+            >>> from openfisca_core import data_storage, periods
+
+            >>> value = numpy.array([1, 2, 3])
+            >>> period = periods.period("2017")
+
+            >>> with tempfile.TemporaryDirectory() as directory:
+            ...     with tempfile.TemporaryDirectory() as clone_directory:
+            ...         storage = data_storage.OnDiskStorage(
+            ...             directory, preserve_storage_dir=True
+            ...         )
+            ...         storage.put(value, period)
+            ...         clone = storage.clone(clone_directory)
+            ...         clone.delete(period)
+            ...         storage.get(period)
+            array([1, 2, 3])
+
+        """
+        if os.path.abspath(storage_dir) == os.path.abspath(self.storage_dir):
+            msg = (
+                f"A storage cannot be cloned into its own directory ('{storage_dir}')."
+            )
+            raise ValueError(msg)
+        os.makedirs(storage_dir, exist_ok=True)
+        clone = OnDiskStorage(
+            storage_dir,
+            is_eternal=self.is_eternal,
+            preserve_storage_dir=self.preserve_storage_dir,
+        )
+        enum = self._enums.get(self.storage_dir)
+        if enum is not None:
+            clone._enums[storage_dir] = enum
+        for period, file in self._files.items():
+            path = os.path.join(storage_dir, os.path.basename(file))
+            shutil.copy(file, path)
+            clone._files[period] = path
+        return clone
+
     def get_known_periods(self) -> KeysView[t.Period]:
         """List of storage's known periods.
 

--- a/openfisca_core/holders/holder.py
+++ b/openfisca_core/holders/holder.py
@@ -57,6 +57,15 @@ class Holder:
         new_dict["population"] = population
         new_dict["simulation"] = population.simulation
 
+        # Storage must not be shared with the original holder: otherwise any
+        # value set, cached or deleted through one simulation would silently
+        # alter the other one.
+        new_dict["_memory_storage"] = self._memory_storage.clone()
+        if self._disk_storage is not None:
+            new_dict["_disk_storage"] = self._disk_storage.clone(
+                os.path.join(new.simulation.data_storage_dir, self.variable.name),
+            )
+
         return new
 
     def create_disk_storage(self, directory=None, preserve=False):

--- a/openfisca_core/populations/group_population.py
+++ b/openfisca_core/populations/group_population.py
@@ -20,10 +20,13 @@ class GroupPopulation(Population):
         self._ordered_members_map = None
 
     def clone(self, simulation):
-        result = GroupPopulation(self.entity, self.members)
+        # ``simulation.persons`` must already be the cloned persons population,
+        # so that members of the cloned group belong to the new simulation.
+        result = GroupPopulation(self.entity, simulation.persons)
         result.simulation = simulation
         result._holders = {
-            variable: holder.clone(self) for (variable, holder) in self._holders.items()
+            variable: holder.clone(result)
+            for (variable, holder) in self._holders.items()
         }
         result.count = self.count
         result.ids = self.ids

--- a/openfisca_core/simulations/simulation.py
+++ b/openfisca_core/simulations/simulation.py
@@ -592,6 +592,11 @@ class Simulation:
             if key not in ("debug", "trace", "tracer"):
                 new_dict[key] = value
 
+        # The clone gets its own on-disk storage directory: sharing it would
+        # make both simulations write and delete each other's files.
+        new_dict["_data_storage_dir"] = None
+        new_dict["invalidated_caches"] = set(self.invalidated_caches)
+
         new.persons = self.persons.clone(new)
         setattr(new, new.persons.entity.key, new.persons)
         new.populations = {new.persons.entity.key: new.persons}

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ dev_requirements = [
 
 setup(
     name="OpenFisca-Core",
-    version="44.7.1",
+    version="44.7.2",
     author="OpenFisca Team",
     author_email="contact@openfisca.org",
     classifiers=[

--- a/tests/core/test_simulations.py
+++ b/tests/core/test_simulations.py
@@ -1,8 +1,12 @@
+import gc
+
+import numpy
 import pytest
 
 from openfisca_country_template.situation_examples import single
 
 from openfisca_core import errors, periods
+from openfisca_core.memory_config import MemoryConfig
 from openfisca_core.simulations import SimulationBuilder
 
 
@@ -57,6 +61,101 @@ def test_clone(tax_benefit_system) -> None:
     assert salary_holder != salary_holder_clone
     assert salary_holder_clone.simulation == simulation_clone
     assert salary_holder_clone.population == simulation_clone.persons
+
+
+def new_simulation(tax_benefit_system):
+    return SimulationBuilder().build_from_entities(
+        tax_benefit_system,
+        {
+            "persons": {
+                "bill": {"salary": {"2017-01": 3000}},
+            },
+            "households": {"household": {"adults": ["bill"]}},
+        },
+    )
+
+
+def test_clone_does_not_share_holder_storage(tax_benefit_system) -> None:
+    simulation = new_simulation(tax_benefit_system)
+    income_tax_before = simulation.calculate("income_tax", "2017-01")
+
+    clone = simulation.clone()
+
+    # Writing in the clone must not pollute the original
+    clone.delete_arrays("salary", "2017-01")
+    clone.set_input("salary", "2017-01", numpy.array([6000.0]))
+    assert simulation.calculate("salary", "2017-01") == 3000
+    assert simulation.calculate("income_tax", "2017-01") == income_tax_before
+
+    # Deleting in the clone must not destroy the original's values
+    clone.delete_arrays("salary")
+    assert simulation.get_array("salary", "2017-01") is not None
+
+
+def test_clone_group_entity_holders_bound_to_clone(tax_benefit_system) -> None:
+    simulation = new_simulation(tax_benefit_system)
+    simulation.calculate("housing_tax", "2017")
+
+    clone = simulation.clone()
+    holder_clone = clone.household.get_holder("housing_tax")
+
+    assert holder_clone.population is clone.household
+    assert holder_clone.simulation is clone
+
+
+def test_clone_members_are_cloned(tax_benefit_system) -> None:
+    simulation = new_simulation(tax_benefit_system)
+
+    clone = simulation.clone()
+
+    assert clone.household.members is clone.persons
+
+
+def test_clone_does_not_share_invalidated_caches(tax_benefit_system) -> None:
+    simulation = new_simulation(tax_benefit_system)
+
+    clone = simulation.clone()
+
+    assert clone.invalidated_caches is not simulation.invalidated_caches
+
+
+@pytest.mark.filterwarnings("ignore")
+def test_clone_disk_storage_is_isolated(tax_benefit_system) -> None:
+    simulation = new_simulation(tax_benefit_system)
+    simulation.memory_config = MemoryConfig(max_memory_occupation=0.0)
+    # Materialize the on-disk storage before cloning, so that the clone
+    # actually has to disentangle itself from the original's directory.
+    simulation.set_input("age", "2017-01", numpy.array([30]))
+
+    clone = simulation.clone()
+
+    clone.delete_arrays("age", "2017-01")
+    clone.set_input("age", "2017-01", numpy.array([99]))
+    assert simulation.calculate("age", "2017-01") == 30
+
+    # "birth" has no holder yet: each simulation lazily creates its own,
+    # which must not end up writing into the same directory.
+    simulation.set_input("birth", "2017-01", numpy.array(["1987-01-01"]))
+    clone.set_input("birth", "2017-01", numpy.array(["1999-01-01"]))
+    assert simulation.calculate("birth", "2017-01") == numpy.datetime64("1987-01-01")
+
+    # Garbage-collecting the clone must not destroy the original's files
+    del clone
+    gc.collect()
+    assert simulation.calculate("age", "2017-01") == 30
+    assert simulation.calculate("birth", "2017-01") == numpy.datetime64("1987-01-01")
+
+
+@pytest.mark.filterwarnings("ignore")
+def test_clone_disk_storage_preserves_enums(tax_benefit_system) -> None:
+    simulation = new_simulation(tax_benefit_system)
+    simulation.memory_config = MemoryConfig(max_memory_occupation=0.0)
+    simulation.set_input("housing_occupancy_status", "2017-01", numpy.array(["tenant"]))
+
+    clone = simulation.clone()
+
+    status = clone.calculate("housing_occupancy_status", "2017-01")
+    assert status.decode_to_str() == ["tenant"]
 
 
 def test_get_memory_usage(tax_benefit_system) -> None:


### PR DESCRIPTION
Fixes #1155.

### Problem

`Simulation.clone()` promises to "copy the simulation just enough to be able to run the copy without modifying the original simulation", but the clone actually shares most of its mutable state with the original. Four distinct defects compound:

1. **`Holder.clone` shares storage by reference**: the cloned holder reuses the original's `InMemoryStorage` and `OnDiskStorage` objects. Any `set_input`, `put_in_cache` or `delete_arrays` through one simulation silently alters the other. Worse, the original can end up internally inconsistent: change `salary` through a clone and the original now returns the new salary but keeps its stale cached `income_tax`.
2. **`GroupPopulation.clone` binds cloned holders to the original population**: `holder.clone(self)` is called instead of `holder.clone(result)`, so the clone's group-entity holders have `population` and `simulation` pointing at the original simulation.
3. **`GroupPopulation.clone` keeps the original persons as `members`** — this is the mechanism @nikhilwoodruff suspected in #1155: `clone.household.members is original.persons`.
4. **The clone shares `_data_storage_dir`**: when both simulations lazily create a holder for the same variable (with a `memory_config` active), their two distinct `OnDiskStorage` objects write `{period}.npy` files into the *same* directory. One simulation then reads the other's values, and garbage-collecting either simulation `rmtree`s the directory, physically destroying the other's data.

Minimal reproduction of defect 1 (before this fix):

```python
simulation = SimulationBuilder().build_from_entities(tbs, situation)  # salary = 2000
simulation.calculate("income_tax", "2026-01")   # 300, cached
clone = simulation.clone()
clone.delete_arrays("salary", "2026-01")
clone.set_input("salary", "2026-01", [4000])
simulation.calculate("salary", "2026-01")       # 4000 — the original was modified
simulation.calculate("income_tax", "2026-01")   # 300 — stale, inconsistent with salary
```

### Fix

- `InMemoryStorage.clone()` / `OnDiskStorage.clone(storage_dir)`: new methods returning independent copies. The in-memory clone copies the period-to-array mapping only (arrays stay shared, as the engine treats them as immutable). The on-disk clone copies the `.npy` files into the new directory and re-registers the enum mapping under the new directory key, so `EnumArray` values survive the copy.
- `Holder.clone` uses them instead of sharing references.
- `GroupPopulation.clone` binds holders to the cloned population and takes the cloned persons (`simulation.persons`) as `members`.
- `Simulation.clone` resets `_data_storage_dir` (the clone lazily gets its own temporary directory) and copies `invalidated_caches`.

### Trade-offs

- Cloning a simulation with on-disk storage now copies the stored files (I/O cost proportional to spilled data). The alternative — sharing files read-only — was rejected because either simulation's cleanup deletes the other's files.
- Arrays themselves are still shared between original and clone, consistently with how they are already shared within a single simulation's cache.
- Code that *relied* on the sharing behaviour (e.g. writing into a clone to warm the original's cache) will observe a change; that behaviour contradicted the documented contract of `clone`.

### Test plan

- 6 new tests in `tests/core/test_simulations.py`, each failing on `master` (except the enum guard, which protects the new copy logic): holder-storage isolation, group holders bound to the clone, cloned `members`, `invalidated_caches` copy, on-disk isolation incl. garbage-collection of the clone, enum preservation on disk clone.
- Full test suite and doctests pass; `isort`/`black`/`flake8`/`pylint` clean on the changed files.
