### PR TITLE
Warn when a spiral substitutes a variable's default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 44.8.0
+
+#### New features
+
+- Emit a `SpiralWarning` when a circular calculation is detected and a variable's default value is silently returned instead of evaluating its formula (closes [#956](https://github.com/openfisca/openfisca-core/issues/956)).
+  - Previously the substitution was completely silent, so there was no way to know that a formula had not been used.
+  - The warning names the variable and period whose formula was skipped, and explains how to avoid the recursion or raise `max_spiral_loops` (including from YAML tests).
+  - The calculation behaviour is unchanged; users who expect spirals can silence the warning with `warnings.filterwarnings("ignore", category=SpiralWarning)`.
+
 ## 44.7.1 [#1383](https://github.com/openfisca/openfisca-core/pull/1383)
 
 #### Bug fixes

--- a/openfisca_core/simulations/simulation.py
+++ b/openfisca_core/simulations/simulation.py
@@ -165,6 +165,25 @@ class Simulation:
 
         except errors.SpiralError:
             array = holder.default_array()
+            message = [
+                (
+                    f"A circular calculation was detected while computing '{variable.name}' "
+                    f"for period {period}: the formula was not evaluated, and the "
+                    f"variable's default value was returned instead."
+                ),
+                (
+                    "If this is unexpected, rewrite the formula to avoid the recursion "
+                    "(e.g. with a closed-form expression or an explicit check on the "
+                    "requested period), or allow deeper recursion by raising "
+                    f"`simulation.max_spiral_loops` (currently {self.max_spiral_loops}; "
+                    "also settable in YAML tests with the `max_spiral_loops` keyword)."
+                ),
+            ]
+            warnings.warn(
+                " ".join(message),
+                core_warnings.SpiralWarning,
+                stacklevel=2,
+            )
 
         return array
 

--- a/openfisca_core/warnings/__init__.py
+++ b/openfisca_core/warnings/__init__.py
@@ -22,4 +22,5 @@
 # See: https://www.python.org/dev/peps/pep-0008/#imports
 
 from .libyaml_warning import LibYAMLWarning  # noqa: F401
+from .spiral_warning import SpiralWarning  # noqa: F401
 from .tempfile_warning import TempfileWarning  # noqa: F401

--- a/openfisca_core/warnings/spiral_warning.py
+++ b/openfisca_core/warnings/spiral_warning.py
@@ -1,0 +1,2 @@
+class SpiralWarning(UserWarning):
+    """Custom warning when a spiral is detected and a default value is used."""

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ dev_requirements = [
 
 setup(
     name="OpenFisca-Core",
-    version="44.7.1",
+    version="44.8.0",
     author="OpenFisca Team",
     author_email="contact@openfisca.org",
     classifiers=[

--- a/tests/core/test_cycles.py
+++ b/tests/core/test_cycles.py
@@ -7,6 +7,7 @@ from openfisca_core.errors import CycleError
 from openfisca_core.periods import DateUnit
 from openfisca_core.simulations import SimulationBuilder
 from openfisca_core.variables import Variable
+from openfisca_core.warnings import SpiralWarning
 
 
 @pytest.fixture
@@ -123,6 +124,11 @@ def test_pure_cycle(simulation, reference_period) -> None:
 def test_spirals_result_in_default_value(simulation, reference_period) -> None:
     variable3 = simulation.calculate("variable3", period=reference_period)
     tools.assert_near(variable3, [0])
+
+
+def test_spirals_warn_when_defaulting(simulation, reference_period) -> None:
+    with pytest.warns(SpiralWarning, match="variable3"):
+        simulation.calculate("variable3", period=reference_period)
 
 
 def test_spiral_heuristic(simulation, reference_period) -> None:


### PR DESCRIPTION
Closes #956.

### Problem

When a circular calculation is detected (`SpiralError`), the engine silently returns the variable's default value instead of evaluating its formula ([simulation.py](https://github.com/openfisca/openfisca-core/blob/master/openfisca_core/simulations/simulation.py#L166)). As reported in #956, nothing tells the user that a formula they wrote was skipped — models end up wrong in ways that are very hard to notice (the reporter only found out by diffing test results that depended on calculation order).

### Fix

The substitution now emits a `SpiralWarning` (new, exported from `openfisca_core.warnings`, following the existing `TempfileWarning` pattern) that names the variable and period whose formula was skipped, and explains the two ways out: rewrite the formula to avoid the recursion, or allow deeper recursion with `simulation.max_spiral_loops` — which, since #956 was opened, can also be set in YAML tests with the `max_spiral_loops` keyword, so the warning mentions that too.

The calculation behaviour is unchanged: same results, same caching, same purge of invalidated values. Users who rely on spirals intentionally can filter the warning out with `warnings.filterwarnings("ignore", category=SpiralWarning)`.

```
SpiralWarning: A circular calculation was detected while computing 'montant_total' for period 2017:
the formula was not evaluated, and the variable's default value was returned instead. If this is
unexpected, rewrite the formula to avoid the recursion (e.g. with a closed-form expression or an
explicit check on the requested period), or allow deeper recursion by raising
`simulation.max_spiral_loops` (currently 1; also settable in YAML tests with the `max_spiral_loops` keyword).
```

### Test plan

- New test in `tests/core/test_cycles.py` asserting the warning is emitted on a spiraling calculation (fails without this change).
- Reproduced the exact scenario from #956 (a yearly variable whose `formula_2018` depends on `period.last_year`) and checked the warning is now emitted where there used to be silence.
- Full test suite passes; `isort`/`black`/`flake8` clean.
