### PR TITLE
Fix `restore_simulation` entity counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 44.7.2
+
+#### Bug fixes
+
+- Fix `restore_simulation` rebuilding entity counts from the members mapping instead of the dumped ids.
+  - A group entity with no member was silently dropped from the restored simulation's `count` (while still listed in `ids`), so subsequent calculations returned arrays with missing entities — or failed with a `ValueError` when a value had been stored for the group entity.
+  - Restoring a simulation whose tax and benefit system has no group entity raised an `UnboundLocalError`.
+  - Each entity's `count` is now restored from its dumped `ids`.
+
 ## 44.7.1 [#1383](https://github.com/openfisca/openfisca-core/pull/1383)
 
 #### Bug fixes

--- a/openfisca_core/tools/simulation_dumper.py
+++ b/openfisca_core/tools/simulation_dumper.py
@@ -41,15 +41,7 @@ def restore_simulation(directory, tax_benefit_system, **kwargs):
 
     entities_dump_dir = os.path.join(directory, "__entities__")
     for population in simulation.populations.values():
-        if population.entity.is_person:
-            continue
-        person_count = _restore_entity(population, entities_dump_dir)
-
-    for population in simulation.populations.values():
-        if not population.entity.is_person:
-            continue
         _restore_entity(population, entities_dump_dir)
-        population.count = person_count
 
     variables_to_restore = (
         variable for variable in os.listdir(directory) if variable != "__entities__"
@@ -92,13 +84,16 @@ def _dump_entity(population, directory) -> None:
     numpy.save(os.path.join(path, "members_role.npy"), encoded_roles)
 
 
-def _restore_entity(population, directory):
+def _restore_entity(population, directory) -> None:
     path = os.path.join(directory, population.entity.key)
 
     population.ids = numpy.load(os.path.join(path, "id.npy"))
+    # The number of entities cannot be inferred from the members mapping, as
+    # a group entity may have no member at all: use the dumped ids instead.
+    population.count = len(population.ids)
 
     if population.entity.is_person:
-        return None
+        return
 
     population.members_position = numpy.load(os.path.join(path, "members_position.npy"))
     population.members_entity_id = numpy.load(
@@ -115,9 +110,6 @@ def _restore_entity(population, directory):
             list(flattened_roles),
             default=None,
         )
-    person_count = len(population.members_entity_id)
-    population.count = max(population.members_entity_id) + 1
-    return person_count
 
 
 def _restore_holder(simulation, variable_name, directory) -> None:

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ dev_requirements = [
 
 setup(
     name="OpenFisca-Core",
-    version="44.7.1",
+    version="44.7.2",
     author="OpenFisca Team",
     author_email="contact@openfisca.org",
     classifiers=[

--- a/tests/core/test_dump_restore.py
+++ b/tests/core/test_dump_restore.py
@@ -1,11 +1,13 @@
 import shutil
 import tempfile
 
+import numpy
 from numpy import testing
 
-from openfisca_country_template import situation_examples
+from openfisca_country_template import entities, situation_examples
 
 from openfisca_core.simulations import SimulationBuilder
+from openfisca_core.taxbenefitsystems import TaxBenefitSystem
 from openfisca_core.tools import simulation_dumper
 
 
@@ -45,5 +47,48 @@ def test_dump(tax_benefit_system) -> None:
     cached_value = disposable_income_holder.get_array("2018-01")
     assert cached_value is not None
     testing.assert_array_equal(cached_value, calculated_value)
+
+    shutil.rmtree(directory)
+
+
+def test_dump_restore_with_memberless_group_entity(tax_benefit_system) -> None:
+    directory = tempfile.mkdtemp(prefix="openfisca_")
+    simulation = SimulationBuilder().build_from_entities(
+        tax_benefit_system,
+        {
+            "persons": {"Alice": {"salary": {"2017-01": 2000}}},
+            "households": {"h1": {"adults": ["Alice"]}, "h2": {}},
+        },
+    )
+    simulation.set_input("accommodation_size", "2017-01", numpy.array([60.0, 80.0]))
+    simulation_dumper.dump_simulation(simulation, directory)
+
+    simulation_2 = simulation_dumper.restore_simulation(directory, tax_benefit_system)
+
+    assert simulation_2.household.count == 2
+    testing.assert_array_equal(simulation.household.ids, simulation_2.household.ids)
+    testing.assert_array_equal(
+        simulation_2.household.get_holder("accommodation_size").get_array("2017-01"),
+        [60.0, 80.0],
+    )
+
+    shutil.rmtree(directory)
+
+
+def test_dump_restore_without_group_entity() -> None:
+    directory = tempfile.mkdtemp(prefix="openfisca_")
+    person_only_tax_benefit_system = TaxBenefitSystem([entities.Person])
+    simulation = SimulationBuilder().build_default_simulation(
+        person_only_tax_benefit_system,
+        count=2,
+    )
+    simulation_dumper.dump_simulation(simulation, directory)
+
+    simulation_2 = simulation_dumper.restore_simulation(
+        directory,
+        person_only_tax_benefit_system,
+    )
+
+    assert simulation_2.persons.count == 2
 
     shutil.rmtree(directory)


### PR DESCRIPTION
### Problem

`restore_simulation` rebuilds each group entity's `count` from the members mapping (`max(members_entity_id) + 1`) and the persons' `count` from the members of the last group entity restored. Two consequences:

- **A group entity with no member is silently dropped** from the restored simulation's `count`, while still listed in its `ids` — an internally inconsistent state. Calculations on the restored simulation then return arrays with missing entities, with no error:

```python
simulation.household.count            # 2 (h1, h2 — h2 has no member)
dump_simulation(simulation, directory)
restored = restore_simulation(directory, tbs)
restored.household.count              # 1 — h2 silently gone
restored.calculate("total_benefits", "2017-01")  # 1 value instead of 2
```

When a value *was* stored for the group entity, restoring instead fails with `ValueError: length is 2 while there are 1 households`.

- **A tax and benefit system with no group entity cannot be restored at all**: the `person_count` local is never assigned and `restore_simulation` raises `UnboundLocalError`.

### Fix

The dump already contains each entity's `ids` (`id.npy`); each entity's `count` is now restored from them. This also removes the `person_count` plumbing and the ordering constraint between the two restore passes.

### Test plan

Two new tests in `tests/core/test_dump_restore.py`, both failing on `master`: roundtrip with a memberless household (count and stored group values preserved), and roundtrip of a person-only tax and benefit system.
